### PR TITLE
feat: add glm-5-turbo model entries for OpenRouter and Zhipu

### DIFF
--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -145,11 +145,14 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("qwen3.5-122b", "qwen/qwen3.5-122b-a10b", "openrouter"),
     ("gemini-3-flash", "google/gemini-3-flash-preview", "openrouter"),
     ("claude-sonnet-4.6", "anthropic/claude-sonnet-4.6", "openrouter"),
+    ("glm-5-turbo", "z-ai/glm-5-turbo", "openrouter"),
     # Zhipu CodePlan (智谱代码计划 — coding-only endpoint)
     ("glm-5", "glm-5", "zhipu-code"),
+    ("glm-5-turbo", "glm-5-turbo", "zhipu-code"),
     ("glm-4.7", "glm-4.7", "zhipu-code"),
     # Zhipu (智谱 — general endpoint, default for simple lookups)
     ("glm-5", "glm-5", "zhipu"),
+    ("glm-5-turbo", "glm-5-turbo", "zhipu"),
     ("glm-4.7", "glm-4.7", "zhipu"),
 ]
 


### PR DESCRIPTION
## Description             
                                                                                                                                  
  Add `glm-5-turbo` model to ZhipuAI (`zhipu`, `zhipu-code`) and OpenRouter (`z-ai/glm-5-turbo`) provider entries in `llm/models.py`.                                               
                                                                                                                                                                                    
## Type of change                                                                                                                                                                 
                                                                                                                                                                                    
  - [ ] Bug fix                                                                                                                                                                     
  - [x] New feature — link issue: #<!-- issue number -->    
  - [ ] Documentation / examples                                                                                                                                                    
  - [ ] Test improvement                                                                                                                                                            
  - [ ] Refactor (no behavior change)                                                                                                                                               
                                                                                                                                                                                    
## Checklist                                                                                                                                                                      
                                                                                                                                                                                    
  - [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)                                                                                                               
  - [ ] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
  - [ ] I have added/updated tests where applicable                                                                                                                                 
  - [x] `uv run ruff check .` passes                                                                                                                                                
  - [x] `uv run pytest` passes      