### PR TITLE
feat: add support for gpt-5.5 model in the LLM configuration and tests

### DIFF
--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -70,6 +70,7 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("claude-haiku-4-5", "claude-haiku-4-5", "custom-anthropic"),
     # Custom OpenAI (third-party OpenAI-compatible endpoints, 3 defaults)
     # Listed BEFORE native openai so MODELS dict defaults to native provider
+    ("gpt-5.5", "gpt-5.5", "custom-openai"),
     ("gpt-5.4", "gpt-5.4", "custom-openai"),
     ("gpt-5.3-codex", "gpt-5.3-codex", "custom-openai"),
     ("gpt-5-mini", "gpt-5-mini", "custom-openai"),
@@ -81,6 +82,7 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("claude-sonnet-4-5", "claude-sonnet-4-5", "anthropic"),
     ("claude-haiku-4-5", "claude-haiku-4-5", "anthropic"),
     # OpenAI
+    ("gpt-5.5", "gpt-5.5", "openai"),
     ("gpt-5.4", "gpt-5.4", "openai"),
     ("gpt-5.4-mini", "gpt-5.4-mini", "openai"),
     ("gpt-5.4-nano", "gpt-5.4-nano", "openai"),
@@ -129,6 +131,7 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("claude-opus-4.7", "anthropic/claude-opus-4.7", "openrouter"),
     ("claude-opus-4.6", "anthropic/claude-opus-4.6", "openrouter"),
     ("claude-sonnet-4.6", "anthropic/claude-sonnet-4.6", "openrouter"),
+    ("gpt-5.5", "openai/gpt-5.5", "openrouter"),
     ("gpt-5.4", "openai/gpt-5.4", "openrouter"),
     ("gpt-5.3-codex", "openai/gpt-5.3-codex", "openrouter"),
     ("gemini-3.1-pro", "google/gemini-3.1-pro-preview", "openrouter"),
@@ -139,6 +142,8 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("mimo-v2-pro", "xiaomi/mimo-v2-pro", "openrouter"),
     ("grok-4.1-fast", "x-ai/grok-4.1-fast", "openrouter"),
     ("qwen3.5-122b", "qwen/qwen3.5-122b-a10b", "openrouter"),
+    ("deepseek-v4-pro", "deepseek/deepseek-v4-pro", "openrouter"),
+    ("deepseek-v4-flash", "deepseek/deepseek-v4-flash", "openrouter"),
     # Zhipu CodePlan (智谱代码计划 — coding-only endpoint)
     ("glm-5.1", "glm-5.1", "zhipu-code"),
     ("glm-5", "glm-5", "zhipu-code"),
@@ -165,6 +170,9 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("qwen-max", "qwen-max", "dashscope"),
     ("qwq-plus", "qwq-plus", "dashscope"),
     # DeepSeek
+    ("deepseek-v4-pro", "deepseek-v4-pro", "deepseek"),
+    ("deepseek-v4-flash", "deepseek-v4-flash", "deepseek"),
+    # Legacy aliases (deprecated 2026-07-24; route to v4-flash thinking/non-thinking)
     ("deepseek-r1", "deepseek-reasoner", "deepseek"),
     ("deepseek-v3", "deepseek-chat", "deepseek"),
     # Moonshot (OpenAI-compatible)
@@ -237,7 +245,11 @@ def _apply_auto_config(
             # ccproxy uses Chat Completions which doesn't support reasoning.
             pass
         else:
-            _eff = "xhigh" if ("5.4" in model_id or "codex" in model_id) else "high"
+            _eff = (
+                "xhigh"
+                if ("5.4" in model_id or "5.5" in model_id or "codex" in model_id)
+                else "high"
+            )
             kwargs["reasoning"] = {"effort": _eff, "summary": "auto"}
 
     # Google GenAI: surface thinking traces

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -895,6 +895,12 @@ class TestAutoConfig:
             "summary": "auto",
         }
 
+        get_chat_model("gpt-5.5", provider="openai")
+        assert mock_init.call_args[1]["reasoning"] == {
+            "effort": "xhigh",
+            "summary": "auto",
+        }
+
     @patch("EvoScientist.llm.models.init_chat_model")
     def test_openai_reasoning_high_fallback(self, mock_init, monkeypatch):
         """Other OpenAI models get high reasoning effort."""


### PR DESCRIPTION
## Description

Register new frontier models: OpenAI **gpt-5.5** (native OpenAI, custom-openai, OpenRouter) and DeepSeek **v4-pro / v4-flash** (native DeepSeek, OpenRouter). Extend the native-OpenAI `xhigh` reasoning-effort auto-config gate to include `gpt-5.5`, matching the existing behaviour for `gpt-5.4` / codex models (per OpenAI docs, gpt-5.5 supports `none/low/medium/high/xhigh`). Legacy `deepseek-r1` / `deepseek-v3` aliases retained (deprecated 2026-07-24 per [DeepSeek docs](https://api-docs.deepseek.com/zh-cn/)).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable (new `gpt-5.5` xhigh assertion in `tests/test_llm.py`)
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes (1669 passed, 10 skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended model catalog with GPT-5.5 support across OpenAI (custom and standard configurations) and OpenRouter platforms
  * Added DeepSeek v4 model family including v4-pro and v4-flash variants, accessible both as native deepseek provider options and through OpenRouter
  * Improved automatic reasoning effort handling for newly supported models to fully enable their advanced capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->