### PR TITLE
feat: route /gpu through the command manager

### DIFF
--- a/EvoScientist/channels/README.md
+++ b/EvoScientist/channels/README.md
@@ -320,6 +320,20 @@ EvoSci serve                # Start agent + all enabled channels
 EvoSci channel start        # Standalone channel mode (message loop only)
 ```
 
+### Built-in slash command: `/gpu`
+
+All channels that run through the shared `MessageBus` support a built-in
+`/gpu` command. If a user sends the exact message `/gpu`, the message is
+handled before the normal agent pipeline:
+
+- EvoScientist runs `nvidia-smi` on the host machine
+- the raw command output is returned directly to the originating channel
+- the normal agent / HITL / ask_user flow is skipped for that message
+
+This works across the standard channel integrations, including Telegram,
+Discord, Slack, Feishu, WeChat, DingTalk, QQ, Signal, Email, and iMessage.
+The host must have `nvidia-smi` available.
+
 ### 4. Health check
 
 ```bash
@@ -800,6 +814,7 @@ All enabled channels run concurrently via the internal `MessageBus`. Each channe
 - Has its own connection lifecycle (connect, reconnect, health check)
 - Shares the same `InboundConsumer` worker pool and agent instance
 - Routes outbound replies back to the originating channel automatically
+- Shares the same built-in commands such as `/gpu`
 
 ### Multi-Channel Architecture
 

--- a/EvoScientist/channels/consumer.py
+++ b/EvoScientist/channels/consumer.py
@@ -438,6 +438,30 @@ class InboundConsumer:
             del self._pending_interrupts[session_key]
 
         async with self._chat_locks[session_key]:
+            from ..commands.channel_dispatch import execute_supported_channel_command
+
+            command_response = await execute_supported_channel_command(
+                msg.content,
+                agent=self.agent,
+                thread_id=thread_id,
+            )
+            if command_response is not None:
+                outbound = OutboundMessage(
+                    channel=msg.channel,
+                    chat_id=msg.chat_id,
+                    content=command_response,
+                    reply_to=msg.message_id or None,
+                    metadata=msg.metadata,
+                )
+                await self.bus.publish_outbound(outbound)
+                self._metrics.total_successes += 1
+                if self._on_message_sent:
+                    try:
+                        self._on_message_sent(outbound)
+                    except Exception:
+                        pass
+                return
+
             await self._stream_with_hitl(msg, channel, thread_id, session_key)
 
     async def _stream_with_hitl(

--- a/EvoScientist/cli/channel.py
+++ b/EvoScientist/cli/channel.py
@@ -521,6 +521,7 @@ async def _bus_inbound_consumer(bus, manager) -> None:
 async def _handle_bus_message(bus, manager, msg) -> None:
     """Handle a single inbound bus message (runs as an independent task)."""
     from ..channels.bus.events import OutboundMessage
+    from ..commands.channel_dispatch import execute_supported_channel_command
 
     _channel_logger.info(
         f"[bus] Received from {msg.channel}:{msg.sender_id}: {msg.content[:60]}..."
@@ -530,6 +531,30 @@ async def _handle_bus_message(bus, manager, msg) -> None:
     channel = manager.get_channel(msg.channel)
     if channel:
         await channel.start_typing(msg.chat_id)
+
+    command_response = await execute_supported_channel_command(
+        msg.content,
+        agent=_cli_agent,
+        thread_id=_cli_thread_id or "",
+    )
+    if command_response is not None:
+        try:
+            await bus.publish_outbound(
+                OutboundMessage(
+                    channel=msg.channel,
+                    chat_id=msg.chat_id,
+                    content=command_response,
+                    reply_to=msg.message_id or None,
+                    metadata=msg.metadata,
+                )
+            )
+            manager.record_message(msg.channel, "sent")
+        except Exception as e:
+            _channel_logger.error(f"[bus] Outbound error: {e}")
+        finally:
+            if channel:
+                await channel.stop_typing(msg.chat_id)
+        return
 
     # Enqueue for main CLI thread to process with its own event loop
     cm = ChannelMessage(

--- a/EvoScientist/commands/channel_dispatch.py
+++ b/EvoScientist/commands/channel_dispatch.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any
+
+from rich.console import Console
+
+from .base import CommandContext
+from .manager import manager
+
+_SUPPORTED_CHANNEL_COMMANDS = {"/gpu"}
+
+
+class _CaptureChannelCommandUI:
+    """Non-interactive command UI that captures output as plain text."""
+
+    def __init__(self) -> None:
+        self._parts: list[str] = []
+
+    @property
+    def supports_interactive(self) -> bool:
+        return False
+
+    @property
+    def output(self) -> str:
+        return "\n".join(part for part in self._parts if part).strip()
+
+    def append_system(self, text: str, style: str = "dim") -> None:
+        del style
+        self._parts.append(text)
+
+    def mount_renderable(self, renderable: Any) -> None:
+        with StringIO() as buffer:
+            console = Console(
+                file=buffer,
+                force_terminal=False,
+                width=120,
+                color_system=None,
+            )
+            console.print(renderable)
+            text = buffer.getvalue().rstrip()
+
+        if text:
+            self._parts.append(f"```\n{text}\n```")
+
+    async def wait_for_thread_pick(
+        self, threads: list[dict], current_thread: str, title: str
+    ) -> str | None:
+        del threads, current_thread
+        self.append_system(f"{title}\nUse /resume <id> to continue.")
+        return None
+
+    async def wait_for_skill_browse(
+        self, index: list[dict], installed_names: set[str], pre_filter_tag: str
+    ) -> list[str] | None:
+        del index, installed_names, pre_filter_tag
+        self.append_system(
+            "Interactive skill browsing is not supported in channel commands."
+        )
+        return None
+
+    async def wait_for_mcp_browse(
+        self, servers: list, installed_names: set[str], pre_filter_tag: str
+    ) -> list | None:
+        del servers, installed_names, pre_filter_tag
+        self.append_system(
+            "Interactive MCP browsing is not supported in channel commands."
+        )
+        return None
+
+    def clear_chat(self) -> None:
+        self.append_system("Clear chat is not supported in channel commands.")
+
+    def request_quit(self) -> None:
+        self.append_system("Quit is ignored in channel commands.")
+
+    def start_new_session(self) -> None:
+        self.append_system("New session requested.")
+
+    async def handle_session_resume(
+        self, thread_id: str, workspace_dir: str | None = None
+    ) -> None:
+        del workspace_dir
+        self.append_system(f"Session resumed: {thread_id}")
+
+    async def flush(self) -> None:
+        return
+
+
+async def execute_supported_channel_command(
+    command_str: str,
+    *,
+    agent: Any,
+    thread_id: str,
+    workspace_dir: str | None = None,
+    checkpointer: Any = None,
+    config: Any = None,
+) -> str | None:
+    """Execute a built-in channel command and return its outbound text."""
+
+    normalized = command_str.strip().lower()
+    if normalized not in _SUPPORTED_CHANNEL_COMMANDS:
+        return None
+
+    ui = _CaptureChannelCommandUI()
+    ctx = CommandContext(
+        agent=agent,
+        thread_id=thread_id,
+        ui=ui,
+        workspace_dir=workspace_dir,
+        checkpointer=checkpointer,
+        config=config,
+    )
+
+    handled = await manager.execute(command_str, ctx)
+    if not handled:
+        return None
+    return ui.output or "No response"

--- a/EvoScientist/commands/implementation/__init__.py
+++ b/EvoScientist/commands/implementation/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from . import channel, general, mcp, session, skills
+from . import channel, general, gpu, mcp, session, skills
 
-__all__ = ["channel", "general", "mcp", "session", "skills"]
+__all__ = ["channel", "general", "gpu", "mcp", "session", "skills"]

--- a/EvoScientist/commands/implementation/gpu.py
+++ b/EvoScientist/commands/implementation/gpu.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+
+from ..base import Command, CommandContext
+from ..manager import manager
+
+_GPU_CHECK_TIMEOUT_SECONDS = 30
+
+
+def _format_code_block(text: str) -> str:
+    body = text.rstrip() or "(empty output)"
+    return f"```text\n{body}\n```"
+
+
+def _run_nvidia_smi(nvidia_smi_path: str = "nvidia-smi") -> str:
+    try:
+        result = subprocess.run(
+            [nvidia_smi_path],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=_GPU_CHECK_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        return "GPU check failed: `nvidia-smi` was not found on this machine."
+    except subprocess.TimeoutExpired:
+        return "GPU check failed: `nvidia-smi` timed out."
+    except subprocess.CalledProcessError as exc:
+        error_text = (exc.stderr or exc.stdout or str(exc)).strip()
+        return f"GPU check failed:\n{_format_code_block(error_text)}"
+
+    return _format_code_block(result.stdout)
+
+
+class GPUCommand(Command):
+    """Show host GPU status."""
+
+    name = "/gpu"
+    description = "Show host GPU status via nvidia-smi"
+
+    async def execute(self, ctx: CommandContext, args: list[str]) -> None:
+        if args:
+            ctx.ui.append_system("Usage: /gpu", style="yellow")
+            return
+
+        output = await asyncio.to_thread(_run_nvidia_smi)
+        ctx.ui.append_system(output)
+
+
+manager.register(GPUCommand())

--- a/README.md
+++ b/README.md
@@ -414,6 +414,13 @@ channel_enabled: "telegram,slack,feishu,qq"
 
 The channel can also be started interactively with `/channel` in the CLI session.
 
+All bus-based messaging channels also support a built-in `/gpu` command. When a
+user sends the exact message `/gpu`, EvoScientist bypasses the normal agent
+pipeline, runs `nvidia-smi` on the host machine, and returns the raw GPU status
+directly. This is useful for quick cluster checks from Telegram, Slack,
+DingTalk, Feishu, WeChat, Discord, QQ, Signal, Email, or iMessage.
+`nvidia-smi` must be available on the host for this command to work.
+
 > [!TIP]
 > For per-channel setup guides, capability matrix, architecture details, and troubleshooting, see the **[Channel Integration Guide](https://github.com/EvoScientist/EvoScientist/tree/main/EvoScientist/channels#channels)**.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -423,6 +423,13 @@ channel_enabled: "telegram,slack,feishu,qq"
 
 也可以在 CLI 会话中通过 `/channel` 交互式启动渠道。
 
+所有基于共享 `MessageBus` 的消息渠道也都支持内置的 `/gpu` 指令。当
+用户发送精确的 `/gpu` 时，EvoScientist 会跳过正常的 agent 流程，直
+接在宿主机上执行 `nvidia-smi`，并将原始 GPU 状态结果返回到对应渠
+道。这适合用来从 Telegram、Slack、钉钉、飞书、微信、Discord、QQ、
+Signal、Email 或 iMessage 快速查看机器的 GPU 使用情况。宿主机需要
+可用的 `nvidia-smi`。
+
 > [!TIP]
 > 关于各渠道设置指南、功能矩阵、架构详情和故障排查，请参阅 **[渠道集成指南](https://github.com/EvoScientist/EvoScientist/tree/main/EvoScientist/channels#channels)**。
 

--- a/tests/test_gpu_command.py
+++ b/tests/test_gpu_command.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from EvoScientist.channels.bus import MessageBus
+from EvoScientist.channels.bus.events import InboundMessage
+from EvoScientist.channels.channel_manager import ChannelManager
+from EvoScientist.channels.consumer import InboundConsumer
+from EvoScientist.cli import channel as channel_cli
+from EvoScientist.commands.channel_dispatch import execute_supported_channel_command
+from tests.conftest import run_async as _run
+
+
+class _CompletedProcess:
+    def __init__(self, stdout: str = "", stderr: str = ""):
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _drain_queue(q) -> None:
+    while not q.empty():
+        try:
+            q.get_nowait()
+        except Exception:
+            break
+
+
+def test_execute_supported_channel_command_only_matches_exact_gpu(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: _CompletedProcess(stdout="GPU 0  70%\n"),
+    )
+
+    async def _test():
+        result = await execute_supported_channel_command(
+            " /GPU ",
+            agent=None,
+            thread_id="thread-1",
+        )
+        not_a_command = await execute_supported_channel_command(
+            "/gpu now",
+            agent=None,
+            thread_id="thread-1",
+        )
+
+        assert result == "```text\nGPU 0  70%\n```"
+        assert not_a_command is None
+
+    _run(_test())
+
+
+def test_execute_supported_channel_command_reports_failures(monkeypatch):
+    def _fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["nvidia-smi"],
+            stderr="driver not loaded",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fail)
+
+    async def _test():
+        result = await execute_supported_channel_command(
+            "/gpu",
+            agent=None,
+            thread_id="thread-1",
+        )
+
+        assert result is not None
+        assert "GPU check failed" in result
+        assert "driver not loaded" in result
+
+    _run(_test())
+
+
+@pytest.mark.parametrize(
+    "channel_name",
+    [
+        "telegram",
+        "discord",
+        "slack",
+        "wechat",
+        "dingtalk",
+        "feishu",
+        "email",
+        "qq",
+        "signal",
+        "imessage",
+    ],
+)
+def test_gpu_command_bypasses_standalone_agent(monkeypatch, channel_name):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: _CompletedProcess(stdout="GPU shortcut output\n"),
+    )
+
+    async def _test():
+        bus = MessageBus()
+        manager = ChannelManager(bus)
+        agent = MagicMock()
+        consumer = InboundConsumer(
+            bus=bus,
+            manager=manager,
+            agent=agent,
+            thread_id="",
+        )
+
+        await consumer._handle_message(
+            InboundMessage(
+                channel=channel_name,
+                sender_id="user-1",
+                chat_id="chat-1",
+                content="/gpu",
+                message_id="msg-1",
+            )
+        )
+
+        outbound = await bus.consume_outbound()
+        assert outbound.channel == channel_name
+        assert outbound.chat_id == "chat-1"
+        assert outbound.reply_to == "msg-1"
+        assert "GPU shortcut output" in outbound.content
+        assert consumer.metrics["total_successes"] == 1
+        assert agent.mock_calls == []
+
+    _run(_test())
+
+
+def test_gpu_command_bypasses_bus_mode_queue(monkeypatch):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: _CompletedProcess(stdout="GPU shortcut output\n"),
+    )
+    _drain_queue(channel_cli._message_queue)
+
+    async def _test():
+        from tests.test_bus_integration import FakeChannel
+
+        bus = MessageBus()
+        manager = ChannelManager(bus)
+        channel = FakeChannel()
+        manager.register(channel)
+
+        consumer = asyncio.create_task(channel_cli._bus_inbound_consumer(bus, manager))
+
+        await bus.publish_inbound(
+            InboundMessage(
+                channel="fake",
+                sender_id="user-1",
+                chat_id="chat-1",
+                content="/gpu",
+                message_id="msg-1",
+            )
+        )
+
+        outbound = await asyncio.wait_for(bus.consume_outbound(), timeout=2.0)
+        await asyncio.sleep(0.05)
+
+        assert channel_cli._message_queue.empty()
+        assert outbound.channel == "fake"
+        assert outbound.chat_id == "chat-1"
+        assert outbound.reply_to == "msg-1"
+        assert "GPU shortcut output" in outbound.content
+        assert manager._message_counts["fake"]["received"] == 1
+        assert manager._message_counts["fake"]["sent"] == 1
+
+        consumer.cancel()
+        try:
+            await consumer
+        except asyncio.CancelledError:
+            pass
+
+    _run(_test())


### PR DESCRIPTION
## Summary

This updates the `/gpu` shortcut implementation to match the current command architecture after the newer command system landed.

Instead of adding a channel-only shortcut layer, this change:

- adds `/gpu` as a real command under `EvoScientist.commands.implementation.gpu`
- routes channel-triggered `/gpu` requests through the shared command manager
- keeps `/gpu` as an exact-match fast path for channel users
- bypasses the normal agent pipeline for `/gpu`, while preserving existing HITL / ask_user priority and chat ordering guarantees

## Why

PR #29 was originally implemented before the newer slash-command architecture was available.
After the command-system refactor, maintainers requested moving the logic into
`EvoScientist.commands.implementation.gpu` instead of `EvoScientist/channels/shortcuts.py`.

This version follows that architecture.

## Behavior

- Trigger: exact message `/gpu`
- Action: run `nvidia-smi` on the host machine
- Response: return the raw command output directly
- Scope: bus-mode channels and standalone channel consumer
- Requirement: `nvidia-smi` must be available on the host

## Implementation

- Added `EvoScientist.commands.implementation.gpu`
- Added `EvoScientist.commands.channel_dispatch` to execute supported channel commands through the shared command manager
- Wired bus-mode channel handling to intercept exact `/gpu` before queueing the message to the main agent loop
- Wired standalone `InboundConsumer` to do the same inside the per-chat lock
- Updated docs in `README.md`, `README.zh-CN.md`, and `EvoScientist/channels/README.md`

## Testing

Passed:

- `python -m ruff check EvoScientist/commands/channel_dispatch.py EvoScientist/commands/implementation/gpu.py EvoScientist/channels/consumer.py EvoScientist/cli/channel.py tests/test_gpu_command.py`
- `python -m ruff format --check EvoScientist/commands/channel_dispatch.py EvoScientist/commands/implementation/gpu.py EvoScientist/channels/consumer.py EvoScientist/cli/channel.py tests/test_gpu_command.py`
- `python -m pytest -q tests/test_gpu_command.py tests/test_bus_integration.py tests/test_channel_comprehensive.py -k 'InboundConsumer or test_gpu_command or TestBusInboundConsumer'`
