### PR TITLE
fix: improve ccproxy OAuth install hint

### DIFF
--- a/EvoScientist/ccproxy_manager.py
+++ b/EvoScientist/ccproxy_manager.py
@@ -49,6 +49,40 @@ def is_ccproxy_available() -> bool:
     return _ccproxy_exe() is not None
 
 
+def _is_editable_install() -> bool:
+    """Return True if EvoScientist was installed in editable/development mode.
+
+    Checks all matching distributions because a stale ``.egg-info`` in the
+    project root can shadow the real ``dist-info`` in site-packages.
+    """
+    try:
+        import json
+        import importlib.metadata as _meta
+
+        for dist in _meta.distributions():
+            name = dist.metadata.get("Name", "")
+            if name.lower() != "evoscientist":
+                continue
+            direct_url = dist.read_text("direct_url.json")
+            if direct_url is not None:
+                data = json.loads(direct_url)
+                if data.get("dir_info", {}).get("editable", False) is True:
+                    return True
+    except Exception:
+        pass
+    return False
+
+
+def _oauth_install_hint() -> str:
+    """Return the appropriate install command depending on install method."""
+    if _is_editable_install():
+        return (
+            "uv sync --extra oauth "
+            "or pip install -e '.[oauth]'"
+        )
+    return "pip install 'evoscientist[oauth]'"
+
+
 def _summarize_auth_output(raw: str) -> str:
     """Extract key fields from ccproxy auth status output into a one-line summary.
 
@@ -356,8 +390,7 @@ def maybe_start_ccproxy(config: EvoScientistConfig) -> subprocess.Popen | None:
     if not is_ccproxy_available():
         raise RuntimeError(
             "ccproxy is required for OAuth mode but not found. "
-            "Install it with: uv sync --extra oauth "
-            "or pip install 'evoscientist[oauth]'"
+            f"Install it with: {_oauth_install_hint()}"
         )
 
     # Check auth for each provider that uses OAuth

--- a/tests/test_ccproxy_manager.py
+++ b/tests/test_ccproxy_manager.py
@@ -334,17 +334,29 @@ class TestMaybeStartCcproxy:
         mock_anthropic_env.assert_called_once()
         mock_codex_env.assert_called_once()
 
+    @patch("EvoScientist.ccproxy_manager._is_editable_install", return_value=True)
     @patch("EvoScientist.ccproxy_manager.is_ccproxy_available", return_value=False)
-    def test_openai_oauth_raises_no_binary(self, mock_avail):
+    def test_openai_oauth_raises_no_binary_editable(self, mock_avail, mock_edit):
         config = MagicMock()
         config.anthropic_auth_mode = "api_key"
         config.openai_auth_mode = "oauth"
         with pytest.raises(RuntimeError) as exc_info:
             maybe_start_ccproxy(config)
-
         msg = str(exc_info.value)
         assert "ccproxy is required for OAuth mode but not found" in msg
         assert "uv sync --extra oauth" in msg
+        assert "pip install -e '.[oauth]'" in msg
+
+    @patch("EvoScientist.ccproxy_manager._is_editable_install", return_value=False)
+    @patch("EvoScientist.ccproxy_manager.is_ccproxy_available", return_value=False)
+    def test_openai_oauth_raises_no_binary_pip(self, mock_avail, mock_edit):
+        config = MagicMock()
+        config.anthropic_auth_mode = "api_key"
+        config.openai_auth_mode = "oauth"
+        with pytest.raises(RuntimeError) as exc_info:
+            maybe_start_ccproxy(config)
+        msg = str(exc_info.value)
+        assert "ccproxy is required for OAuth mode but not found" in msg
         assert "pip install 'evoscientist[oauth]'" in msg
 
     @patch(


### PR DESCRIPTION
## Description

Improve the missing-ccproxy OAuth startup error so source-checkout users get a uv-specific recovery command in addition to the existing pip install hint.

## Type of change

- [x] Bug fix
- [ ] New feature — link issue: #<!-- issue number -->
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable
- [x] All checks passed! passes
- [x] ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/rqq/EvoScientist
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.12.1, langsmith-0.7.20, timeout-2.4.0, cov-7.0.0
collected 1112 items

tests/test_additional_channel_smoke.py .........                         [  0%]
tests/test_agent_mcp_cache.py ..                                         [  0%]
tests/test_ask_user.py ................................................. [  5%]
                                                                         [  5%]
tests/test_backends.py ................................................. [  9%]
...........                                                              [ 10%]
tests/test_bus_integration.py ....                                       [ 11%]
tests/test_ccproxy_manager.py .................................          [ 14%]
tests/test_channel_comprehensive.py .................................... [ 17%]
........................................................................ [ 23%]
.................                                                        [ 25%]
tests/test_cli_channel_bus_mode.py ...                                   [ 25%]
tests/test_cli_run_name.py .....                                         [ 26%]
tests/test_cli_serve.py ....                                             [ 26%]
tests/test_cli_tui_dispatch.py .                                         [ 26%]
tests/test_compact_command.py ..............                             [ 27%]
tests/test_config.py .....................................               [ 31%]
tests/test_diff_format.py ...........................                    [ 33%]
tests/test_dingtalk_channel.py ........................                  [ 35%]
tests/test_discord_channel.py ......                                     [ 36%]
tests/test_event_loop.py .........                                       [ 37%]
tests/test_feishu_channel.py ........................................... [ 40%]
.                                                                        [ 41%]
tests/test_hitl.py ...........................................           [ 44%]
tests/test_llm.py ................................................       [ 49%]
tests/test_mcp_client.py ............................................... [ 53%]
............................................                             [ 57%]
tests/test_memory_merge.py .....                                         [ 57%]
tests/test_onboard.py .................................................. [ 62%]
......                                                                   [ 62%]
tests/test_paths.py .....                                                [ 63%]
tests/test_prompts.py .........                                          [ 64%]
tests/test_rich_escape.py ..                                             [ 64%]
tests/test_sessions.py ...........................                       [ 66%]
tests/test_skills_manager.py .........................................   [ 70%]
tests/test_slack_channel.py ........                                     [ 71%]
tests/test_stream_emitter.py ...............                             [ 72%]
tests/test_stream_events.py .............                                [ 73%]
tests/test_stream_state.py ............................................. [ 77%]
..............                                                           [ 78%]
tests/test_stream_tracker.py .............                               [ 80%]
tests/test_stream_utils.py ............................................. [ 84%]
.....                                                                    [ 84%]
tests/test_summarization.py ..........................                   [ 86%]
tests/test_telegram_channel.py ......                                    [ 87%]
tests/test_thread_selector.py ...........................                [ 89%]
tests/test_tool_error_handler.py .................                       [ 91%]
tests/test_tools.py ....                                                 [ 91%]
tests/test_tui_widgets.py .............................................  [ 95%]
tests/test_ui_runtime.py .......                                         [ 96%]
tests/test_wechat_channel.py ..........................sssss........     [100%]

======================= 1107 passed, 5 skipped in 15.92s ======================= passes
