### PR TITLE
fix(skill-manager): update skill source filtering to include workspac…

### DIFF
--- a/EvoScientist/tools/skill_manager.py
+++ b/EvoScientist/tools/skill_manager.py
@@ -83,8 +83,8 @@ def skill_manager(
             if include_system:
                 return "No skills found."
             return "No user skills installed. Use action='install' to add skills, or set include_system=True to see built-in skills."
-        user_skills = [s for s in skills if s.source == "user"]
-        system_skills = [s for s in skills if s.source == "system"]
+        user_skills = [s for s in skills if s.source in ("workspace", "global")]
+        system_skills = [s for s in skills if s.source == "builtin"]
         lines = []
         if user_skills:
             lines.append(f"User Skills ({len(user_skills)}):")

--- a/tests/test_skills_manager.py
+++ b/tests/test_skills_manager.py
@@ -671,3 +671,125 @@ class TestFetchRemoteSkillIndex:
 
         assert call_count == 1  # Only cloned once
         assert index1 == index2
+
+
+# =============================================================================
+# Tests for skill_manager tool — action="list" filtering
+# =============================================================================
+
+
+class TestSkillManagerList:
+    """Tests for the skill_manager() tool's action='list' output.
+
+    These tests verify that the source-based filtering in skill_manager.py
+    correctly maps skills_manager.py's tier names ("workspace", "global",
+    "builtin") to the User Skills / System Skills display sections.
+    """
+
+    def _make_skill(self, tmp_path, name, description="A skill"):
+        skill_dir = tmp_path / name
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {description}\n---\n"
+        )
+        return skill_dir
+
+    def test_list_user_skills_workspace(self, tmp_path):
+        """Workspace-tier skills appear under 'User Skills'."""
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        self._make_skill(tmp_path, "ws-skill")
+        install_skill(str(tmp_path / "ws-skill"), str(workspace_dir))
+
+        with (
+            patch("EvoScientist.paths.USER_SKILLS_DIR", workspace_dir),
+            patch("EvoScientist.paths.GLOBAL_SKILLS_DIR", global_dir),
+        ):
+            result = skill_manager.invoke({"action": "list", "include_system": False})
+
+        assert "User Skills (1)" in result
+        assert "ws-skill" in result
+        assert "System Skills" not in result
+
+    def test_list_user_skills_global(self, tmp_path):
+        """Global-tier skills appear under 'User Skills'."""
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        self._make_skill(tmp_path, "global-skill")
+        install_skill(str(tmp_path / "global-skill"), str(global_dir))
+
+        with (
+            patch("EvoScientist.paths.USER_SKILLS_DIR", workspace_dir),
+            patch("EvoScientist.paths.GLOBAL_SKILLS_DIR", global_dir),
+        ):
+            result = skill_manager.invoke({"action": "list", "include_system": False})
+
+        assert "User Skills (1)" in result
+        assert "global-skill" in result
+
+    def test_list_include_system_shows_both_sections(self, tmp_path):
+        """include_system=True shows both User Skills and System Skills sections."""
+        from EvoScientist.tools.skill_manager import skill_manager
+        from EvoScientist.tools.skills_manager import SkillInfo
+
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        self._make_skill(tmp_path, "user-skill")
+        install_skill(str(tmp_path / "user-skill"), str(workspace_dir))
+
+        builtin_skill = SkillInfo(
+            name="builtin-skill",
+            description="A built-in skill",
+            path=tmp_path / "builtin-skill",
+            source="builtin",
+        )
+
+        with (
+            patch("EvoScientist.paths.USER_SKILLS_DIR", workspace_dir),
+            patch("EvoScientist.paths.GLOBAL_SKILLS_DIR", global_dir),
+            patch(
+                "EvoScientist.tools.skills_manager.list_skills",
+                return_value=[
+                    SkillInfo(
+                        name="user-skill",
+                        description="A user skill",
+                        path=workspace_dir / "user-skill",
+                        source="workspace",
+                    ),
+                    builtin_skill,
+                ],
+            ),
+        ):
+            result = skill_manager.invoke({"action": "list", "include_system": True})
+
+        assert "User Skills (1)" in result
+        assert "user-skill" in result
+        assert "System Skills (1)" in result
+        assert "builtin-skill" in result
+
+    def test_list_no_user_skills_returns_message(self, tmp_path):
+        """Empty workspace and global dirs return the 'no user skills' message."""
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+
+        with (
+            patch("EvoScientist.paths.USER_SKILLS_DIR", workspace_dir),
+            patch("EvoScientist.paths.GLOBAL_SKILLS_DIR", global_dir),
+        ):
+            result = skill_manager.invoke({"action": "list", "include_system": False})
+
+        assert "No user skills installed" in result


### PR DESCRIPTION
## Description

Fixes `skill_manager(action=list)` always returning an empty result.
                                        
The tool wrapper was filtering skills by `source == "user"` and `source == "system"`, but `list_skills()`
actually returns `source="workspace"`, `source="global"`, and `source="builtin"`. The mismatch caused both      
filter lists to always be empty, resulting in a blank string returned to the agent.
                                                                                                                
Root cause: commit 05d5aa9 upgraded skills from a 2-tier (user/system) to 3-tier (workspace/global/builtin)
architecture and updated `skills_manager.py`, but did not update the tool wrapper `skill_manager.py`.           
                                                          
## Type of change                                                                                               

- [x] Bug fix                                                                                                   
                                                          
## Checklist
                                                                                                                
- [x] I have read the Contributing Guidelines
- [x] This targets core functionality used by the majority of users                                             
- [x] I have added/updated tests where applicable         
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated skill categorization logic to correctly filter skills in the "User Skills" and "System Skills" sections when listing installed skills.

* **Tests**
  * Added comprehensive test coverage for skill listing functionality, including filtering and empty-state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->