### PR TITLE
fix(tui): simplify behaviour of pasting clipboard to textbox

### DIFF
--- a/EvoScientist/cli/tui_interactive.py
+++ b/EvoScientist/cli/tui_interactive.py
@@ -1805,12 +1805,8 @@ def run_textual_interactive(
                 return
 
             prompt = self.query_one("#prompt", ChatTextArea)
-            # Insert at cursor position
-            pos = prompt.cursor_position
-            current = prompt.value
-            new_value = current[:pos] + text + current[pos:]
-            prompt.value = new_value
-            prompt.cursor_position = pos + len(text)
+            prompt.insert(text)
+            prompt.focus()
 
         def action_tab_complete(self) -> None:
             """Handle TAB: cycle completions when visible, otherwise no-op.
@@ -1873,8 +1869,6 @@ def run_textual_interactive(
                 prompt.value = new_val
             else:
                 prompt.value = selected + " "
-
-            prompt.cursor_position = len(prompt.value)
 
         def _hide_completions(self) -> None:
             self._comp_items = []


### PR DESCRIPTION
## Description

Closes #91 

Changing to `.insert()` simplifies the code as it already handles the cursor position and fixes the bug.

```
bound method ChatTextArea.insert(
    text: str,
    location: tuple[int, int] | None = None,
    *,
    maintain_selection_offset: bool = True
) -> EditResult
Insert text into the document.
Args:
    text: The text to insert.
    location: The location to insert text, or None to use the cursor location.
    maintain_selection_offset: If True, the active Selection will be updated
        such that the same text is selected before and after the selection,
        if possible. Otherwise, the cursor will jump to the end point of the
        edit.
Returns:
    An EditResult containing information about the edit.
```

## Type of change

- [X] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified text insertion and cursor handling in the interactive CLI prompt for more reliable paste behavior.
  * Improved focus and selection behavior after inserting text or applying completions for a smoother typing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->