### PR TITLE
Fix/onboard channel auto install

### DIFF
--- a/EvoScientist/config/onboard.py
+++ b/EvoScientist/config/onboard.py
@@ -1751,7 +1751,7 @@ def _step_channels(config: EvoScientistConfig) -> dict[str, object]:
                         except ImportError:
                             console.print("  [red]✗ Package installed but import failed.[/red]")
                             console.print(
-                                f"  [dim]Try restarting and running:[/dim] evosci channel setup"
+                                "  [dim]Try restarting and running:[/dim] evosci channel setup"
                             )
                     else:
                         console.print("  [red]✗ Installation failed.[/red]")


### PR DESCRIPTION
## fix: fully configure channels during onboard (auto-install + verify)

### Summary

- Install channel dependencies directly (e.g. `qq-botpy`) instead of via `evoscientist[extras]`, which fails on editable/dev installs not published to PyPI
- Invalidate Python import caches (`importlib.invalidate_caches()`) after pip install so newly-installed packages are importable in the same process
- Verify the import actually succeeds after installation before proceeding to credential prompts; surface a clear error if it doesn't

### Background

Previously, selecting a channel (e.g. QQ) during `evosci onboard` when its dependency wasn't installed would either skip the channel entirely (old behavior) or attempt `pip install "evoscientist[qq]"` which could fail if the package wasn't on PyPI. Users had to finish onboarding, then run `evosci channel setup` separately to actually configure the channel — defeating the purpose of onboarding.

### What changed

| Area | Before | After |
|------|--------|-------|
| Package install | `pip install "evoscientist[qq]"` | `pip install "qq-botpy>=1.0"` (direct dep) |
| Import caches | Not invalidated after install | `importlib.invalidate_caches()` called |
| Post-install check | Assumed success, no verification | Re-runs `__import__` to confirm |
| Fallback message | Generic manual install hint | Points to `evosci channel setup` |

### Test plan

- [x] Existing onboard tests pass (56/56)