### PR TITLE
fix: ccproxy Windows compatibility — shebang detection and system message rejection

### DIFF
--- a/EvoScientist/ccproxy_manager.py
+++ b/EvoScientist/ccproxy_manager.py
@@ -305,9 +305,18 @@ def _patch_ccproxy_oauth_header() -> None:
         if not ccproxy_bin:
             return
 
-        # Find the Python interpreter used by the ccproxy binary via shebang
-        shebang = pathlib.Path(ccproxy_bin).read_text().splitlines()[0]
-        python_exe = shebang.lstrip("#!").strip()
+        # Find the Python interpreter used by the ccproxy binary via shebang.
+        # On Windows ccproxy is a compiled EXE with no shebang — fall back to
+        # sys.executable (both tools are typically in the same conda/venv env).
+        import sys as _sys
+
+        binary_data = pathlib.Path(ccproxy_bin).read_bytes()
+        if binary_data.startswith(b"#!"):
+            shebang = binary_data.split(b"\n", 1)[0].decode("utf-8", errors="replace")
+            python_exe = shebang.lstrip("#!").strip()
+        else:
+            # Binary executable (e.g. Windows .exe) — use current interpreter.
+            python_exe = _sys.executable
 
         # Ask that Python where ccproxy's adapter lives
         result = subprocess.run(

--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -102,6 +102,73 @@ def _flatten_message_content(content: Any) -> str | Any:
     return "\n\n".join(parts) if parts else ""
 
 
+def _patch_system_messages_for_proxy(model: Any) -> None:
+    """Convert system messages to human messages for proxies that reject system role.
+
+    Some OpenAI-compatible proxies (e.g. ccproxy's Codex endpoint) return HTTP
+    400 "System messages are not allowed" when the request includes a system-role
+    message.  This patch intercepts _generate / _agenerate and prepends system
+    message content to the first non-system message so the proxy never sees it.
+    """
+    import copy
+    import functools
+
+    from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+
+    def _convert(messages: list[BaseMessage]) -> list[BaseMessage]:
+        system_parts: list[str] = []
+        rest: list[BaseMessage] = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                text = (
+                    msg.content
+                    if isinstance(msg.content, str)
+                    else _flatten_message_content(msg.content)
+                )
+                if text:
+                    system_parts.append(text)
+            else:
+                rest.append(msg)
+        if not system_parts:
+            return messages
+        prefix = "\n\n".join(system_parts)
+        if rest:
+            first = copy.copy(rest[0])
+            existing = (
+                first.content
+                if isinstance(first.content, str)
+                else _flatten_message_content(first.content)
+            )
+            first.content = f"{prefix}\n\n{existing}" if existing else prefix
+            rest[0] = first
+        else:
+            rest = [HumanMessage(content=prefix)]
+        return rest
+
+    orig_generate = getattr(model, "_generate", None)
+    if orig_generate is None:
+        return
+
+    @functools.wraps(orig_generate)
+    def _patched_generate(
+        messages: list[BaseMessage], *args: Any, **kwargs: Any
+    ) -> Any:
+        return orig_generate(_convert(messages), *args, **kwargs)
+
+    model._generate = _patched_generate
+
+    orig_agenerate = getattr(model, "_agenerate", None)
+    if orig_agenerate is not None:
+
+        @functools.wraps(orig_agenerate)
+        async def _patched_agenerate(
+            messages: list[BaseMessage], *args: Any, **kwargs: Any
+        ) -> Any:
+            return await orig_agenerate(_convert(messages), *args, **kwargs)
+
+        model._agenerate = _patched_agenerate
+
+
 def _patch_openai_compat_content(model: Any) -> None:
     """Flatten list content to strings before OpenAI-compatible API calls.
 
@@ -514,6 +581,11 @@ def get_chat_model(
     # native OpenAI through a proxy, to avoid "sequence expected string" errors.
     if _is_third_party or _is_openai_proxy:
         _patch_openai_compat_content(chat_model)
+
+    # Convert system messages to human messages for proxies that reject system role
+    # (e.g. ccproxy's Codex endpoint returns 400 "System messages are not allowed").
+    if _is_openai_proxy:
+        _patch_system_messages_for_proxy(chat_model)
 
     return chat_model
 


### PR DESCRIPTION
## Summary

Fixes two issues when running EvoScientist with ccproxy OAuth mode on Windows:

- **`ccproxy_manager.py`**: `_patch_ccproxy_oauth_header()` used `read_text()` on the ccproxy binary to extract a Unix shebang line. On Windows the binary is a compiled `.exe` (byte `0x90` = x86 NOP), causing `UnicodeDecodeError`. Fix: read in binary mode, detect `#!` prefix; fall back to `sys.executable` for Windows EXEs.

- **`llm/models.py`**: `use_responses_api=True` is silently ignored by `langchain-openai <1.3`, so requests fall back to Chat Completions which includes `role: system` messages. ccproxy's Codex endpoint rejects these with HTTP 400 `"System messages are not allowed"`, cascading into `Connection error` on subsequent requests. Fix: add `_patch_system_messages_for_proxy()` that prepends system message content into the first user message before the request reaches the proxy.

## Errors fixed

```
⚠️  Warning: Could not auto-patch ccproxy adapter: 'utf-8' codec can't decode byte 0x90 in position 2
Error: Error code: 400 - {'detail': 'System messages are not allowed'}
Error: Connection error
```

## Test plan

- [x] Run EvoScientist with `openai_auth_mode: oauth` + ccproxy on Windows — verify no UTF-8 warning
- [x] Send multi-turn conversation with system prompt via ccproxy Codex endpoint — verify no 400 error
- [ ] Verify Linux/macOS shebang path still works (binary starts with `#!`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Python interpreter detection to properly handle both shebang-based and non-shebang binaries, with improved compatibility for Windows executable files.

* **New Features**
  * Added system message preprocessing for proxy-based chat models, consolidating multiple system messages into a unified prefix that integrates seamlessly with conversation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->