### PR TITLE
Fix/feishu ws cross thread loop

### DIFF
--- a/EvoScientist/channels/feishu/channel.py
+++ b/EvoScientist/channels/feishu/channel.py
@@ -384,24 +384,24 @@ class FeishuChannel(Channel, WebhookMixin, TokenMixin):
         )
 
         def _run_ws():
-            # Workaround: nest_asyncio (used by the main process) patches
-            # the event loop policy globally but does NOT patch Handle._run
-            # for context re-entry (versions < 1.7).  The SDK creates its
-            # own event loop in this thread; its transport callbacks hit
-            #   RuntimeError: cannot enter context: … is already entered
-            # Fix: patch Handle._run to retry with a context copy.
-            _orig_handle_run = asyncio.Handle._run
+            # Root cause: lark_oapi.ws.client stores the event loop in a
+            # *module-level* variable at import time.  When imported from
+            # the main thread this captures the main loop (which has
+            # nest_asyncio patches).  The SDK then calls
+            # loop.run_until_complete() from THIS thread on that *main*
+            # loop, causing cross-thread task-tracking conflicts:
+            #   RuntimeError: Leaving task … does not match the current task
+            #   AttributeError: 'NoneType' object has no attribute 'select'
+            #
+            # Fix: create a fresh event loop for this thread and replace
+            # the module-level ``loop`` variable so the SDK uses an
+            # isolated loop with no cross-thread interaction.
+            import lark_oapi.ws.client as _ws_mod
 
-            def _safe_handle_run(self):
-                try:
-                    self._context.run(self._callback, *self._args)
-                except RuntimeError as exc:
-                    if "cannot enter context" not in str(exc):
-                        raise
-                    ctx = self._context.copy()
-                    ctx.run(self._callback, *self._args)
+            fresh_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(fresh_loop)
+            _ws_mod.loop = fresh_loop
 
-            asyncio.Handle._run = _safe_handle_run
             try:
                 ws_client.start()
             except Exception:
@@ -410,8 +410,6 @@ class FeishuChannel(Channel, WebhookMixin, TokenMixin):
                     "The channel will no longer receive messages. "
                     "Check app_id/app_secret and connection limits."
                 )
-            finally:
-                asyncio.Handle._run = _orig_handle_run
 
         self._lark_ws_thread = threading.Thread(target=_run_ws, daemon=True)
         self._lark_ws_thread.start()


### PR DESCRIPTION
## Summary

- **Root cause**: `lark_oapi.ws.client` stores the event loop in a module-level variable at import time, capturing the main thread's loop. The SDK thread then calls `loop.run_until_complete()` on that shared main loop, causing cross-thread task-tracking conflicts with `nest_asyncio` on Linux/Python 3.12.
- **Fix**: Create a fresh `asyncio` event loop in the SDK thread and replace the module-level `loop` variable (`_ws_mod.loop = fresh_loop`), giving the SDK a fully isolated loop.
- **Removes** the previous `Handle._run` monkey-patch which only suppressed symptoms without addressing the root cause.

## Reproduce

<img width="847" height="641" alt="b492a91567e7644b1ffe62f15298a6ab" src="https://github.com/user-attachments/assets/23dce0be-12ee-4f79-9336-f662e772f935" />


## Test plan

- [x] Start `EvoSci serve` with Feishu WebSocket mode on **Linux** (Python 3.12) — verify no `RuntimeError` or `AttributeError`
- [x] Verify Feishu WebSocket message receiving still works end-to-end
- [x] Verify macOS remains unaffected (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved WebSocket handling in the Feishu channel: worker threads now run isolated event loops to manage WebSocket connections, replacing the previous workaround. This change increases connection reliability and reduces cross-thread interference, leading to more stable real-time messaging for the Feishu integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->