### PR TITLE
fix: centralize dotenv loading inside get_effective_config (#45)

### DIFF
--- a/EvoScientist/cli/commands.py
+++ b/EvoScientist/cli/commands.py
@@ -499,10 +499,6 @@ def serve(
 
     nest_asyncio.apply()
 
-    from dotenv import load_dotenv, find_dotenv  # type: ignore[import-untyped]
-
-    load_dotenv(find_dotenv(), override=True)
-
     from ..config import get_effective_config, apply_config_to_env
 
     cli_overrides = {}
@@ -944,11 +940,6 @@ def _main_callback(
     # If a subcommand was invoked, don't run the default behavior
     if ctx.invoked_subcommand is not None:
         return
-
-    from dotenv import load_dotenv, find_dotenv  # type: ignore[import-untyped]
-
-    # find_dotenv() traverses up the directory tree to locate .env
-    load_dotenv(find_dotenv(), override=True)
 
     # Load and apply configuration
     from ..config import get_effective_config, apply_config_to_env

--- a/EvoScientist/config/settings.py
+++ b/EvoScientist/config/settings.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, asdict, fields
+from dotenv import find_dotenv, load_dotenv
 from pathlib import Path
 from typing import Any, Literal
 
@@ -376,6 +377,8 @@ def get_effective_config(
     Returns:
         EvoScientistConfig with merged values.
     """
+    load_dotenv(find_dotenv(usecwd=True), override=True)
+
     # Start with file config (includes defaults for missing values)
     config = load_config()
     data = asdict(config)

--- a/EvoScientist/tools/search.py
+++ b/EvoScientist/tools/search.py
@@ -8,13 +8,10 @@ import asyncio
 from typing import Literal
 
 import httpx
-from dotenv import load_dotenv
 from langchain_core.tools import InjectedToolArg, tool
 from markdownify import markdownify
 from tavily import TavilyClient
 from typing_extensions import Annotated
-
-load_dotenv(override=True)
 
 # Lazy initialization - only create client when needed
 _tavily_client = None

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -30,7 +30,6 @@ def _run_serve_once(
     no_thinking: bool = False,
     cwd: str | None = None,
 ):
-    import dotenv
     import EvoScientist.config as config_mod
 
     order: list[tuple[str, str | None]] = []
@@ -71,9 +70,6 @@ def _run_serve_once(
 
     monkeypatch.setattr(config_mod, "get_effective_config", lambda *_a, **_k: config)
     monkeypatch.setattr(config_mod, "apply_config_to_env", lambda _cfg: None)
-
-    monkeypatch.setattr(dotenv, "load_dotenv", lambda *_a, **_k: None)
-    monkeypatch.setattr(dotenv, "find_dotenv", lambda *_a, **_k: "")
 
     if cwd is not None:
         monkeypatch.setattr(commands.os, "getcwd", lambda: cwd)


### PR DESCRIPTION
## Description

`load_dotenv` was called in three scattered places: `commands.py` (main and serve entry points) and `search.py` (at module import time). This could re-override env vars after config resolution. I moved the single `load_dotenv` call into `get_effective_config()` so it participates in the config priority chain, and removed it from all other call sites.

## Type of change

<!-- Check the one that applies. -->

- [x] Bug fix
- [ ] New feature — link issue: #<!-- issue number -->
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [ ] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes
