### PR TITLE
feat: add paper-navigator skill for end-to-end paper search and reading

### DIFF
--- a/EvoScientist/skills/paper-navigator/SKILL.md
+++ b/EvoScientist/skills/paper-navigator/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: paper-navigator
+description: >
+  End-to-end academic paper workflow: discover papers (search, citation traversal,
+  recommendations, arXiv monitoring, trending detection), evaluate them (TLDR,
+  citation metrics, code availability, SOTA ranking), read full text with structured
+  analysis (3-level reading strategy), and organize into literature maps (novelty
+  tree, challenge-insight tree). Use when the user asks about finding papers, reading
+  a paper, related work, literature survey, citation analysis, new papers, research
+  trends, paper implementations, SOTA results, or datasets.
+---
+
+# Paper Navigator
+
+End-to-end paper workflow in four stages:
+
+```
+┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+│ Discover │ →  │ Evaluate │ →  │   Read   │ →  │ Organize │
+│ 发现论文  │    │ 筛选评估  │    │ 深度阅读  │    │ 文献图谱  │
+└──────────┘    └──────────┘    └──────────┘    └──────────┘
+```
+
+| Stage | Input | Scripts | Output |
+|-------|-------|---------|--------|
+| Discover | keywords / author / field | `scholar_search`, `citation_traverse`, `recommend`, `author_search`, `arxiv_monitor`, `trending` | candidate list |
+| Evaluate | candidate list | `scholar_search` (TLDR/citations), `find_code`, `sota`, `dataset_search` | reading list |
+| Read | paper ID / URL | `fetch_paper` + `references/reading-strategy.md` | structured notes |
+| Organize | multiple notes | (agent applies framework — no script) | literature map |
+
+**Setup:** All scripts use `httpx` (already in project). Optional env vars for higher rate limits:
+- `S2_API_KEY` — Semantic Scholar ([request here](https://www.semanticscholar.org/product/api#api-key))
+- `JINA_API_KEY` — Jina Reader (free tier works without key)
+
+Scripts are in `EvoScientist/skills/paper-navigator/scripts/`. Run via `python EvoScientist/skills/paper-navigator/scripts/<name>.py`.
+
+---
+
+## Stage 1: Discover
+
+Six discovery paths, ordered by frequency of use.
+
+### Path A: Keyword Search (most common)
+
+```bash
+python scripts/scholar_search.py --query "transformer attention mechanism" --limit 20 --sort-by citations
+```
+
+Options: `--year-min/--year-max`, `--open-access-only`, `--sort-by relevance|citations|year`.
+
+Returns: title, authors, year, citations, TLDR, OA PDF link.
+
+### Path B: Citation Traversal (from a seed paper)
+
+```bash
+# Forward — who cited this paper
+python scripts/citation_traverse.py --paper-id ArXiv:1706.03762 --direction forward --limit 20
+
+# Backward — what this paper cites
+python scripts/citation_traverse.py --paper-id ArXiv:1706.03762 --direction backward --limit 20
+
+# Co-citation — papers frequently cited alongside this one (sister works)
+python scripts/citation_traverse.py --paper-id ArXiv:1706.03762 --direction co-citation --limit 15
+```
+
+Co-citation is the most powerful discovery method — it finds closely related work that keyword search misses.
+
+### Path C: "More Like This" Recommendations
+
+```bash
+python scripts/recommend.py --positive ArXiv:1706.03762,ArXiv:2005.14165 --limit 15
+# Optionally exclude certain directions:
+python scripts/recommend.py --positive ArXiv:1706.03762 --negative ArXiv:2301.00001 --limit 10
+```
+
+### Path D: Author Tracking
+
+```bash
+python scripts/author_search.py --name "Geoffrey Hinton" --papers --limit 20 --sort-by citations
+```
+
+### Path E: New Paper Monitoring
+
+```bash
+# By category (see references/arxiv-categories.md for codes)
+python scripts/arxiv_monitor.py --categories cs.CL,cs.AI --days 3 --limit 30
+
+# By keywords
+python scripts/arxiv_monitor.py --keywords "chain of thought,reasoning" --days 7
+```
+
+### Path F: Trending Detection
+
+```bash
+python scripts/trending.py --query "large language models" --period 90 --limit 15
+```
+
+Ranks by citation velocity (citations/month). Useful for finding rapidly rising papers.
+
+### Citation Graph Visualization
+
+After traversal, visualize with Mermaid (keep ≤30 nodes):
+
+```mermaid
+graph TD
+    SEED["Attention Is All You Need<br/>2017 · 100k+"]
+    A["BERT · 2018"] --> SEED
+    B["GPT-2 · 2019"] --> SEED
+    C["Vision Transformer · 2020"] --> SEED
+```
+
+---
+
+## Stage 2: Evaluate
+
+Goal: filter candidates into a reading list. Use data already returned by Discover scripts plus targeted checks.
+
+### Quick Assessment (from scholar_search output)
+
+| Signal | What it tells you |
+|--------|-------------------|
+| TLDR | One-sentence understanding |
+| Citation count | Overall impact |
+| Influential citations | Quality of impact |
+| Year + venue | Recency and authority |
+| Open Access PDF | Whether you can read full text |
+
+### Code Availability Check
+
+```bash
+python scripts/find_code.py --arxiv-id 1706.03762
+```
+
+Returns: GitHub URLs, stars, framework, whether official implementation.
+
+### SOTA Ranking
+
+```bash
+python scripts/sota.py --task "Machine Translation" --dataset "WMT14 EN-DE"
+# List available tasks first:
+python scripts/sota.py --task "Machine Translation" --list-tasks
+# List datasets for a task:
+python scripts/sota.py --task "Machine Translation" --list-datasets
+```
+
+### Dataset Discovery
+
+```bash
+python scripts/dataset_search.py --query "sentiment analysis" --limit 10
+```
+
+### Reproducibility Assessment
+
+After gathering the above, assess each paper:
+
+| Dimension | Check | Score |
+|-----------|-------|-------|
+| Code | Open-source? Official? Stars? Last update? | |
+| Results | Reproduced on SOTA leaderboard? | |
+| Data | Dataset publicly available? | |
+| **Overall** | | High / Medium / Low / None |
+
+---
+
+## Stage 3: Read
+
+### Fetch Full Text
+
+```bash
+# By paper ID (auto-resolves to best URL via S2 metadata)
+python scripts/fetch_paper.py --paper-id ArXiv:1706.03762
+
+# By direct URL
+python scripts/fetch_paper.py --url "https://arxiv.org/abs/1706.03762"
+
+# Metadata only (no full text fetch)
+python scripts/fetch_paper.py --paper-id ArXiv:1706.03762 --metadata-only
+```
+
+Uses Jina Reader (`r.jina.ai`) to convert any paper URL to clean Markdown. Works with arXiv HTML, PDF links, and publisher pages.
+
+### Choose Reading Depth
+
+| Level | Goal | When to use | Effort |
+|-------|------|-------------|--------|
+| **L1 Technical** | Can reimplement the method | Building directly on this paper | High |
+| **L2 Analytical** | Understand motivation, design choices, tradeoffs | Most papers in your survey | Medium |
+| **L3 Contextual** | Know what it is and where it fits | Quick scanning, staying current | Low |
+
+Most papers need only L2-L3. Reserve L1 for papers you will build upon.
+
+Detailed reading methodology: `references/reading-strategy.md`
+
+### Take Notes
+
+Use the template at `assets/paper-summary-template.md`. Save notes to `/artifacts/paper-notes/{paper-id}.md`.
+
+Key questions to answer:
+1. What problem does this paper address?
+2. What is the key contribution (one sentence)?
+3. What is the key technical insight?
+4. What are the limitations (stated and unstated)?
+5. How does this relate to my research?
+
+---
+
+## Stage 4: Organize
+
+After reading multiple papers, build two structures to map the literature.
+
+### Novelty Tree
+
+Classify each paper:
+
+| Type | Meaning | Novelty |
+|------|---------|---------|
+| 1 | Milestone — defines a new task or paradigm | Highest |
+| 2 | New pipeline or data representation | High |
+| 3 | New module or component | Medium |
+| 4 | Incremental improvement on existing approach | Low |
+
+### Challenge-Insight Tree
+
+Build a many-to-many mapping:
+
+1. **Extract challenges:** From each paper, what technical problem does it solve?
+2. **Extract insights:** What technique or key idea does it use?
+3. **Build the map:**
+
+```
+Challenge: Long-range dependencies in sequences
+├── Insight: Self-attention (Transformer)
+├── Insight: State-space models (Mamba)
+└── Insight: Linear attention approximation
+
+Challenge: Quadratic attention cost
+├── Insight: Sparse attention patterns
+├── Insight: Linear attention
+└── Insight: IO-aware computation (Flash Attention)
+```
+
+4. **Analyze the map:**
+   - Challenges with many solutions → well-studied area
+   - Challenges with few solutions → **research opportunity**
+   - Insights that solve many challenges → powerful, versatile technique
+   - Insights not yet applied to a challenge → **potential for transfer**
+
+Save to `/artifacts/literature-tree.md` and update incrementally.
+
+---
+
+## Common Workflows
+
+### Workflow 1: Comprehensive Literature Survey (full pipeline)
+
+> "Help me survey transformers in medical imaging"
+
+1. **Discover:** `scholar_search --query "transformer medical imaging" --limit 20 --sort-by citations` → pick top results → `citation_traverse --direction forward` on seminal papers
+2. **Evaluate:** Review TLDR + citations → shortlist top 10 → `find_code` to check reproducibility
+3. **Read:** `fetch_paper` for top 5 → L2 reading → notes using template
+4. **Organize:** Classify by novelty type → build challenge-insight tree → output survey report
+
+### Workflow 2: Find and Read a Specific Paper
+
+> "Find Attention Is All You Need and analyze it"
+
+1. **Discover:** `scholar_search --query "Attention Is All You Need"`
+2. **Evaluate:** Check TLDR + citations
+3. **Read:** `fetch_paper` → L1 or L2 reading → notes
+
+### Workflow 3: Track Field Developments
+
+> "What's new in NLP this week?"
+
+1. **Discover:** `arxiv_monitor --categories cs.CL --days 7` + `trending --query "NLP" --period 30`
+2. **Evaluate:** Scan TLDRs, highlight high-potential papers
+
+### Workflow 4: Find a Baseline with Code
+
+> "I need a baseline for text classification with code"
+
+1. **Discover:** `scholar_search --query "text classification" --sort-by citations`
+2. **Evaluate:** `find_code` on top results + `sota --task "Text Classification"` → pick one with official code + strong results
+3. Output: recommended baseline + GitHub link + SOTA position
+
+### Workflow 5: Read a Paper by URL
+
+> "Read this paper: arxiv.org/abs/2301.12345"
+
+1. **Read:** `fetch_paper --url "https://arxiv.org/abs/2301.12345"` → choose reading level → notes
+
+---
+
+## Script Reference
+
+All scripts output Markdown to stdout, errors to stderr. Common flags:
+
+| Flag | Description |
+|------|-------------|
+| `--limit N` | Max results (prevents oversized output) |
+| `--json` | Raw JSON output (for programmatic use) |
+
+### Paper ID Formats
+
+Scripts accept multiple ID formats and normalize automatically:
+- S2 ID: `649def34f8be52c8b66281af98ae884c09aef38b`
+- arXiv: `ArXiv:1706.03762` or `1706.03762` or `https://arxiv.org/abs/1706.03762`
+- DOI: `DOI:10.18653/v1/N18-3011` or `10.18653/v1/N18-3011`
+
+### Rate Limits
+
+| API | Without key | With key |
+|-----|-------------|----------|
+| Semantic Scholar | ~100 req / 5 min | ~1 req/s sustained |
+| arXiv | 1 req / 3s (courtesy) | N/A |
+| Jina Reader | Free tier | Higher with key |
+| Papers With Code | Generous | N/A |
+
+### Error Handling
+
+All scripts retry on 429 (rate limit) and 5xx errors with exponential backoff (2s, 4s, 8s). Non-retryable errors print to stderr and exit.
+
+---
+
+## Integration
+
+- **research-ideation:** After organizing papers with the novelty tree and challenge-insight tree, feed gaps into research-ideation for idea generation.
+- **experiment-pipeline:** After finding a baseline via Workflow 4, hand off to experiment-pipeline.
+- **literature-review:** The paper notes and literature tree from Stage 3-4 serve as input for literature-review skill's formal write-up.

--- a/EvoScientist/skills/paper-navigator/assets/paper-summary-template.md
+++ b/EvoScientist/skills/paper-navigator/assets/paper-summary-template.md
@@ -1,0 +1,51 @@
+# Paper Summary: [Title]
+
+## Metadata
+
+- **Authors:** [Author list]
+- **Year:** [Year]
+- **Venue:** [Conference/Journal]
+- **arXiv:** [arXiv ID]
+- **Citations:** [Count]
+- **Code:** [GitHub URL or "None"]
+- **Reading Level:** L1 / L2 / L3
+- **Novelty Type:** 1 / 2 / 3 / 4
+
+## TLDR
+
+[One-sentence summary]
+
+## Problem
+
+[What problem does this paper address? Why does it matter?]
+
+## Key Insight
+
+[What is the core technical insight or intuition?]
+
+## Method
+
+[Brief description of the approach — adapt detail based on reading level]
+
+## Results
+
+[Key experimental results — main numbers, comparison to baselines]
+
+## Strengths
+
+- [Strength 1]
+- [Strength 2]
+
+## Limitations
+
+- [Limitation 1 — acknowledged by authors]
+- [Limitation 2 — not acknowledged but observed]
+
+## Relevance to My Research
+
+[How does this relate to my work? What can I use?]
+
+## Challenge-Insight Entry
+
+- **Challenge:** [Technical challenge this paper addresses]
+- **Insight:** [Key technique / solution used]

--- a/EvoScientist/skills/paper-navigator/references/api-reference.md
+++ b/EvoScientist/skills/paper-navigator/references/api-reference.md
@@ -1,0 +1,120 @@
+# API Reference
+
+Quick reference for APIs used by paper-navigator scripts.
+
+## Semantic Scholar (S2) API
+
+**Base URL:** `https://api.semanticscholar.org/graph/v1`
+
+**Auth:** Optional `S2_API_KEY` env var (header: `x-api-key`)
+- Without key: ~100 requests / 5 minutes
+- With key: ~1 request / second sustained
+
+### Paper ID Formats
+
+| Format | Example | Usage |
+|--------|---------|-------|
+| S2 ID | `649def34f8be52c8b66281af98ae884c09aef38b` | Default internal ID |
+| ArXiv | `ArXiv:1706.03762` | Prefix with `ArXiv:` |
+| DOI | `DOI:10.18653/v1/N18-3011` | Prefix with `DOI:` |
+| ACL | `ACL:N18-3011` | Prefix with `ACL:` |
+| PubMed | `PMID:19872477` | Prefix with `PMID:` |
+| URL | `https://arxiv.org/abs/1706.03762` | Full URL also accepted |
+
+### Key Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/paper/search?query=...&fields=...&limit=N` | GET | Search papers |
+| `/paper/{id}?fields=...` | GET | Single paper details |
+| `/paper/{id}/citations?fields=...&limit=N` | GET | Papers citing this paper |
+| `/paper/{id}/references?fields=...&limit=N` | GET | Papers this paper cites |
+| `/author/search?query=...` | GET | Search authors |
+| `/author/{id}/papers?fields=...` | GET | Author's papers |
+
+### Recommendations API
+
+**Base URL:** `https://api.semanticscholar.org/recommendations/v1`
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/papers/` | POST | `{"positivePaperIds": [...], "negativePaperIds": [...]}` |
+
+### Useful Fields
+
+```
+paperId,externalIds,title,authors,year,citationCount,
+influentialCitationCount,tldr,isOpenAccess,openAccessPdf,
+publicationVenue,abstract,publicationDate
+```
+
+---
+
+## arXiv API
+
+**Base URL:** `http://export.arxiv.org/api/query`
+
+**Auth:** None required
+**Rate limit:** Max 1 request per 3 seconds (courtesy)
+
+### Query Parameters
+
+| Param | Example | Description |
+|-------|---------|-------------|
+| `search_query` | `cat:cs.CL AND ti:transformer` | Search query |
+| `sortBy` | `submittedDate` / `relevance` | Sort order |
+| `sortOrder` | `descending` / `ascending` | Sort direction |
+| `max_results` | `50` | Limit (max 2000) |
+
+### Query Syntax
+
+- `ti:` — title
+- `abs:` — abstract
+- `au:` — author
+- `cat:` — category
+- `submittedDate:` — date range `[YYYYMMDD0000 TO YYYYMMDD2359]`
+- Boolean: `AND`, `OR`, `ANDNOT`
+- Exact phrase: `"chain of thought"`
+
+### Response Format
+
+Returns Atom XML. Namespace: `{http://www.w3.org/2005/Atom}`
+
+---
+
+## Jina Reader
+
+**URL pattern:** `https://r.jina.ai/{target_url}`
+
+**Auth:** Optional `JINA_API_KEY` (header: `Authorization: Bearer <key>`)
+**Header:** `Accept: text/markdown`
+
+Returns the target URL content as clean Markdown. Works with:
+- arXiv abstract pages (HTML → Markdown)
+- PDF URLs (extracts text)
+- Any web page
+
+---
+
+## Papers With Code API
+
+**Base URL:** `https://paperswithcode.com/api/v1`
+
+**Auth:** None required
+**Rate limit:** Generous (undocumented)
+
+### Key Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/papers/?q=...` | GET | Search papers |
+| `/papers/?arxiv_id=...` | GET | Find paper by arXiv ID |
+| `/papers/{id}/repositories/` | GET | Code repos for a paper |
+| `/tasks/?q=...` | GET | Search tasks/benchmarks |
+| `/tasks/{id}/datasets/` | GET | Datasets for a task |
+| `/evaluations/?task=...&dataset=...` | GET | SOTA results |
+| `/datasets/?q=...` | GET | Search datasets |
+
+### IDs
+
+Paper IDs and task IDs use URL-slug format (e.g. `attention-is-all-you-need`, `machine-translation`).

--- a/EvoScientist/skills/paper-navigator/references/arxiv-categories.md
+++ b/EvoScientist/skills/paper-navigator/references/arxiv-categories.md
@@ -1,0 +1,76 @@
+# arXiv Category Codes
+
+Common categories for `arxiv_monitor.py --categories`.
+
+## Computer Science (cs.*)
+
+| Code | Name |
+|------|------|
+| cs.AI | Artificial Intelligence |
+| cs.CL | Computation and Language (NLP) |
+| cs.CV | Computer Vision and Pattern Recognition |
+| cs.LG | Machine Learning |
+| cs.IR | Information Retrieval |
+| cs.RO | Robotics |
+| cs.SE | Software Engineering |
+| cs.CR | Cryptography and Security |
+| cs.DB | Databases |
+| cs.DC | Distributed Computing |
+| cs.DS | Data Structures and Algorithms |
+| cs.HC | Human-Computer Interaction |
+| cs.NE | Neural and Evolutionary Computing |
+| cs.PL | Programming Languages |
+| cs.SI | Social and Information Networks |
+| cs.SY | Systems and Control |
+| cs.MA | Multiagent Systems |
+
+## Statistics (stat.*)
+
+| Code | Name |
+|------|------|
+| stat.ML | Machine Learning |
+| stat.TH | Statistics Theory |
+| stat.ME | Methodology |
+| stat.AP | Applications |
+
+## Mathematics (math.*)
+
+| Code | Name |
+|------|------|
+| math.OC | Optimization and Control |
+| math.ST | Statistics Theory |
+| math.NA | Numerical Analysis |
+| math.PR | Probability |
+
+## Electrical Engineering (eess.*)
+
+| Code | Name |
+|------|------|
+| eess.AS | Audio and Speech Processing |
+| eess.IV | Image and Video Processing |
+| eess.SP | Signal Processing |
+
+## Quantitative Biology (q-bio.*)
+
+| Code | Name |
+|------|------|
+| q-bio.BM | Biomolecules |
+| q-bio.GN | Genomics |
+| q-bio.QM | Quantitative Methods |
+
+## Physics
+
+| Code | Name |
+|------|------|
+| physics.comp-ph | Computational Physics |
+| cond-mat.dis-nn | Disordered Systems and Neural Networks |
+| quant-ph | Quantum Physics |
+
+## Common Combinations
+
+- **NLP/LLM research:** `cs.CL,cs.AI,cs.LG`
+- **Computer Vision:** `cs.CV,cs.LG`
+- **Robotics + RL:** `cs.RO,cs.AI,cs.LG`
+- **ML Theory:** `cs.LG,stat.ML,math.OC`
+- **Bioinformatics:** `q-bio.BM,q-bio.GN,cs.AI`
+- **Speech/Audio:** `eess.AS,cs.CL,cs.SD`

--- a/EvoScientist/skills/paper-navigator/references/reading-strategy.md
+++ b/EvoScientist/skills/paper-navigator/references/reading-strategy.md
@@ -1,0 +1,124 @@
+# Paper Reading Strategy
+
+Extracted from the research-ideation methodology. Use this to guide structured paper analysis.
+
+## 3-Level Reading Framework
+
+### L1: Technical Reading (High effort)
+
+**Goal:** Fully understand the method — able to reimplement it.
+
+**Process:**
+1. Read abstract + introduction for motivation and claims
+2. Study methodology section in detail:
+   - What is the exact formulation / algorithm?
+   - What are the inputs, outputs, and intermediate representations?
+   - What are the key hyperparameters and design choices?
+3. Analyze experiments:
+   - What baselines are compared?
+   - What metrics are used and why?
+   - Do ablation studies support the claimed contributions?
+4. Check supplementary materials for implementation details
+5. Look at the code (use `find_code.py`) to verify understanding
+
+**When to use:** Papers you will directly build upon.
+
+### L2: Analytical Reading (Medium effort)
+
+**Goal:** Understand the *why* — motivation, design rationale, tradeoffs.
+
+**Process:**
+1. Read abstract + intro + conclusion first (5 min)
+2. Study figures and tables — they tell the story
+3. Focus on:
+   - What problem does this solve, and why does it matter?
+   - What is the key insight / intuition?
+   - What are the design choices and why were they made?
+   - How does this compare to alternative approaches?
+4. Skim experiments for main results (skip ablations unless relevant)
+
+**When to use:** Most papers in your literature survey.
+
+### L3: Contextual Reading (Low effort)
+
+**Goal:** Know what it is and where it fits in the landscape.
+
+**Process:**
+1. Read title + abstract + TLDR (if available from `scholar_search.py`)
+2. Glance at figures
+3. Read conclusion
+4. Note: main contribution, year, citation count, relation to your work
+
+**When to use:** Quick scanning, staying current with field trends.
+
+---
+
+## Reading Decision Tree
+
+```
+Is this paper directly related to my implementation?
+├── Yes → L1 Technical Reading
+└── No
+    ├── Is it in my research area / related work?
+    │   ├── Yes → L2 Analytical Reading
+    │   └── No → L3 Contextual Reading
+    └── Am I just browsing / monitoring?
+        └── L3 Contextual Reading
+```
+
+---
+
+## Key Questions to Answer for Each Paper
+
+### Core Questions (all levels)
+
+1. **What problem** does this paper address?
+2. **What is the key contribution** (in one sentence)?
+3. **How novel is this?** (Type 1-4 on the novelty scale)
+
+### Deeper Questions (L1-L2)
+
+4. **What is the key technical insight?**
+5. **What assumptions does this approach make?**
+6. **What are the limitations the authors acknowledge?**
+7. **What limitations do they NOT acknowledge?**
+8. **How does this relate to my research?**
+
+### Implementation Questions (L1 only)
+
+9. **Can I reproduce the results with the given information?**
+10. **What would I need to change to adapt this to my problem?**
+11. **What is the computational cost?**
+
+---
+
+## Novelty Classification (for Organize stage)
+
+| Type | Description | Example |
+|------|-------------|---------|
+| Type 1 | Milestone — defines a new task or paradigm | Attention Is All You Need |
+| Type 2 | New pipeline or data representation | BERT (pre-train + fine-tune paradigm) |
+| Type 3 | New module or component | Flash Attention (efficient attention module) |
+| Type 4 | Incremental improvement on existing methods | Most papers |
+
+---
+
+## Challenge-Insight Tree Construction
+
+After reading multiple papers, build a mapping:
+
+**Challenges** (technical problems):
+- Extract from each paper: "What problem does it solve?"
+- Group related challenges
+
+**Insights** (solutions / techniques):
+- Extract from each paper: "What technique / insight does it use?"
+- Link insights to challenges they address
+
+**Analysis:**
+- Which challenges have many solutions? → Well-studied area
+- Which challenges have few solutions? → Research opportunity
+- Which insights are versatile (solve many challenges)? → Powerful technique
+- Which insights are underexplored? → Potential for transfer
+
+Save the tree to `/artifacts/literature-tree.md` and update as you read more papers.

--- a/EvoScientist/skills/paper-navigator/scripts/arxiv_monitor.py
+++ b/EvoScientist/skills/paper-navigator/scripts/arxiv_monitor.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Monitor arXiv for new papers by category or keywords.
+
+Uses the arXiv API to fetch recent papers from specific categories
+or matching keywords.
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.parse
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+ARXIV_API = "http://export.arxiv.org/api/query"
+NS = {"atom": "http://www.w3.org/2005/Atom", "arxiv": "http://arxiv.org/schemas/atom"}
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+_UA = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+
+
+def _request_with_retry(client: httpx.Client, url: str, params: dict) -> str:
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(url, params=params, headers=_UA, timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.text
+        except httpx.HTTPError as e:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            raise SystemExit(f"Error: {e}") from e
+    return ""
+
+
+def _parse_entries(xml_text: str) -> list[dict]:
+    """Parse arXiv Atom XML into paper dicts."""
+    root = ET.fromstring(xml_text)
+    entries = root.findall("atom:entry", NS)
+    papers = []
+    for entry in entries:
+        title = entry.findtext("atom:title", "", NS).replace("\n", " ").strip()
+        summary = entry.findtext("atom:summary", "", NS).strip()
+        published = entry.findtext("atom:published", "", NS)
+        updated = entry.findtext("atom:updated", "", NS)
+
+        # Extract arXiv ID from the id URL
+        id_url = entry.findtext("atom:id", "", NS)
+        arxiv_id = id_url.split("/abs/")[-1] if "/abs/" in id_url else id_url
+
+        authors = []
+        for author in entry.findall("atom:author", NS):
+            name = author.findtext("atom:name", "", NS)
+            if name:
+                authors.append(name)
+
+        categories = []
+        for cat in entry.findall("atom:category", NS):
+            term = cat.get("term", "")
+            if term:
+                categories.append(term)
+
+        # PDF link
+        pdf_url = ""
+        for link in entry.findall("atom:link", NS):
+            if link.get("title") == "pdf":
+                pdf_url = link.get("href", "")
+
+        # Comment (often contains page count, conference info)
+        comment = ""
+        comment_el = entry.find("arxiv:comment", NS)
+        if comment_el is not None and comment_el.text:
+            comment = comment_el.text.strip()
+
+        papers.append({
+            "arxiv_id": arxiv_id,
+            "title": title,
+            "authors": authors,
+            "summary": summary[:300],
+            "categories": categories,
+            "published": published,
+            "updated": updated,
+            "pdf_url": pdf_url,
+            "comment": comment,
+        })
+    return papers
+
+
+def fetch_by_categories(categories: list[str], days: int = 1, limit: int = 50) -> list[dict]:
+    """Fetch recent papers from specific arXiv categories."""
+    # arXiv API query: cat:cs.CL OR cat:cs.AI
+    cat_query = " OR ".join(f"cat:{c}" for c in categories)
+
+    # Date filter via submittedDate
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days)
+    date_range = f"[{start.strftime('%Y%m%d')}0000 TO {end.strftime('%Y%m%d')}2359]"
+
+    query = f"({cat_query}) AND submittedDate:{date_range}"
+    params = {
+        "search_query": query,
+        "sortBy": "submittedDate",
+        "sortOrder": "descending",
+        "max_results": min(limit, 200),
+    }
+
+    with httpx.Client() as client:
+        xml_text = _request_with_retry(client, ARXIV_API, params)
+    return _parse_entries(xml_text)
+
+
+def fetch_by_keywords(keywords: list[str], days: int = 7, limit: int = 50) -> list[dict]:
+    """Fetch recent papers matching keywords."""
+    # Search in title and abstract
+    kw_parts = []
+    for kw in keywords:
+        kw = kw.strip()
+        if " " in kw:
+            kw_parts.append(f'ti:"{kw}" OR abs:"{kw}"')
+        else:
+            kw_parts.append(f"ti:{kw} OR abs:{kw}")
+
+    kw_query = " OR ".join(f"({p})" for p in kw_parts)
+
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days)
+    date_range = f"[{start.strftime('%Y%m%d')}0000 TO {end.strftime('%Y%m%d')}2359]"
+
+    query = f"({kw_query}) AND submittedDate:{date_range}"
+    params = {
+        "search_query": query,
+        "sortBy": "submittedDate",
+        "sortOrder": "descending",
+        "max_results": min(limit, 200),
+    }
+
+    with httpx.Client() as client:
+        xml_text = _request_with_retry(client, ARXIV_API, params)
+    return _parse_entries(xml_text)
+
+
+def format_paper(p: dict, idx: int) -> str:
+    title = p["title"]
+    arxiv_id = p["arxiv_id"]
+    authors = ", ".join(p["authors"][:3])
+    if len(p["authors"]) > 3:
+        authors += " et al."
+    cats = ", ".join(p["categories"][:3])
+    published = p["published"][:10] if p["published"] else "?"
+    summary = p["summary"][:200]
+    if len(p["summary"]) > 200:
+        summary = summary.rsplit(" ", 1)[0] + "…"
+
+    comment = f"\n  📝 {p['comment']}" if p["comment"] else ""
+
+    return (f"{idx}. **{title}**\n"
+            f"  {authors} | {published} | [{cats}]\n"
+            f"  arXiv:`{arxiv_id}` | [PDF]({p['pdf_url']}){comment}\n"
+            f"  > {summary}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Monitor arXiv for new papers")
+    parser.add_argument("--categories", "-c", help="Comma-separated arXiv categories (e.g. cs.CL,cs.AI)")
+    parser.add_argument("--keywords", "-k", help="Comma-separated keywords to search")
+    parser.add_argument("--days", "-d", type=int, default=3, help="Look back N days (default 3)")
+    parser.add_argument("--limit", "-l", type=int, default=30, help="Max results (default 30)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    if not args.categories and not args.keywords:
+        print("Error: --categories or --keywords required", file=sys.stderr)
+        sys.exit(1)
+
+    papers = []
+    if args.categories:
+        cats = [c.strip() for c in args.categories.split(",")]
+        papers = fetch_by_categories(cats, args.days, args.limit)
+    else:
+        kws = [k.strip() for k in args.keywords.split(",")]
+        papers = fetch_by_keywords(kws, args.days, args.limit)
+
+    if not papers:
+        print("No new papers found.", file=sys.stderr)
+        sys.exit(0)
+
+    if args.json:
+        print(json.dumps(papers, indent=2))
+        return
+
+    mode = f"categories: {args.categories}" if args.categories else f"keywords: {args.keywords}"
+    print(f"# arXiv Monitor: {mode}\n")
+    print(f"Last **{args.days}** days | Found **{len(papers)}** papers\n")
+    for i, p in enumerate(papers, 1):
+        print(format_paper(p, i))
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/author_search.py
+++ b/EvoScientist/skills/paper-navigator/scripts/author_search.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Search for authors and their papers via Semantic Scholar API."""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import httpx
+
+S2_BASE = "https://api.semanticscholar.org/graph/v1"
+AUTHOR_FIELDS = "authorId,name,affiliations,paperCount,citationCount,hIndex"
+PAPER_FIELDS = "paperId,externalIds,title,year,citationCount,tldr,isOpenAccess,openAccessPdf"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+def _headers() -> dict:
+    h = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+    key = os.environ.get("S2_API_KEY")
+    if key:
+        h["x-api-key"] = key
+    return h
+
+
+def _request_with_retry(client: httpx.Client, url: str, params: dict | None = None) -> dict:
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(url, params=params, headers=_headers(), timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError:
+            raise
+        except httpx.HTTPError as e:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            raise SystemExit(f"Error: {e}") from e
+    return {}
+
+
+def search_author(name: str) -> list[dict]:
+    """Search for authors by name."""
+    with httpx.Client() as client:
+        data = _request_with_retry(client, f"{S2_BASE}/author/search",
+                                   {"query": name, "fields": AUTHOR_FIELDS, "limit": 5})
+    return data.get("data", [])
+
+
+def get_author_papers(author_id: str, limit: int = 20) -> list[dict]:
+    """Get papers by a specific author."""
+    with httpx.Client() as client:
+        data = _request_with_retry(
+            client,
+            f"{S2_BASE}/author/{author_id}/papers",
+            {"fields": PAPER_FIELDS, "limit": min(limit, 1000)}
+        )
+    return data.get("data", [])
+
+
+def format_author(a: dict) -> str:
+    name = a.get("name", "Unknown")
+    aid = a.get("authorId", "")
+    affiliations = ", ".join(a.get("affiliations", [])[:2]) or "N/A"
+    papers = a.get("paperCount", 0)
+    citations = a.get("citationCount", 0)
+    h_index = a.get("hIndex", "?")
+    return (f"**{name}** (ID: `{aid}`)\n"
+            f"  Affiliation: {affiliations} | Papers: {papers} | "
+            f"Citations: {citations} | h-index: {h_index}")
+
+
+def format_paper(p: dict, idx: int) -> str:
+    title = p.get("title", "Unknown")
+    year = p.get("year", "?")
+    citations = p.get("citationCount", 0)
+    ext = p.get("externalIds", {})
+    arxiv = ext.get("ArXiv", "")
+    id_str = f"arXiv:`{arxiv}`" if arxiv else f"S2:`{p.get('paperId', '')[:12]}…`"
+
+    tldr = ""
+    if p.get("tldr") and p["tldr"].get("text"):
+        tldr = f"\n  > {p['tldr']['text']}"
+
+    return f"{idx}. **{title}** ({year}) — ⭐{citations} — {id_str}{tldr}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search authors via Semantic Scholar")
+    parser.add_argument("--name", help="Author name to search")
+    parser.add_argument("--author-id", help="S2 author ID (skip name search)")
+    parser.add_argument("--papers", action="store_true", help="List author's papers")
+    parser.add_argument("--limit", "-l", type=int, default=20, help="Max papers (default 20)")
+    parser.add_argument("--sort-by", choices=["citations", "year"], default="year")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    if not args.name and not args.author_id:
+        print("Error: --name or --author-id required", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve author ID
+    author_id = args.author_id
+    if not author_id:
+        authors = search_author(args.name)
+        if not authors:
+            print(f"No author found for '{args.name}'", file=sys.stderr)
+            sys.exit(0)
+
+        if args.json and not args.papers:
+            print(json.dumps(authors, indent=2))
+            return
+
+        print("# Author Search Results\n")
+        for a in authors:
+            print(format_author(a))
+            print()
+
+        author_id = authors[0]["authorId"]
+        if not args.papers:
+            return
+        print("---\n")
+
+    # Get papers
+    if args.papers or args.author_id:
+        papers = get_author_papers(author_id, args.limit)
+
+        if args.sort_by == "citations":
+            papers.sort(key=lambda p: p.get("citationCount", 0), reverse=True)
+        else:
+            papers.sort(key=lambda p: p.get("year", 0), reverse=True)
+
+        papers = papers[:args.limit]
+
+        if args.json:
+            print(json.dumps(papers, indent=2))
+            return
+
+        print(f"# Papers by Author `{author_id}`\n")
+        print(f"Showing **{len(papers)}** papers (sorted by {args.sort_by})\n")
+        for i, p in enumerate(papers, 1):
+            print(format_paper(p, i))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/citation_traverse.py
+++ b/EvoScientist/skills/paper-navigator/scripts/citation_traverse.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Traverse citation graphs via Semantic Scholar API.
+
+Supports forward citations (who cited this), backward citations
+(references), and co-citation discovery.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import httpx
+
+S2_BASE = "https://api.semanticscholar.org/graph/v1"
+S2_FIELDS = "paperId,externalIds,title,authors,year,citationCount,influentialCitationCount,tldr,isOpenAccess,openAccessPdf"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+def _headers() -> dict:
+    h = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+    key = os.environ.get("S2_API_KEY")
+    if key:
+        h["x-api-key"] = key
+    return h
+
+
+def _request_with_retry(client: httpx.Client, url: str, params: dict | None = None) -> dict:
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(url, params=params, headers=_headers(), timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError:
+            raise
+        except httpx.HTTPError as e:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            raise SystemExit(f"Error: {e}") from e
+    return {}
+
+
+def _normalize_paper_id(raw: str) -> str:
+    """Normalize paper ID: strip URL prefixes, add ArXiv: prefix if needed."""
+    raw = raw.strip()
+    for prefix in ["https://arxiv.org/abs/", "http://arxiv.org/abs/",
+                    "https://arxiv.org/pdf/", "http://arxiv.org/pdf/"]:
+        if raw.startswith(prefix):
+            raw = raw[len(prefix):].rstrip(".pdf")
+            return f"ArXiv:{raw}"
+    if raw.startswith("10."):
+        return f"DOI:{raw}"
+    return raw
+
+
+def get_citations(paper_id: str, limit: int = 20) -> list[dict]:
+    """Forward citations: papers that cite this paper."""
+    params = {"fields": S2_FIELDS, "limit": min(limit, 1000)}
+    with httpx.Client() as client:
+        data = _request_with_retry(client, f"{S2_BASE}/paper/{paper_id}/citations", params)
+    return [c["citingPaper"] for c in data.get("data", []) if c.get("citingPaper")]
+
+
+def get_references(paper_id: str, limit: int = 20) -> list[dict]:
+    """Backward citations: papers this paper references."""
+    params = {"fields": S2_FIELDS, "limit": min(limit, 1000)}
+    with httpx.Client() as client:
+        data = _request_with_retry(client, f"{S2_BASE}/paper/{paper_id}/references", params)
+    return [r["citedPaper"] for r in data.get("data", []) if r.get("citedPaper")]
+
+
+def get_co_citations(paper_id: str, limit: int = 15) -> list[dict]:
+    """Co-citation: papers frequently cited alongside this paper.
+
+    Strategy: get forward citations, collect their references,
+    find most common papers (excluding the seed).
+    """
+    # Get papers that cite the seed
+    citers = get_citations(paper_id, limit=50)
+    if not citers:
+        return []
+
+    # Sample up to 10 citers to stay within rate limits
+    sample = citers[:10]
+    ref_counts: dict[str, dict] = {}
+
+    with httpx.Client() as client:
+        for citer in sample:
+            citer_id = citer.get("paperId")
+            if not citer_id:
+                continue
+            try:
+                params = {"fields": S2_FIELDS, "limit": 100}
+                data = _request_with_retry(client, f"{S2_BASE}/paper/{citer_id}/references", params)
+                for r in data.get("data", []):
+                    ref = r.get("citedPaper", {})
+                    rid = ref.get("paperId")
+                    if rid and rid != paper_id:
+                        if rid not in ref_counts:
+                            ref_counts[rid] = {"paper": ref, "count": 0}
+                        ref_counts[rid]["count"] += 1
+                time.sleep(0.5)  # Rate limit courtesy
+            except Exception:
+                continue
+
+    # Sort by co-citation frequency
+    sorted_refs = sorted(ref_counts.values(), key=lambda x: x["count"], reverse=True)
+    return [r["paper"] for r in sorted_refs[:limit]]
+
+
+def format_paper(p: dict, idx: int) -> str:
+    title = p.get("title", "Unknown")
+    year = p.get("year", "?")
+    citations = p.get("citationCount", 0)
+    authors = p.get("authors", [])
+    author_str = ", ".join(a.get("name", "") for a in authors[:3])
+    if len(authors) > 3:
+        author_str += " et al."
+
+    tldr = ""
+    if p.get("tldr") and p["tldr"].get("text"):
+        tldr = f"\n  > {p['tldr']['text']}"
+
+    pid = p.get("paperId", "")
+    ext = p.get("externalIds", {})
+    arxiv = ext.get("ArXiv", "")
+    id_str = f"S2:`{pid[:8]}…`"
+    if arxiv:
+        id_str = f"arXiv:`{arxiv}`"
+
+    return f"{idx}. **{title}** — {author_str} ({year}) — ⭐{citations} — {id_str}{tldr}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Traverse citation graphs via Semantic Scholar")
+    parser.add_argument("--paper-id", "-p", required=True, help="Paper ID (S2, ArXiv:, DOI:, or URL)")
+    parser.add_argument("--direction", "-d", required=True,
+                        choices=["forward", "backward", "co-citation"],
+                        help="Traversal direction")
+    parser.add_argument("--limit", "-l", type=int, default=20, help="Max results (default 20)")
+    parser.add_argument("--min-citations", type=int, default=0,
+                        help="Minimum citation count filter")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    paper_id = _normalize_paper_id(args.paper_id)
+
+    direction_labels = {
+        "forward": "Forward Citations (papers citing this paper)",
+        "backward": "Backward Citations (papers referenced by this paper)",
+        "co-citation": "Co-cited Papers (frequently cited alongside this paper)",
+    }
+
+    print(f"# {direction_labels[args.direction]}\n", file=sys.stderr)
+    print(f"Seed paper: `{paper_id}`\n", file=sys.stderr)
+
+    if args.direction == "forward":
+        papers = get_citations(paper_id, args.limit)
+    elif args.direction == "backward":
+        papers = get_references(paper_id, args.limit)
+    else:
+        print("⚠️  Co-citation requires multiple API calls (may be slow)…\n", file=sys.stderr)
+        papers = get_co_citations(paper_id, args.limit)
+
+    # Filter by min citations
+    if args.min_citations > 0:
+        papers = [p for p in papers if (p.get("citationCount") or 0) >= args.min_citations]
+
+    # Sort by citations
+    papers.sort(key=lambda p: p.get("citationCount", 0), reverse=True)
+    papers = papers[:args.limit]
+
+    if not papers:
+        print("No papers found.", file=sys.stderr)
+        sys.exit(0)
+
+    if args.json:
+        print(json.dumps(papers, indent=2))
+        return
+
+    print(f"# {direction_labels[args.direction]}\n")
+    print(f"Seed: `{paper_id}` | Results: **{len(papers)}**\n")
+    for i, p in enumerate(papers, 1):
+        print(format_paper(p, i))
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/dataset_search.py
+++ b/EvoScientist/skills/paper-navigator/scripts/dataset_search.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Search for datasets via Papers With Code API."""
+
+import argparse
+import json
+import sys
+import time
+
+import httpx
+
+PWC_BASE = "https://paperswithcode.com/api/v1"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+_UA = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+
+
+def _request_with_retry(client: httpx.Client, url: str, params: dict | None = None) -> dict:
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(url, params=params, headers=_UA, timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return {}
+            raise
+        except httpx.HTTPError as e:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            raise SystemExit(f"Error: {e}") from e
+    return {}
+
+
+def search_datasets(query: str, limit: int = 10) -> list[dict]:
+    """Search PwC datasets."""
+    with httpx.Client() as client:
+        data = _request_with_retry(client, f"{PWC_BASE}/datasets/", {"q": query})
+    results = data.get("results", [])
+    return results[:limit]
+
+
+def format_dataset(d: dict, idx: int) -> str:
+    name = d.get("name", "Unknown")
+    did = d.get("id", "")
+    full_name = d.get("full_name", "")
+    num_papers = d.get("num_papers", "?")
+    homepage = d.get("homepage", "")
+    desc = (d.get("description") or "")[:200]
+    if len(d.get("description", "") or "") > 200:
+        desc = desc.rsplit(" ", 1)[0] + "..."
+
+    modalities = d.get("modalities", [])
+    modality_str = ", ".join(modalities[:3]) if modalities else ""
+
+    lines = [f"{idx}. **{name}**"]
+    if full_name and full_name != name:
+        lines[0] += f" ({full_name})"
+    lines.append(f"   Papers: {num_papers} | ID: `{did}`")
+    if modality_str:
+        lines.append(f"   Modalities: {modality_str}")
+    if homepage:
+        lines.append(f"   Homepage: {homepage}")
+    if desc:
+        lines.append(f"   > {desc}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search datasets via Papers With Code")
+    parser.add_argument("--query", "-q", required=True, help="Search query")
+    parser.add_argument("--limit", "-l", type=int, default=10, help="Max results (default 10)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    datasets = search_datasets(args.query, args.limit)
+
+    if not datasets:
+        print(f"No datasets found for '{args.query}'", file=sys.stderr)
+        sys.exit(0)
+
+    if args.json:
+        print(json.dumps(datasets, indent=2))
+        return
+
+    print(f"# Datasets: \"{args.query}\"\n")
+    print(f"Found **{len(datasets)}** datasets\n")
+    for i, d in enumerate(datasets, 1):
+        print(format_dataset(d, i))
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/fetch_paper.py
+++ b/EvoScientist/skills/paper-navigator/scripts/fetch_paper.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Fetch full paper text using Semantic Scholar metadata + Jina Reader.
+
+Resolves paper ID to a URL, then uses Jina Reader (r.jina.ai) to
+convert the paper page to clean Markdown.
+"""
+
+import argparse
+import os
+import sys
+import time
+
+import httpx
+
+S2_BASE = "https://api.semanticscholar.org/graph/v1"
+JINA_PREFIX = "https://r.jina.ai/"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+def _s2_headers() -> dict:
+    h = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+    key = os.environ.get("S2_API_KEY")
+    if key:
+        h["x-api-key"] = key
+    return h
+
+
+def _jina_headers() -> dict:
+    headers = {"Accept": "text/markdown"}
+    key = os.environ.get("JINA_API_KEY")
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    return headers
+
+
+def _normalize_paper_id(raw: str) -> str:
+    raw = raw.strip()
+    for prefix in ["https://arxiv.org/abs/", "http://arxiv.org/abs/",
+                    "https://arxiv.org/pdf/", "http://arxiv.org/pdf/"]:
+        if raw.startswith(prefix):
+            raw = raw[len(prefix):].rstrip(".pdf")
+            return f"ArXiv:{raw}"
+    if raw.startswith("10."):
+        return f"DOI:{raw}"
+    return raw
+
+
+def resolve_paper_url(paper_id: str) -> tuple[str, dict]:
+    """Resolve paper ID to best available URL + metadata."""
+    pid = _normalize_paper_id(paper_id)
+
+    fields = "paperId,externalIds,title,authors,year,citationCount,tldr,isOpenAccess,openAccessPdf,abstract"
+
+    with httpx.Client() as client:
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = client.get(f"{S2_BASE}/paper/{pid}",
+                                  params={"fields": fields},
+                                  headers=_s2_headers(), timeout=30)
+                if resp.status_code == 429 or resp.status_code >= 500:
+                    if attempt < MAX_RETRIES - 1:
+                        time.sleep(RETRY_DELAYS[attempt])
+                        continue
+                resp.raise_for_status()
+                meta = resp.json()
+                break
+            except httpx.HTTPError as e:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+                raise SystemExit(f"Error resolving paper: {e}") from e
+        else:
+            meta = {}
+
+    # Determine best URL
+    url = ""
+    # Prefer OA PDF
+    if meta.get("openAccessPdf") and meta["openAccessPdf"].get("url"):
+        url = meta["openAccessPdf"]["url"]
+    # Fallback: arXiv abstract page (Jina handles HTML well)
+    elif meta.get("externalIds", {}).get("ArXiv"):
+        arxiv_id = meta["externalIds"]["ArXiv"]
+        url = f"https://arxiv.org/abs/{arxiv_id}"
+    # Fallback: DOI
+    elif meta.get("externalIds", {}).get("DOI"):
+        doi = meta["externalIds"]["DOI"]
+        url = f"https://doi.org/{doi}"
+
+    return url, meta
+
+
+def fetch_via_jina(url: str, limit_chars: int = 50000) -> str:
+    """Fetch URL content as Markdown via Jina Reader."""
+    jina_url = f"{JINA_PREFIX}{url}"
+
+    with httpx.Client() as client:
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = client.get(jina_url, headers=_jina_headers(), timeout=60,
+                                  follow_redirects=True)
+                if resp.status_code == 429 or resp.status_code >= 500:
+                    if attempt < MAX_RETRIES - 1:
+                        time.sleep(RETRY_DELAYS[attempt])
+                        continue
+                resp.raise_for_status()
+                text = resp.text
+                if len(text) > limit_chars:
+                    text = text[:limit_chars] + f"\n\n---\n*[Truncated at {limit_chars} characters]*"
+                return text
+            except httpx.HTTPError as e:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+                return f"Error fetching paper: {e}"
+    return ""
+
+
+def format_metadata(meta: dict) -> str:
+    """Format paper metadata header."""
+    title = meta.get("title", "Unknown")
+    authors = meta.get("authors", [])
+    author_str = ", ".join(a.get("name", "") for a in authors[:5])
+    if len(authors) > 5:
+        author_str += f" et al. ({len(authors)} authors)"
+    year = meta.get("year", "?")
+    citations = meta.get("citationCount", 0)
+
+    tldr = ""
+    if meta.get("tldr") and meta["tldr"].get("text"):
+        tldr = f"\n> **TLDR:** {meta['tldr']['text']}\n"
+
+    ext = meta.get("externalIds", {})
+    ids = []
+    if ext.get("ArXiv"):
+        ids.append(f"arXiv: `{ext['ArXiv']}`")
+    if ext.get("DOI"):
+        ids.append(f"DOI: `{ext['DOI']}`")
+    ids.append(f"S2: `{meta.get('paperId', '')}`")
+
+    return (f"# {title}\n\n"
+            f"**{author_str}** ({year}) | Citations: {citations}\n"
+            f"{' | '.join(ids)}\n"
+            f"{tldr}\n---\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch paper full text via Jina Reader")
+    parser.add_argument("--paper-id", "-p", help="Paper ID (S2, ArXiv:, DOI:, or URL)")
+    parser.add_argument("--url", "-u", help="Direct URL to fetch (skip S2 lookup)")
+    parser.add_argument("--limit-chars", type=int, default=50000,
+                        help="Max output characters (default 50000)")
+    parser.add_argument("--metadata-only", action="store_true",
+                        help="Only show metadata, skip full text")
+    args = parser.parse_args()
+
+    if not args.paper_id and not args.url:
+        print("Error: --paper-id or --url required", file=sys.stderr)
+        sys.exit(1)
+
+    if args.url:
+        # Direct URL mode
+        url = args.url
+        meta = {}
+        # Try to get metadata from S2 if it looks like an arXiv URL
+        if "arxiv.org" in url:
+            arxiv_id = url.split("/abs/")[-1].split("/pdf/")[-1].rstrip(".pdf")
+            try:
+                _, meta = resolve_paper_url(f"ArXiv:{arxiv_id}")
+            except Exception:
+                pass
+    else:
+        url, meta = resolve_paper_url(args.paper_id)
+
+    if meta:
+        print(format_metadata(meta))
+
+    if args.metadata_only:
+        if meta.get("abstract"):
+            print(f"## Abstract\n\n{meta['abstract']}\n")
+        return
+
+    if not url:
+        print("Error: no accessible URL found for this paper", file=sys.stderr)
+        if meta.get("abstract"):
+            print(f"\n## Abstract (full text not available)\n\n{meta['abstract']}\n")
+        sys.exit(1)
+
+    print(f"*Fetching from: {url}*\n", file=sys.stderr)
+    content = fetch_via_jina(url, args.limit_chars)
+    print(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/find_code.py
+++ b/EvoScientist/skills/paper-navigator/scripts/find_code.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Find code implementations for papers via Papers With Code API."""
+
+import argparse
+import json
+import sys
+import time
+
+import httpx
+
+PWC_BASE = "https://paperswithcode.com/api/v1"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+_UA = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+
+
+def _request_with_retry(client: httpx.Client, url: str, params: dict | None = None) -> dict | list:
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(url, params=params, headers=_UA, timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return {}
+            raise
+        except httpx.HTTPError as e:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            raise SystemExit(f"Error: {e}") from e
+    return {}
+
+
+def _find_paper_id(client: httpx.Client, arxiv_id: str | None = None,
+                   title: str | None = None) -> str | None:
+    """Find PwC paper ID by arXiv ID or title search."""
+    if arxiv_id:
+        # Clean arXiv ID
+        arxiv_id = arxiv_id.strip().replace("ArXiv:", "").replace("arxiv:", "")
+        for prefix in ["https://arxiv.org/abs/", "http://arxiv.org/abs/"]:
+            if arxiv_id.startswith(prefix):
+                arxiv_id = arxiv_id[len(prefix):]
+
+        # Search by arXiv ID
+        data = _request_with_retry(client, f"{PWC_BASE}/papers/",
+                                   {"arxiv_id": arxiv_id})
+        if isinstance(data, dict) and data.get("results"):
+            return data["results"][0].get("id")
+
+    if title:
+        data = _request_with_retry(client, f"{PWC_BASE}/papers/",
+                                   {"q": title})
+        if isinstance(data, dict) and data.get("results"):
+            return data["results"][0].get("id")
+
+    return None
+
+
+def find_code(arxiv_id: str | None = None, title: str | None = None,
+              limit: int = 5) -> list[dict]:
+    """Find code repos for a paper."""
+    with httpx.Client() as client:
+        paper_id = _find_paper_id(client, arxiv_id, title)
+        if not paper_id:
+            return []
+
+        data = _request_with_retry(
+            client,
+            f"{PWC_BASE}/papers/{paper_id}/repositories/",
+        )
+
+        repos = data.get("results", []) if isinstance(data, dict) else data if isinstance(data, list) else []
+        # Sort by stars
+        repos.sort(key=lambda r: r.get("stars", 0), reverse=True)
+        return repos[:limit]
+
+
+def format_repo(r: dict, idx: int) -> str:
+    url = r.get("url", "")
+    stars = r.get("stars", 0)
+    framework = r.get("framework", "unknown")
+    is_official = r.get("is_official", False)
+    desc = r.get("description", "")[:150]
+
+    official_tag = " 🏷️ **Official**" if is_official else ""
+
+    return (f"{idx}. [{url}]({url}){official_tag}\n"
+            f"   ⭐ {stars} | Framework: {framework}\n"
+            f"   {desc}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Find code implementations via Papers With Code")
+    parser.add_argument("--arxiv-id", "-a", help="arXiv ID (e.g. 1706.03762)")
+    parser.add_argument("--title", "-t", help="Paper title to search")
+    parser.add_argument("--limit", "-l", type=int, default=5, help="Max repos (default 5)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    if not args.arxiv_id and not args.title:
+        print("Error: --arxiv-id or --title required", file=sys.stderr)
+        sys.exit(1)
+
+    repos = find_code(args.arxiv_id, args.title, args.limit)
+
+    if not repos:
+        query = args.arxiv_id or args.title
+        print(f"No code found for '{query}'", file=sys.stderr)
+        sys.exit(0)
+
+    if args.json:
+        print(json.dumps(repos, indent=2))
+        return
+
+    query = args.arxiv_id or args.title
+    print(f"# Code Implementations: {query}\n")
+    print(f"Found **{len(repos)}** repositories\n")
+    for i, r in enumerate(repos, 1):
+        print(format_repo(r, i))
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/recommend.py
+++ b/EvoScientist/skills/paper-navigator/scripts/recommend.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Get paper recommendations from Semantic Scholar.
+
+Given seed papers (positive examples, optionally negative examples),
+returns semantically similar papers.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import httpx
+
+S2_BASE = "https://api.semanticscholar.org/recommendations/v1"
+S2_GRAPH = "https://api.semanticscholar.org/graph/v1"
+S2_FIELDS = "paperId,externalIds,title,authors,year,citationCount,influentialCitationCount,tldr,isOpenAccess,openAccessPdf"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+def _headers() -> dict:
+    h = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+    key = os.environ.get("S2_API_KEY")
+    if key:
+        h["x-api-key"] = key
+    return h
+
+
+def _normalize_paper_id(raw: str) -> str:
+    raw = raw.strip()
+    for prefix in ["https://arxiv.org/abs/", "http://arxiv.org/abs/",
+                    "https://arxiv.org/pdf/", "http://arxiv.org/pdf/"]:
+        if raw.startswith(prefix):
+            raw = raw[len(prefix):].rstrip(".pdf")
+            return f"ArXiv:{raw}"
+    if raw.startswith("10."):
+        return f"DOI:{raw}"
+    return raw
+
+
+def _resolve_to_s2_id(client: httpx.Client, paper_id: str) -> str:
+    """Resolve any paper ID format to S2 paperId."""
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(f"{S2_GRAPH}/paper/{paper_id}",
+                              params={"fields": "paperId"},
+                              headers=_headers(), timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.json().get("paperId", paper_id)
+        except Exception:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            return paper_id
+    return paper_id
+
+
+def recommend(positive_ids: list[str], negative_ids: list[str] | None = None,
+              limit: int = 10) -> list[dict]:
+    """Get recommendations based on seed papers."""
+    with httpx.Client() as client:
+        # Resolve all IDs to S2 format
+        pos_s2 = [_resolve_to_s2_id(client, _normalize_paper_id(pid)) for pid in positive_ids]
+        neg_s2 = [_resolve_to_s2_id(client, _normalize_paper_id(pid)) for pid in (negative_ids or [])]
+
+        body: dict = {
+            "positivePaperIds": pos_s2,
+        }
+        if neg_s2:
+            body["negativePaperIds"] = neg_s2
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = client.post(
+                    f"{S2_BASE}/papers/",
+                    json=body,
+                    params={"fields": S2_FIELDS, "limit": min(limit, 500)},
+                    headers=_headers(),
+                    timeout=30,
+                )
+                if resp.status_code == 429 or resp.status_code >= 500:
+                    if attempt < MAX_RETRIES - 1:
+                        time.sleep(RETRY_DELAYS[attempt])
+                        continue
+                resp.raise_for_status()
+                return resp.json().get("recommendedPapers", [])
+            except httpx.HTTPStatusError:
+                raise
+            except httpx.HTTPError as e:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+                raise SystemExit(f"Error: {e}") from e
+    return []
+
+
+def format_paper(p: dict, idx: int) -> str:
+    title = p.get("title", "Unknown")
+    year = p.get("year", "?")
+    citations = p.get("citationCount", 0)
+    authors = p.get("authors", [])
+    author_str = ", ".join(a.get("name", "") for a in authors[:3])
+    if len(authors) > 3:
+        author_str += " et al."
+
+    tldr = ""
+    if p.get("tldr") and p["tldr"].get("text"):
+        tldr = f"\n  > {p['tldr']['text']}"
+
+    ext = p.get("externalIds", {})
+    arxiv = ext.get("ArXiv", "")
+    pid = p.get("paperId", "")
+    id_str = f"arXiv:`{arxiv}`" if arxiv else f"S2:`{pid[:12]}…`"
+
+    pdf = ""
+    if p.get("openAccessPdf") and p["openAccessPdf"].get("url"):
+        pdf = f" 📄"
+
+    return f"{idx}. **{title}** — {author_str} ({year}) — ⭐{citations}{pdf} — {id_str}{tldr}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get paper recommendations from Semantic Scholar")
+    parser.add_argument("--positive", "-p", required=True,
+                        help="Comma-separated seed paper IDs (positive examples)")
+    parser.add_argument("--negative", "-n",
+                        help="Comma-separated paper IDs to avoid (negative examples)")
+    parser.add_argument("--limit", "-l", type=int, default=10, help="Max results (default 10)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    positive = [p.strip() for p in args.positive.split(",") if p.strip()]
+    negative = [p.strip() for p in args.negative.split(",") if p.strip()] if args.negative else None
+
+    if not positive:
+        print("Error: at least one positive paper ID required", file=sys.stderr)
+        sys.exit(1)
+
+    papers = recommend(positive, negative, args.limit)
+
+    if not papers:
+        print("No recommendations found.", file=sys.stderr)
+        sys.exit(0)
+
+    if args.json:
+        print(json.dumps(papers, indent=2))
+        return
+
+    print("# Paper Recommendations\n")
+    print(f"Seeds: {', '.join(f'`{p}`' for p in positive)}")
+    if negative:
+        print(f"Avoid: {', '.join(f'`{n}`' for n in negative)}")
+    print(f"\nFound **{len(papers)}** recommendations\n")
+    for i, p in enumerate(papers, 1):
+        print(format_paper(p, i))
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/scholar_search.py
+++ b/EvoScientist/skills/paper-navigator/scripts/scholar_search.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Search academic papers via Semantic Scholar API.
+
+Returns paper metadata including title, authors, year, citation count,
+TLDR summary, and open-access PDF links.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import httpx
+
+S2_BASE = "https://api.semanticscholar.org/graph/v1"
+S2_FIELDS = "paperId,externalIds,title,authors,year,citationCount,influentialCitationCount,tldr,isOpenAccess,openAccessPdf,publicationVenue,abstract"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+def _headers() -> dict:
+    h = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+    key = os.environ.get("S2_API_KEY")
+    if key:
+        h["x-api-key"] = key
+    return h
+
+
+def _request_with_retry(client: httpx.Client, url: str, params: dict | None = None) -> dict:
+    """GET with retry on 429/5xx."""
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(url, params=params, headers=_headers(), timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError:
+            raise
+        except httpx.HTTPError as e:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            raise SystemExit(f"Error: {e}") from e
+    return {}
+
+
+def search(query: str, limit: int = 10, year_min: int | None = None,
+           year_max: int | None = None, open_access_only: bool = False) -> list[dict]:
+    """Search S2 for papers matching query."""
+    params: dict = {
+        "query": query,
+        "limit": min(limit, 100),
+        "fields": S2_FIELDS,
+    }
+    if year_min or year_max:
+        lo = year_min or ""
+        hi = year_max or ""
+        params["year"] = f"{lo}-{hi}"
+    if open_access_only:
+        params["openAccessPdf"] = ""
+
+    with httpx.Client() as client:
+        data = _request_with_retry(client, f"{S2_BASE}/paper/search", params)
+    return data.get("data", [])
+
+
+def get_paper(paper_id: str) -> dict:
+    """Get single paper details by S2 paper ID or external ID."""
+    with httpx.Client() as client:
+        return _request_with_retry(client, f"{S2_BASE}/paper/{paper_id}",
+                                   {"fields": S2_FIELDS})
+
+
+def _truncate(text: str | None, max_len: int = 200) -> str:
+    if not text:
+        return ""
+    if len(text) <= max_len:
+        return text
+    return text[:max_len].rsplit(" ", 1)[0] + "…"
+
+
+def format_paper(p: dict, idx: int | None = None) -> str:
+    """Format a single paper as Markdown."""
+    prefix = f"### {idx}. " if idx is not None else "### "
+    title = p.get("title", "Unknown")
+    year = p.get("year", "?")
+    citations = p.get("citationCount", 0)
+    influential = p.get("influentialCitationCount", 0)
+
+    authors = p.get("authors", [])
+    author_str = ", ".join(a.get("name", "") for a in authors[:5])
+    if len(authors) > 5:
+        author_str += f" et al. ({len(authors)} authors)"
+
+    venue = ""
+    if p.get("publicationVenue"):
+        venue = p["publicationVenue"].get("name", "")
+
+    tldr = ""
+    if p.get("tldr") and p["tldr"].get("text"):
+        tldr = f"\n> **TLDR:** {p['tldr']['text']}"
+
+    abstract = ""
+    if not tldr and p.get("abstract"):
+        abstract = f"\n> {_truncate(p['abstract'])}"
+
+    pdf = ""
+    if p.get("openAccessPdf") and p["openAccessPdf"].get("url"):
+        pdf = f"\n📄 [Open Access PDF]({p['openAccessPdf']['url']})"
+
+    paper_id = p.get("paperId", "")
+    ext_ids = p.get("externalIds", {})
+    arxiv_id = ext_ids.get("ArXiv", "")
+    doi = ext_ids.get("DOI", "")
+
+    ids_line = f"S2: `{paper_id}`"
+    if arxiv_id:
+        ids_line += f" | arXiv: `{arxiv_id}`"
+    if doi:
+        ids_line += f" | DOI: `{doi}`"
+
+    return f"""{prefix}{title}
+**{author_str}** ({year}) — {venue}
+Citations: **{citations}** (influential: {influential})
+{ids_line}{tldr}{abstract}{pdf}
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search papers via Semantic Scholar")
+    parser.add_argument("--query", "-q", required=True, help="Search query")
+    parser.add_argument("--limit", "-l", type=int, default=10, help="Max results (default 10)")
+    parser.add_argument("--year-min", type=int, help="Minimum publication year")
+    parser.add_argument("--year-max", type=int, help="Maximum publication year")
+    parser.add_argument("--open-access-only", action="store_true", help="Only return OA papers")
+    parser.add_argument("--sort-by", choices=["citations", "year", "relevance"],
+                        default="relevance", help="Sort order")
+    parser.add_argument("--paper-id", help="Get single paper by ID instead of searching")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    if args.paper_id:
+        paper = get_paper(args.paper_id)
+        if args.json:
+            print(json.dumps(paper, indent=2))
+        else:
+            print(format_paper(paper))
+        return
+
+    papers = search(args.query, args.limit, args.year_min, args.year_max, args.open_access_only)
+
+    if not papers:
+        print(f"No papers found for '{args.query}'", file=sys.stderr)
+        sys.exit(0)
+
+    if args.sort_by == "citations":
+        papers.sort(key=lambda p: p.get("citationCount", 0), reverse=True)
+    elif args.sort_by == "year":
+        papers.sort(key=lambda p: p.get("year", 0), reverse=True)
+
+    if args.json:
+        print(json.dumps(papers, indent=2))
+        return
+
+    print(f"# Search Results: \"{args.query}\"\n")
+    print(f"Found **{len(papers)}** papers\n")
+    for i, p in enumerate(papers, 1):
+        print(format_paper(p, i))
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/sota.py
+++ b/EvoScientist/skills/paper-navigator/scripts/sota.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Query SOTA leaderboards via Papers With Code API."""
+
+import argparse
+import json
+import sys
+import time
+
+import httpx
+
+PWC_BASE = "https://paperswithcode.com/api/v1"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+_UA = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+
+
+def _request_with_retry(client: httpx.Client, url: str, params: dict | None = None) -> dict:
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(url, params=params, headers=_UA, timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return {}
+            raise
+        except httpx.HTTPError as e:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            raise SystemExit(f"Error: {e}") from e
+    return {}
+
+
+def _slugify(text: str) -> str:
+    """Convert text to PwC URL slug format."""
+    return text.lower().strip().replace(" ", "-").replace("_", "-")
+
+
+def search_tasks(query: str, limit: int = 5) -> list[dict]:
+    """Search for tasks/benchmarks."""
+    with httpx.Client() as client:
+        data = _request_with_retry(client, f"{PWC_BASE}/tasks/", {"q": query})
+    results = data.get("results", [])
+    return results[:limit]
+
+
+def get_task_datasets(task_id: str) -> list[dict]:
+    """Get datasets for a task."""
+    with httpx.Client() as client:
+        data = _request_with_retry(client, f"{PWC_BASE}/tasks/{task_id}/datasets/")
+    return data.get("results", []) if isinstance(data, dict) else []
+
+
+def get_sota(task_id: str, dataset_id: str | None = None, limit: int = 10) -> list[dict]:
+    """Get SOTA results for a task (optionally filtered by dataset)."""
+    with httpx.Client() as client:
+        if dataset_id:
+            url = f"{PWC_BASE}/evaluations/"
+            data = _request_with_retry(client, url,
+                                       {"task": task_id, "dataset": dataset_id})
+        else:
+            # Get first dataset for the task
+            datasets = get_task_datasets(task_id)
+            if not datasets:
+                return []
+            dataset_id = datasets[0].get("id", "")
+            url = f"{PWC_BASE}/evaluations/"
+            data = _request_with_retry(client, url,
+                                       {"task": task_id, "dataset": dataset_id})
+
+    results = data.get("results", []) if isinstance(data, dict) else []
+    return results[:limit]
+
+
+def format_task(t: dict, idx: int) -> str:
+    name = t.get("name", "Unknown")
+    tid = t.get("id", "")
+    desc = (t.get("description") or "")[:150]
+    return f"{idx}. **{name}** (`{tid}`)\n   {desc}\n"
+
+
+def format_evaluation(e: dict, idx: int) -> str:
+    method = e.get("method", "Unknown")
+    metrics = e.get("metrics", {})
+    paper = e.get("paper", "")
+    code = e.get("code_links", [])
+
+    metrics_str = " | ".join(f"{k}: **{v}**" for k, v in metrics.items()) if isinstance(metrics, dict) else str(metrics)
+    code_str = " 💻" if code else ""
+
+    return f"{idx}. {method} — {metrics_str}{code_str}\n   Paper: {paper}\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query SOTA leaderboards via Papers With Code")
+    parser.add_argument("--task", "-t", required=True, help="Task name to search")
+    parser.add_argument("--dataset", "-d", help="Dataset name (optional)")
+    parser.add_argument("--limit", "-l", type=int, default=10, help="Max results (default 10)")
+    parser.add_argument("--list-tasks", action="store_true", help="List matching tasks only")
+    parser.add_argument("--list-datasets", action="store_true", help="List datasets for the task")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    # Search for tasks
+    tasks = search_tasks(args.task, limit=5)
+    if not tasks:
+        print(f"No tasks found for '{args.task}'", file=sys.stderr)
+        sys.exit(0)
+
+    if args.list_tasks:
+        if args.json:
+            print(json.dumps(tasks, indent=2))
+            return
+        print(f"# Tasks matching: \"{args.task}\"\n")
+        for i, t in enumerate(tasks, 1):
+            print(format_task(t, i))
+        return
+
+    task_id = tasks[0].get("id", "")
+    task_name = tasks[0].get("name", args.task)
+
+    if args.list_datasets:
+        datasets = get_task_datasets(task_id)
+        if args.json:
+            print(json.dumps(datasets, indent=2))
+            return
+        print(f"# Datasets for: {task_name}\n")
+        for i, d in enumerate(datasets[:20], 1):
+            print(f"{i}. **{d.get('name', '')}** (`{d.get('id', '')}`)")
+        return
+
+    # Get SOTA
+    dataset_id = _slugify(args.dataset) if args.dataset else None
+    results = get_sota(task_id, dataset_id, args.limit)
+
+    if not results:
+        print(f"No SOTA results found for '{task_name}'", file=sys.stderr)
+        # Fallback: show available datasets
+        datasets = get_task_datasets(task_id)
+        if datasets:
+            print("\nAvailable datasets:", file=sys.stderr)
+            for d in datasets[:5]:
+                print(f"  - {d.get('name', '')} ({d.get('id', '')})", file=sys.stderr)
+        sys.exit(0)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return
+
+    ds_label = f" on {args.dataset}" if args.dataset else ""
+    print(f"# SOTA: {task_name}{ds_label}\n")
+    for i, e in enumerate(results, 1):
+        print(format_evaluation(e, i))
+
+
+if __name__ == "__main__":
+    main()

--- a/EvoScientist/skills/paper-navigator/scripts/trending.py
+++ b/EvoScientist/skills/paper-navigator/scripts/trending.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Detect trending papers via Semantic Scholar.
+
+Finds papers with high citation velocity (citations per month)
+within a recent time period.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+
+import httpx
+
+S2_BASE = "https://api.semanticscholar.org/graph/v1"
+S2_FIELDS = "paperId,externalIds,title,authors,year,citationCount,influentialCitationCount,tldr,isOpenAccess,openAccessPdf,publicationDate"
+
+MAX_RETRIES = 3
+RETRY_DELAYS = [2, 4, 8]
+
+
+def _headers() -> dict:
+    h = {"User-Agent": "EvoScientist/1.0 (paper-navigator)"}
+    key = os.environ.get("S2_API_KEY")
+    if key:
+        h["x-api-key"] = key
+    return h
+
+
+def _request_with_retry(client: httpx.Client, url: str, params: dict | None = None) -> dict:
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = client.get(url, params=params, headers=_headers(), timeout=30)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(RETRY_DELAYS[attempt])
+                    continue
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPStatusError:
+            raise
+        except httpx.HTTPError as e:
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAYS[attempt])
+                continue
+            raise SystemExit(f"Error: {e}") from e
+    return {}
+
+
+def _citation_velocity(paper: dict) -> float:
+    """Calculate citations per month since publication."""
+    pub_date = paper.get("publicationDate")
+    citations = paper.get("citationCount", 0)
+    if not pub_date or not citations:
+        return 0.0
+    try:
+        pub = datetime.strptime(pub_date, "%Y-%m-%d")
+        months = max((datetime.now() - pub).days / 30.0, 1.0)
+        return citations / months
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def find_trending(query: str, period_days: int = 90, min_citations: int = 5,
+                  limit: int = 20) -> list[dict]:
+    """Search for papers and rank by citation velocity."""
+    now = datetime.now()
+    year_min = now.year - max(period_days // 365, 1)
+
+    params: dict = {
+        "query": query,
+        "limit": 100,  # Fetch more to filter
+        "fields": S2_FIELDS,
+        "year": f"{year_min}-",
+    }
+
+    with httpx.Client() as client:
+        data = _request_with_retry(client, f"{S2_BASE}/paper/search", params)
+
+    papers = data.get("data", [])
+
+    # Filter by min citations
+    papers = [p for p in papers if (p.get("citationCount") or 0) >= min_citations]
+
+    # Calculate velocity and sort
+    for p in papers:
+        p["_velocity"] = _citation_velocity(p)
+
+    papers.sort(key=lambda p: p["_velocity"], reverse=True)
+    return papers[:limit]
+
+
+def format_paper(p: dict, idx: int) -> str:
+    title = p.get("title", "Unknown")
+    year = p.get("year", "?")
+    citations = p.get("citationCount", 0)
+    velocity = p.get("_velocity", 0)
+    pub_date = p.get("publicationDate", "")
+
+    authors = p.get("authors", [])
+    author_str = ", ".join(a.get("name", "") for a in authors[:3])
+    if len(authors) > 3:
+        author_str += " et al."
+
+    tldr = ""
+    if p.get("tldr") and p["tldr"].get("text"):
+        tldr = f"\n  > {p['tldr']['text']}"
+
+    ext = p.get("externalIds", {})
+    arxiv = ext.get("ArXiv", "")
+    id_str = f"arXiv:`{arxiv}`" if arxiv else f"S2:`{p.get('paperId', '')[:12]}…`"
+
+    return (f"{idx}. **{title}**\n"
+            f"  {author_str} ({year}) | Published: {pub_date}\n"
+            f"  ⭐ {citations} citations | 🔥 **{velocity:.1f} cit/month** | {id_str}{tldr}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect trending papers via Semantic Scholar")
+    parser.add_argument("--query", "-q", required=True, help="Search query")
+    parser.add_argument("--period", "-p", type=int, default=90,
+                        help="Look back period in days (default 90)")
+    parser.add_argument("--min-citations", type=int, default=5,
+                        help="Minimum citations filter (default 5)")
+    parser.add_argument("--limit", "-l", type=int, default=20, help="Max results (default 20)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    args = parser.parse_args()
+
+    papers = find_trending(args.query, args.period, args.min_citations, args.limit)
+
+    if not papers:
+        print(f"No trending papers found for '{args.query}'", file=sys.stderr)
+        sys.exit(0)
+
+    if args.json:
+        print(json.dumps(papers, indent=2, default=str))
+        return
+
+    print(f"# Trending Papers: \"{args.query}\"\n")
+    print(f"Period: last **{args.period}** days | Min citations: {args.min_citations}\n")
+    for i, p in enumerate(papers, 1):
+        print(format_paper(p, i))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Unified skill covering the complete paper workflow pipeline: Discover → Evaluate → Read → Organize

- 10 scripts: scholar_search, citation_traverse, recommend, author_search, arxiv_monitor, trending, fetch_paper, find_code, sota, dataset_search
- 3 reference docs: API reference, arXiv categories, reading strategy
- 1 asset: paper summary template
- SKILL.md with Pipeline architecture and 5 common workflows

APIs: Semantic Scholar, arXiv, Jina Reader, Papers With Code
Dependencies: httpx (already in project), xml.etree (stdlib)

https://claude.ai/code/session_01RC7h7SsYD4Fhc1PTD7F5GG

## Description

<!-- What does this PR do? Link the related issue (e.g. "Closes #123"). -->

## Type of change

<!-- Check the one that applies. -->

- [ ] Bug fix
- [ ] New feature — link issue: #<!-- issue number -->
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [ ] I have added/updated tests where applicable
- [ ] `uv run ruff check .` passes
- [ ] `uv run pytest` passes
