### PR TITLE
Fix/deepseek sequence content error

### DIFF
--- a/EvoScientist/config/onboard.py
+++ b/EvoScientist/config/onboard.py
@@ -361,6 +361,33 @@ def validate_openrouter_key(api_key: str) -> tuple[bool, str]:
         return False, f"Error: {e}"
 
 
+def validate_deepseek_key(api_key: str) -> tuple[bool, str]:
+    """Validate a DeepSeek API key by making a test request.
+
+    Returns:
+        Tuple of (is_valid, message).
+    """
+    if not api_key:
+        return True, "Skipped (no key provided)"
+
+    try:
+        import openai
+
+        client = openai.OpenAI(api_key=api_key, base_url="https://api.deepseek.com")
+        client.models.list()
+        return True, "Valid"
+    except Exception as e:
+        error_str = str(e).lower()
+        if (
+            "401" in error_str
+            or "unauthorized" in error_str
+            or "invalid" in error_str
+            or "authentication" in error_str
+        ):
+            return False, "Invalid API key"
+        return False, f"Error: {e}"
+
+
 def validate_zhipu_key(api_key: str) -> tuple[bool, str]:
     """Validate a ZhipuAI API key by making a test request.
 
@@ -622,6 +649,10 @@ def _step_provider(config: EvoScientistConfig) -> str:
             title="DashScope (阿里云 — Qwen models)",
             value="dashscope",
         ),
+        Choice(
+            title="DeepSeek (DeepSeek-R1, DeepSeek-V3)",
+            value="deepseek",
+        ),
         # Local
         Choice(title="Ollama (local models)", value="ollama"),
         # Third-party / aggregator
@@ -695,6 +726,11 @@ def _provider_key_info(config: EvoScientistConfig, provider: str):
             "OpenRouter",
             config.openrouter_api_key or os.environ.get("OPENROUTER_API_KEY", ""),
             validate_openrouter_key,
+        ),
+        "deepseek": (
+            "DeepSeek",
+            config.deepseek_api_key or os.environ.get("DEEPSEEK_API_KEY", ""),
+            validate_deepseek_key,
         ),
         "zhipu": (
             "ZhipuAI",
@@ -2401,6 +2437,7 @@ def run_onboard(skip_validation: bool = False) -> bool:
             "google-genai": "google_api_key",
             "siliconflow": "siliconflow_api_key",
             "openrouter": "openrouter_api_key",
+            "deepseek": "deepseek_api_key",
             "zhipu": "zhipu_api_key",
             "zhipu-code": "zhipu_api_key",
             "volcengine": "volcengine_api_key",

--- a/EvoScientist/config/settings.py
+++ b/EvoScientist/config/settings.py
@@ -69,6 +69,7 @@ class EvoScientistConfig:
     minimax_api_key: str = ""
     siliconflow_api_key: str = ""
     openrouter_api_key: str = ""
+    deepseek_api_key: str = ""
     zhipu_api_key: str = ""
     volcengine_api_key: str = ""
     dashscope_api_key: str = ""
@@ -349,6 +350,7 @@ _ENV_MAPPINGS = {
     "minimax_api_key": "MINIMAX_API_KEY",
     "siliconflow_api_key": "SILICONFLOW_API_KEY",
     "openrouter_api_key": "OPENROUTER_API_KEY",
+    "deepseek_api_key": "DEEPSEEK_API_KEY",
     "zhipu_api_key": "ZHIPU_API_KEY",
     "volcengine_api_key": "VOLCENGINE_API_KEY",
     "dashscope_api_key": "DASHSCOPE_API_KEY",
@@ -434,6 +436,8 @@ def apply_config_to_env(config: EvoScientistConfig) -> None:
         os.environ["SILICONFLOW_API_KEY"] = config.siliconflow_api_key
     if config.openrouter_api_key and not os.environ.get("OPENROUTER_API_KEY"):
         os.environ["OPENROUTER_API_KEY"] = config.openrouter_api_key
+    if config.deepseek_api_key and not os.environ.get("DEEPSEEK_API_KEY"):
+        os.environ["DEEPSEEK_API_KEY"] = config.deepseek_api_key
     if config.zhipu_api_key and not os.environ.get("ZHIPU_API_KEY"):
         os.environ["ZHIPU_API_KEY"] = config.zhipu_api_key
     if config.volcengine_api_key and not os.environ.get("VOLCENGINE_API_KEY"):

--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -67,20 +67,23 @@ def strip_thinking_tags(content: str) -> str:
     return _THINKING_TAG_RE.sub("", content)
 
 
-# ---------------------------------------------------------------------------
-# Utility: flatten list-of-blocks content to a plain string.
-# OpenAI-compatible APIs (DeepSeek, SiliconFlow, etc.) reject assistant
-# messages whose content is a list rather than a string.
-# ---------------------------------------------------------------------------
 _SKIP_CONTENT_TYPES = frozenset({"thinking", "reasoning", "reasoning_content"})
 
 
 def _flatten_message_content(content: Any) -> str | Any:
     """Convert list-of-blocks content to a plain string.
 
-    - Extracts text from ``{"type": "text", "text": "..."}`` blocks.
-    - Skips ``thinking`` / ``reasoning`` / ``reasoning_content`` blocks.
-    - Returns string content unchanged.
+    OpenAI-compatible APIs (DeepSeek, SiliconFlow, etc.) reject assistant
+    messages whose ``content`` is a list rather than a string.
+
+    Args:
+        content: Message content — either a string, a list of content blocks
+            (dicts with ``type`` and ``text`` keys), or another type.
+
+    Returns:
+        A plain string with text blocks joined by double newlines.
+        Thinking/reasoning blocks are skipped.  Non-list input is
+        returned unchanged.
     """
     if isinstance(content, str):
         return content
@@ -99,32 +102,38 @@ def _flatten_message_content(content: Any) -> str | Any:
     return "\n\n".join(parts) if parts else ""
 
 
-# ---------------------------------------------------------------------------
-# Patch: wrap _generate / _agenerate on OpenAI-compatible models to flatten
-# list content to strings before the API call, preventing "invalid type:
-# sequence, expected a string" errors from strict APIs like DeepSeek.
-# ---------------------------------------------------------------------------
 def _patch_openai_compat_content(model: Any) -> None:
-    """Wrap ``_generate`` / ``_agenerate`` to flatten message content to strings.
+    """Flatten list content to strings before OpenAI-compatible API calls.
 
-    Follows the same monkey-patching pattern as ``_patch_anthropic_proxy_compat``.
+    Wraps ``_generate`` / ``_agenerate`` to prevent "invalid type: sequence,
+    expected a string" errors from strict APIs like DeepSeek.  Follows the
+    same monkey-patching pattern as ``_patch_anthropic_proxy_compat``.
+
+    Args:
+        model: A LangChain chat model instance to patch in-place.
     """
+    import copy
     import functools
 
     from langchain_core.messages import BaseMessage
 
     def _sanitize_messages(messages: list[BaseMessage]) -> list[BaseMessage]:
+        out: list[BaseMessage] = []
         for msg in messages:
             if isinstance(msg.content, list):
+                msg = copy.copy(msg)
                 msg.content = _flatten_message_content(msg.content)
-        return messages
+            out.append(msg)
+        return out
 
     orig_generate = getattr(model, "_generate", None)
     if orig_generate is None:
         return
 
     @functools.wraps(orig_generate)
-    def _patched_generate(messages: list[BaseMessage], *args: Any, **kwargs: Any) -> Any:
+    def _patched_generate(
+        messages: list[BaseMessage], *args: Any, **kwargs: Any
+    ) -> Any:
         return orig_generate(_sanitize_messages(messages), *args, **kwargs)
 
     model._generate = _patched_generate

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -597,6 +597,73 @@ class TestMiniMaxProvider:
 
 
 # =============================================================================
+# Test _flatten_message_content
+# =============================================================================
+
+
+class TestFlattenMessageContent:
+    """Tests for the content-flattening utility used by OpenAI-compatible providers."""
+
+    def test_string_passthrough(self):
+        from EvoScientist.llm.models import _flatten_message_content
+
+        assert _flatten_message_content("hello") == "hello"
+
+    def test_non_list_passthrough(self):
+        from EvoScientist.llm.models import _flatten_message_content
+
+        assert _flatten_message_content(42) == 42
+        assert _flatten_message_content(None) is None
+
+    def test_text_blocks(self):
+        from EvoScientist.llm.models import _flatten_message_content
+
+        content = [
+            {"type": "text", "text": "Hello"},
+            {"type": "text", "text": "World"},
+        ]
+        assert _flatten_message_content(content) == "Hello\n\nWorld"
+
+    def test_skips_thinking_blocks(self):
+        from EvoScientist.llm.models import _flatten_message_content
+
+        content = [
+            {"type": "thinking", "text": "Let me think..."},
+            {"type": "text", "text": "The answer is 42"},
+            {"type": "reasoning", "text": "internal reasoning"},
+            {"type": "reasoning_content", "text": "more reasoning"},
+        ]
+        assert _flatten_message_content(content) == "The answer is 42"
+
+    def test_string_blocks(self):
+        from EvoScientist.llm.models import _flatten_message_content
+
+        content = ["hello", "world"]
+        assert _flatten_message_content(content) == "hello\n\nworld"
+
+    def test_mixed_blocks(self):
+        from EvoScientist.llm.models import _flatten_message_content
+
+        content = [
+            {"type": "thinking", "text": "skip me"},
+            "plain string",
+            {"type": "text", "text": "dict text"},
+        ]
+        assert _flatten_message_content(content) == "plain string\n\ndict text"
+
+    def test_empty_list(self):
+        from EvoScientist.llm.models import _flatten_message_content
+
+        assert _flatten_message_content([]) == ""
+
+    def test_only_thinking_blocks(self):
+        from EvoScientist.llm.models import _flatten_message_content
+
+        content = [{"type": "thinking", "text": "thought"}]
+        assert _flatten_message_content(content) == ""
+
+
+# =============================================================================
 # Test _apply_auto_config
 # =============================================================================
 


### PR DESCRIPTION
 ## Description

 DeepSeek and other OpenAI-compatible APIs (SiliconFlow, OpenRouter, etc.) reject assistant messages whose
 `content` is a list of blocks instead of a plain string, raising `"invalid type: sequence, expected a string"`
 errors. This PR fixes the issue and adds first-class DeepSeek support.

 Closes the "sequence content" error when using DeepSeek models via LangChain.

 ## Type of change

 - [x] Bug fix
 - [x] New feature

 ## Changes

 - **Add DeepSeek as a recognized provider** — base URL, API key env var (`DEEPSEEK_API_KEY`), and short names
 (`deepseek-r1`, `deepseek-v3`)
 - **Add `_flatten_message_content` utility** — converts list-of-blocks content to a plain string, skipping
 `thinking`/`reasoning` blocks
 - **Patch `_generate`/`_agenerate` on OpenAI-compatible models** — automatically flattens message content before
  API calls for all OpenAI-routed and proxied providers
 - **Update tests** — verify DeepSeek appears in provider registry and model entries

 ## Checklist

 - [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
 - [x] This targets **core functionality** used by the majority of users
 - [x] I have added/updated tests where applicable
 - [ ] `uv run ruff check .` passes
 - [ ] `uv run pytest` passes