### PR TITLE
Fix: Support XDG_CONFIG_HOME for sessions.db on Windows with non-ASCII usernames

### DIFF
--- a/EvoScientist/sessions.py
+++ b/EvoScientist/sessions.py
@@ -39,22 +39,40 @@ AGENT_NAME = "EvoScientist"
 # ---------------------------------------------------------------------------
 
 
-def get_db_path() -> Path:
-    """Return ``~/.config/evoscientist/sessions.db``, creating parents.
+def _to_short_path(path: str) -> str:
+    """Try to convert a Windows path to its 8.3 short form.
 
-    Supports XDG_CONFIG_HOME environment variable to override default location.
-    This is useful on Windows systems with non-ASCII usernames where SQLite
-    may have issues with Unicode paths.
+    On Windows, sqlite3 may fail to open databases at paths containing
+    non-ASCII characters (e.g., Chinese usernames).  Short paths are
+    ASCII-safe when available, but conversion is best-effort: it fails
+    when 8.3 name generation is disabled, on non-NTFS volumes, or for
+    nonexistent targets.  Returns the original path on non-Windows or
+    on failure.
     """
-    import os
+    import sys
 
-    xdg_config = os.environ.get("XDG_CONFIG_HOME")
-    if xdg_config:
-        db_dir = Path(xdg_config) / "evoscientist"
-    else:
-        db_dir = Path.home() / ".config" / "evoscientist"
+    if sys.platform != "win32":
+        return path
+    import ctypes
+
+    buf = ctypes.create_unicode_buffer(32767)
+    if ctypes.windll.kernel32.GetShortPathNameW(path, buf, len(buf)):
+        return buf.value
+    return path
+
+
+def get_db_path() -> Path:
+    """Return the sessions database path, creating parents.
+
+    Reuses ``get_config_dir()`` for XDG_CONFIG_HOME support, then applies
+    a best-effort Windows 8.3 short-path conversion on the *directory*
+    (which exists after ``mkdir``) so sqlite3 can handle non-ASCII paths.
+    """
+    from .config.settings import get_config_dir
+
+    db_dir = get_config_dir()
     db_dir.mkdir(parents=True, exist_ok=True)
-    return db_dir / "sessions.db"
+    return Path(_to_short_path(str(db_dir))) / "sessions.db"
 
 
 def generate_thread_id() -> str:


### PR DESCRIPTION
## Description

This PR fixes the SQLite database opening failure on Windows systems with non-ASCII usernames (e.g., Chinese characters).

Fixes #101

## Changes

- Modified `get_db_path()` in `EvoScientist/sessions.py` to support the `XDG_CONFIG_HOME` environment variable
- This makes the function consistent with `get_config_dir()` in `settings.py`
- Added documentation about the Windows Unicode path issue

## Problem

On Windows systems where the username contains non-ASCII characters (e.g., `C:\Users\樊\.config\evoscientist\sessions.db`), Python's sqlite3 module fails to open the database file with:

```
sqlite3.OperationalError: unable to open database file
```

## Solution

Users can now set the `XDG_CONFIG_HOME` environment variable to use an alternative path:

```powershell
$env:XDG_CONFIG_HOME = "D:\TRAE\star\.config"
EvoSci -p "hello"
```

This follows the XDG Base Directory Specification and is consistent with the existing `get_config_dir()` function in `settings.py`.

## Testing

- [x] Tested on Windows with Chinese username
- [x] Backward compatible - works without `XDG_CONFIG_HOME` set
- [x] Consistent with existing `get_config_dir()` behavior

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Changes are backward compatible
- [x] Documentation updated (docstring)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions database location now respects XDG_CONFIG_HOME, allowing customization of where config and DB files are stored; falls back to the previous default when not set.
* **Bug Fixes / Compatibility**
  * Improved Windows path handling by converting config paths to an ASCII-safe short form when possible to avoid issues with long or non-ASCII paths.
* **Chores**
  * Directory creation and the sessions filename remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->