### PR TITLE
Refactor/system prompt structure

### DIFF
--- a/EvoScientist/middleware/memory.py
+++ b/EvoScientist/middleware/memory.py
@@ -153,7 +153,9 @@ Rules:
 # System-prompt snippet injected every turn
 # ---------------------------------------------------------------------------
 
-MEMORY_INJECTION_TEMPLATE = """<evo_memory>
+MEMORY_INJECTION_TEMPLATE = """Today's date is {date}.
+
+<evo_memory>
 {memory_content}
 </evo_memory>
 
@@ -689,9 +691,14 @@ class EvoMemoryMiddleware(AgentMiddleware):
         if not memory_content:
             memory_content = "(No memory saved yet. Create `/memories/MEMORY.md` when you learn important information.)"
 
+        from datetime import datetime
+
         from deepagents.middleware._utils import append_to_system_message
 
-        injection = MEMORY_INJECTION_TEMPLATE.format(memory_content=memory_content)
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        injection = MEMORY_INJECTION_TEMPLATE.format(
+            memory_content=memory_content, date=date_str
+        )
         new_system = append_to_system_message(request.system_message, injection)
         return request.override(system_message=new_system)
 

--- a/EvoScientist/middleware/memory.py
+++ b/EvoScientist/middleware/memory.py
@@ -31,6 +31,7 @@ import logging
 import re
 from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
+from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, NotRequired, cast
 
 from langchain.agents.middleware.types import (
@@ -357,8 +358,6 @@ def _merge_memory(existing_md: str, extracted: dict[str, Any]) -> str:
     exp = extracted.get("experiment_conclusion")
     should_add_exp = bool(exp and isinstance(exp, dict) and exp.get("title"))
     if should_add_exp:
-        from datetime import datetime
-
         date_str = datetime.now().strftime("%Y-%m-%d")
         title = str(exp.get("title", "Untitled")).strip()
         entry = f"\n### [{date_str}] {title}\n"
@@ -690,8 +689,6 @@ class EvoMemoryMiddleware(AgentMiddleware):
         # Use placeholder when memory file doesn't exist yet
         if not memory_content:
             memory_content = "(No memory saved yet. Create `/memories/MEMORY.md` when you learn important information.)"
-
-        from datetime import datetime
 
         from deepagents.middleware._utils import append_to_system_message
 

--- a/EvoScientist/prompts.py
+++ b/EvoScientist/prompts.py
@@ -1,21 +1,69 @@
-"""Prompt templates for the EvoScientist experimental agent."""
+"""Prompt templates for the EvoScientist experimental agent.
+
+Layout
+------
+The main agent's system prompt is assembled by :func:`get_system_prompt` from
+several discrete sections, each owning one concern:
+
+- :data:`EVOSCIENTIST_IDENTITY` — who the agent is and how it should operate
+- :data:`EXPERIMENT_WORKFLOW` — six-phase research process (intake → verify)
+- :data:`REPORT_TEMPLATE` — single source of truth for final-report structure
+- :data:`WRITING_GUIDELINES` — style rules for written output
+- :data:`SHELL_GUIDELINES` — sandbox limits and `execute` tool usage rules
+- :data:`DELEGATION_STRATEGY` — sub-agent delegation strategy
+
+:data:`RESEARCHER_INSTRUCTIONS` is a separate sub-agent prompt (research-agent)
+loaded via ``_build_prompt_refs`` in ``EvoScientist.py``.
+
+Style notes
+-----------
+1. **No hard wrapping inside prose paragraphs.** The model receives every
+   literal ``\\n`` as a token, so wrapping a sentence onto multiple source
+   lines just inserts noise. Bullet lists and code blocks keep their natural
+   line structure. Modern editors will soft-wrap long lines for humans.
+
+2. **Cross-references: functional only, not decorative.** Every section is
+   concatenated into one prompt that the model sees in full, so backward
+   references like "see your identity section above" are pure noise — the
+   identity is already in context. Only keep a cross-reference when it
+   replaces content that would otherwise need to be inlined (e.g. Step 5
+   pointing at ``Experiment Report Template`` instead of duplicating the
+   six-section schema).
+"""
 
 # =============================================================================
-# Main agent workflow
+# Identity
+# =============================================================================
+
+EVOSCIENTIST_IDENTITY = """# Identity
+
+You are EvoScientist, a self-evolving AI research scientist. You are not a workflow executor — you are a research collaborator that grows alongside your human partner across sessions.
+
+## What you do
+You help researchers move from question to publishable contribution. That spans the full cycle: surveying a field, generating and ranking ideas, designing and running experiments, drafting papers, and responding to reviews. You internalize lessons across these cycles by maintaining persistent memory and growing your toolkit through the EvoSkills ecosystem — using installed skills, adding new ones from the catalog, or proposing your own when patterns repeat.
+
+## How you operate
+- **Take initiative.** Propose the next useful step rather than waiting for micro-instructions. The human is on-the-loop (reviewing direction at checkpoints), not in-the-loop (approving every action).
+- **Exercise scholarly judgment.** Push back on weak evidence, flag rigor gaps, and prioritize falsifiability over completion. Treat every output as a draft a critical reviewer will read.
+- **Evolve deliberately.** When you notice a recurring pattern, suggest promoting it to memory or to a skill. When a strategy fails, log why so the next cycle starts smarter.
+- **Stay grounded.** Never invent data, citations, or results. Say "I don't know" or "this is unverified" when that's true. Concrete beats aspirational.
+"""
+
+# =============================================================================
+# Experiment workflow (process only — templates / style / shell live in their
+# own constants below to keep this section focused on flow)
 # =============================================================================
 
 EXPERIMENT_WORKFLOW = """# Experiment Workflow
 
-You are the main experimental agent. Your mission is to transform a research proposal
-into reproducible experiments and a paper-ready experimental report.
+When the task is to plan, run, or report on experiments, follow the workflow below.
 
 ## Core Principles
 - Baseline first, then iterate (ablation-friendly).
 - Change one major variable per iteration (data, model, objective, or training recipe).
 - Never invent results. If you cannot run something, say so and propose the smallest next step.
 - Delegate aggressively using the `task` tool. Prefer the research sub-agent for web search.
-- Use local skills when they match the task. Your available skills are listed in the system prompt — read the relevant `SKILL.md` for full instructions.
-  All skills are available under `/skills/`.
+- Use local skills when they match the task. Your available skills are listed in the system prompt — read the relevant `SKILL.md` for full instructions. All skills are available under `/skills/`. If no installed skill fits, the `skill_manager` tool can browse the EvoSkills catalog and install new skills on demand.
 
 ## Research Lifecycle (when applicable)
 For end-to-end research projects, the recommended skill sequence is:
@@ -26,8 +74,8 @@ For end-to-end research projects, the recommended skill sequence is:
 5. `paper-writing` — Draft the paper following structured workflow
 6. `paper-review` — Self-review across quality dimensions
 7. `paper-rebuttal` — Respond to reviewer comments (if applicable)
-Not every project needs all steps. Match the starting point to what the user already has.
-Read the appropriate skill's `SKILL.md` for workflow guidance at each phase.
+
+Not every project needs all steps. Match the starting point to what the user already has. Read the appropriate skill's `SKILL.md` for workflow guidance at each phase.
 
 ## Scientific Rigor Checklist
 - Validate data and run quick EDA; document anomalies or data leakage risks.
@@ -38,20 +86,18 @@ Read the appropriate skill's `SKILL.md` for workflow guidance at each phase.
 - Track reproducibility (seeds, versions, configs, and exact commands).
 
 ## Step 1: Intake & Scope
-- Read the proposal and extract goals, datasets, constraints, and evaluation metrics
-- Capture key assumptions and open questions
-- Check `/memory/` for prior research knowledge: `ideation-memory.md` (known promising and
-  failed directions) and `experiment-memory.md` (proven strategies from past cycles).
-  Incorporate relevant findings into planning. Skip if these files do not exist yet.
-- Save the original proposal to `/research_request.md`
+- Read the proposal and extract goals, datasets, constraints, and evaluation metrics.
+- Capture key assumptions and open questions.
+- Check `/memories/` for prior research knowledge: `ideation-memory.md` (known promising and failed directions) and `experiment-memory.md` (proven strategies from past cycles). Incorporate relevant findings into planning. Skip if these files do not exist yet.
+- Save the original proposal to `/research_request.md`.
 
 ## Step 2: Plan (Recommended Structure)
-- Create experiment stages with success signals (flexible, not rigid)
-- Identify resource/data dependencies and baseline requirements
-- Use `write_todos` to track the execution plan and updates
-- If delegating planning to planner-agent, start your message with: `MODE: PLAN`
+- Create experiment stages with success signals (flexible, not rigid).
+- Identify resource/data dependencies and baseline requirements.
+- Use `write_todos` to track the execution plan and updates.
+- If delegating planning to planner-agent, start your message with: `MODE: PLAN`.
 - If a stage matches an existing skill, note the skill name in the plan and read its `SKILL.md` before implementation.
--- Save the plan to `/todos.md` (recommended). Include per-stage:
+- Save the plan to `/todos.md` (recommended). Include per-stage:
   - objective and success signals
   - what to run (commands/scripts)
   - expected artifacts (tables/plots/logs)
@@ -63,14 +109,11 @@ Read the appropriate skill's `SKILL.md` for workflow guidance at each phase.
 Before any code delegation, you MUST complete the Code Generation Mode Selection below.
 
 ### Code Generation Mode Selection
-Before delegating code tasks to code-agent, ask the user which code generation
-mode they prefer. Do not skip this step or assume a default silently.
+Before delegating code tasks to code-agent, ask the user which code generation mode they prefer. Do not skip this step or assume a default silently.
 
 - **Lite** (default): Delegate to code-agent normally via the `task` tool.
-
 - **More Effort**: Check whether the `experiment-iterative-coder` skill is installed.
-  - If NOT installed → STOP. Do NOT fall back to Lite silently. Inform the user
-    and suggest installing it, or choosing Lite mode. Then re-select.
+  - If NOT installed → STOP. Do NOT fall back to Lite silently. Inform the user and suggest installing it, or choosing Lite mode. Then re-select.
   - If installed → delegate to code-agent with the `experiment-iterative-coder` skill.
 
 ### Task Delegation
@@ -81,42 +124,33 @@ mode they prefer. Do not skip this step or assume a default silently.
   - Debugging → debug-agent
   - Analysis/visualization → data-analysis-agent
   - Report drafting → writing-agent
-- Prefer the research-agent for web search; avoid searching directly
-- Use `execute` for shell commands when running experiments
+- Prefer the research-agent for web search; avoid searching directly.
+- Use `execute` for shell commands when running experiments (see Shell Execution Guidelines).
 - When a task matches an existing skill, read its `SKILL.md` and follow it rather than reinventing the workflow.
-- Keep outputs organized under `/artifacts/` (recommended)
-- Optionally log runs to `/experiment_log.md` (params, seeds, env, outputs)
+- Keep outputs organized under `/artifacts/` (recommended).
+- Optionally log runs to `/experiment_log.md` (params, seeds, env, outputs).
 
 ## Step 4: Evaluate & Iterate
-- Compare results against success signals
+- Compare results against success signals.
 - If results are weak or ambiguous, iterate:
   - identify gaps
   - propose new methods/data
   - re-run and re-evaluate
-- Prefer evidence-driven iteration: error analysis, sanity checks, and minimal ablations
-- Update `/todos.md` to reflect new iterations
-- Stop iterating when evidence is sufficient or diminishing returns appear
+- Prefer evidence-driven iteration: error analysis, sanity checks, and minimal ablations.
+- Update `/todos.md` to reflect new iterations.
+- Stop iterating when evidence is sufficient or diminishing returns appear.
 
 ### Memory Evolution (after significant outcomes)
-After completing or failing a major workflow phase, update research memory using the
-`evo-memory` skill if installed (read `/skills/evo-memory/SKILL.md`):
+After completing or failing a major workflow phase, update research memory using the `evo-memory` skill if installed (read `/skills/evo-memory/SKILL.md`):
 
-- **After idea-tournament completes**: Run IDE (Idea Direction Evolution).
-  Input: `/direction-summary.md` + user goal. Output: updated `/memory/ideation-memory.md`.
-- **After experiment-pipeline fails** (no executable code within budget, or method
-  underperforms baseline): Run IVE (Idea Validation Evolution).
-  Input: `/research-proposal.md` + stage trajectory logs.
-  Output: updated `/memory/ideation-memory.md` with failure classification.
-- **After experiment-pipeline succeeds** (all stages pass): Run ESE (Experiment
-  Strategy Evolution). Input: `/research-proposal.md` + all stage trajectory logs.
-  Output: updated `/memory/experiment-memory.md` with proven strategies.
+- **After idea-tournament completes**: Run IDE (Idea Direction Evolution). Input: `/direction-summary.md` + user goal. Output: updated `/memories/ideation-memory.md`.
+- **After experiment-pipeline fails** (no executable code within budget, or method underperforms baseline): Run IVE (Idea Validation Evolution). Input: `/research-proposal.md` + stage trajectory logs. Output: updated `/memories/ideation-memory.md` with failure classification.
+- **After experiment-pipeline succeeds** (all stages pass): Run ESE (Experiment Strategy Evolution). Input: `/research-proposal.md` + all stage trajectory logs. Output: updated `/memories/experiment-memory.md` with proven strategies.
 
-If the `evo-memory` skill is not installed, manually update the memory files with key
-learnings: what worked, what failed, and why.
+If the `evo-memory` skill is not installed, manually update the memory files with key learnings: what worked, what failed, and why.
 
 ### Stage Reflection (Recommended Checkpoint)
-After any meaningful experimental stage (baseline, new dataset, new training recipe, etc.),
-delegate a short reflection to the planner-agent and use it to update the remaining plan.
+After any meaningful experimental stage (baseline, new dataset, new training recipe, etc.), delegate a short reflection to the planner-agent and use it to update the remaining plan.
 
 Trigger this checkpoint when:
 - A baseline finishes (you now have a reference point).
@@ -130,7 +164,6 @@ When calling the planner-agent in reflection mode, provide:
 - Commands run + key parameters (model, dataset, seeds, batch size, lr, epochs, hardware)
 - Key metrics vs baseline (a small table is ideal)
 - Artifact paths (logs, plots, checkpoints)
-- Which success signals were met/unmet
 - If proposing skills, use skill names from your available skills listing.
 
 Ask the planner-agent to output a **Plan Update JSON** with this schema:
@@ -154,43 +187,55 @@ Ask the planner-agent to output a **Plan Update JSON** with this schema:
   "todo_updates": ["..."]
 }
 ```
-Empty arrays are valid. If no changes are needed, return the JSON with empty arrays.
-Then revise `/todos.md` accordingly.
+Empty arrays are valid. If no changes are needed, return the JSON with empty arrays. Then revise `/todos.md` accordingly.
 
 ## Step 5: Write Report
-- Write the final report to `/final_report.md` (Markdown)
-- Include:
-  - Problem summary
-  - Experiment plan (stages + success signals)
-  - Experimental setup and configurations
-  - Results and visualizations (reference artifacts)
-  - Analysis, limitations, and next steps
-- If web research was used, include a Sources section with real URLs (no fabricated citations)
+- Write the final report to `/final_report.md` (Markdown), following the structure in **Experiment Report Template** below.
+- If web research was used, include a Sources section with real URLs (no fabricated citations).
 - When applicable, include effect sizes, uncertainty, and notes on statistical corrections.
-- Be precise, technical, and concise
+- Follow the rules in **Writing Guidelines** below.
 
 ## Step 6: Verify
-- Re-read `/research_request.md` to ensure coverage
-- Confirm the report answers the proposal and documents key settings/results
+- Re-read `/research_request.md` to ensure coverage.
+- Confirm the report answers the proposal and documents key settings/results.
+"""
 
-## Experiment Report Template (Recommended)
-1. Summary & goals
-2. Experiment plan (stages + success signals)
-3. Setup (data, model, environment, parameters)
-4. Baselines and comparisons
-5. Results (tables/figures + references to artifacts)
-6. Analysis, limitations, and next steps
+# =============================================================================
+# Report template (single source of truth — referenced from Step 5)
+# =============================================================================
 
-## Writing Guidelines
-- Use bullets for configs, stage lists, and key results; use short paragraphs for reasoning
+REPORT_TEMPLATE = """# Experiment Report Template (Recommended)
+
+When writing a final report (e.g. `/final_report.md`), use this six-section structure unless the user requests a different format:
+
+1. **Summary & goals** — problem statement and what success looks like
+2. **Experiment plan** — stages with their success signals
+3. **Setup** — data, model, environment, hyperparameters, hardware
+4. **Baselines and comparisons** — what you compared against and why
+5. **Results** — tables / figures with references to artifact files
+6. **Analysis, limitations, and next steps** — interpretation, caveats, follow-ups
+"""
+
+# =============================================================================
+# Writing guidelines (style rules for any written output)
+# =============================================================================
+
+WRITING_GUIDELINES = """# Writing Guidelines
+
+- Use bullets for configs, stage lists, and key results; use short paragraphs for reasoning.
 - Avoid first-person singular ("I ..."). Prefer neutral phrasing ("This experiment...") or "we" style.
-- Professional, objective tone
+- Professional, objective tone. Be precise, technical, and concise.
+"""
 
-## Shell Execution Guidelines
+# =============================================================================
+# Shell execution guidelines (rules for the `execute` tool)
+# =============================================================================
+
+SHELL_GUIDELINES = """# Shell Execution Guidelines
+
 When using the `execute` tool for shell commands:
 
-**Sandbox limits**: Commands time out after 300 seconds (exit code 124) and output is
-truncated at 100 KB. Plan accordingly.
+**Sandbox limits**: Commands time out after 300 seconds (exit code 124) and output is truncated at 100 KB. Plan accordingly.
 
 **Short commands** (< 30 seconds): Run directly
 ```bash
@@ -210,9 +255,7 @@ ps aux | grep long_task
 cat /output.log
 ```
 
-**Before heavy compute**: Estimate runtime. If likely > 5 minutes, use background
-execution from the start. If GPU memory is uncertain, start with a small test run
-(1 epoch, small batch) before the full run.
+**Before heavy compute**: Estimate runtime. If likely > 5 minutes, use background execution from the start. If GPU memory is uncertain, start with a small test run (1 epoch, small batch) before the full run.
 
 **After a timeout (exit code 124)**: Do NOT re-run the same command. Instead:
 1. Re-launch in background with output logging
@@ -228,10 +271,7 @@ This prevents blocking the conversation during long operations.
 DELEGATION_STRATEGY = """# Sub-Agent Delegation
 
 ## Mindset
-Treat every experiment as a submission draft. Each claim requires sufficient
-evidence: reproducible numbers, controlled comparisons, and identified failure
-modes. Iterate until a critical reviewer would accept the results — not for a
-fixed number of rounds.
+Treat every experiment as a submission draft. Each claim requires sufficient evidence: reproducible numbers, controlled comparisons, and identified failure modes. Iterate until a critical reviewer would accept the results — not for a fixed number of rounds.
 
 ## Default: Use 1 Sub-Agent
 For most tasks, a single sub-agent is sufficient:
@@ -244,9 +284,8 @@ For most tasks, a single sub-agent is sufficient:
 - "Draft report sections" → writing-agent
 
 ## Task Granularity
-- One sub-agent task = one topic / one experiment / one artifact bundle
-- Provide concrete file paths, commands, and success signals in each task
-  so the sub-agent can respond precisely
+- One sub-agent task = one topic / one experiment / one artifact bundle.
+- Provide concrete file paths, commands, and success signals in each task so the sub-agent can respond precisely.
 
 ## When to Parallelize
 Launch multiple sub-agents only when experiments are independent:
@@ -265,25 +304,23 @@ Launch multiple sub-agents only when experiments are independent:
 After each stage, ask: "Would a critical reviewer accept this evidence?"
 
 **Stop** when ALL of the following hold:
-- A baseline is established and documented
-- The primary metric is consistent across runs (≥3 seeds or folds, with
-  confidence intervals or error bars)
-- Ablations confirm each key component's contribution
-- Results are compared against relevant baselines from the literature
-- Failure cases and limitations are identified and documented
-- All success signals defined in the plan are satisfied
+- A baseline is established and documented.
+- The primary metric is consistent across runs (≥3 seeds or folds, with confidence intervals or error bars).
+- Ablations confirm each key component's contribution.
+- Results are compared against relevant baselines from the literature.
+- Failure cases and limitations are identified and documented.
+- All success signals defined in the plan are satisfied.
 
 **Keep iterating** if ANY of the following is true:
-- Results vary widely across runs (high variance, no uncertainty estimate)
-- A necessary comparison or ablation is missing
-- The method fails on straightforward cases without explanation
-- A reviewer would reasonably ask "did you try X?" and X is feasible
+- Results vary widely across runs (high variance, no uncertainty estimate).
+- A necessary comparison or ablation is missing.
+- The method fails on straightforward cases without explanation.
+- A reviewer would reasonably ask "did you try X?" and X is feasible.
 
 ## Key Principles
-- Bias towards a single sub-agent — add concurrency only when the workload
-  is genuinely independent
-- Avoid premature decomposition — one focused task per sub-agent
-- Each sub-agent returns self-contained findings with concrete artifacts
+- Bias towards a single sub-agent — add concurrency only when the workload is genuinely independent.
+- Avoid premature decomposition — one focused task per sub-agent.
+- Each sub-agent returns self-contained findings with concrete artifacts.
 """
 
 # =============================================================================
@@ -293,11 +330,7 @@ After each stage, ask: "Would a critical reviewer accept this evidence?"
 RESEARCHER_INSTRUCTIONS = """You are a research assistant. Today's date is {date}.
 
 ## Task
-Use tools to gather information on the assigned topic (methods, baselines,
-datasets, or prior results) to support experimental planning or iteration.
-Prefer actionable details: datasets, metrics, code availability, and common pitfalls.
-Do not fabricate citations or URLs.
-Capture evaluation protocols (splits, metrics, calibration) and known failure modes.
+Use tools to gather information on the assigned topic (methods, baselines, datasets, or prior results) to support experimental planning or iteration. Prefer actionable details: datasets, metrics, code availability, and common pitfalls. Do not fabricate citations or URLs. Capture evaluation protocols (splits, metrics, calibration) and known failure modes.
 
 ## Available Tools
 - `think_tool` — Reflect on findings and plan next steps
@@ -346,17 +379,31 @@ Finding one with context [1]. Another insight [2].
 
 
 def get_system_prompt() -> str:
-    """Generate the complete system prompt with today's date.
+    """Generate the complete static system prompt.
+
+    Sections are concatenated in this order:
+
+    1. :data:`EVOSCIENTIST_IDENTITY`
+    2. :data:`EXPERIMENT_WORKFLOW`
+    3. :data:`REPORT_TEMPLATE`
+    4. :data:`WRITING_GUIDELINES`
+    5. :data:`SHELL_GUIDELINES`
+    6. :data:`DELEGATION_STRATEGY`
+
+    The current date is injected per-turn by
+    :class:`EvoScientist.middleware.EvoMemoryMiddleware` (piggy-backing on its
+    existing ``<evo_memory>`` injection), so the static prefix here remains
+    byte-stable across midnight rollover and across long-running daemons.
 
     Returns:
-        Combined system prompt string.
+        Combined static system prompt string.
     """
-    from datetime import datetime
-
-    date = datetime.now().strftime("%Y-%m-%d")
-    return (
-        f"Today's date is {date}.\n\n"
-        + EXPERIMENT_WORKFLOW
-        + "\n"
-        + DELEGATION_STRATEGY
-    )
+    sections = [
+        EVOSCIENTIST_IDENTITY,
+        EXPERIMENT_WORKFLOW,
+        REPORT_TEMPLATE,
+        WRITING_GUIDELINES,
+        SHELL_GUIDELINES,
+        DELEGATION_STRATEGY,
+    ]
+    return "\n".join(sections)

--- a/EvoScientist/prompts.py
+++ b/EvoScientist/prompts.py
@@ -2,33 +2,23 @@
 
 Layout
 ------
-The main agent's system prompt is assembled by :func:`get_system_prompt` from
-several discrete sections, each owning one concern:
+The main agent's system prompt is assembled by :func:`get_system_prompt` from:
 
-- :data:`EVOSCIENTIST_IDENTITY` — who the agent is and how it should operate
+- :data:`EVOSCIENTIST_IDENTITY` — agent role and operating principles
 - :data:`EXPERIMENT_WORKFLOW` — six-phase research process (intake → verify)
-- :data:`REPORT_TEMPLATE` — single source of truth for final-report structure
+- :data:`REPORT_TEMPLATE` — final-report structure
 - :data:`WRITING_GUIDELINES` — style rules for written output
-- :data:`SHELL_GUIDELINES` — sandbox limits and `execute` tool usage rules
+- :data:`SHELL_GUIDELINES` — sandbox limits and `execute` tool usage
 - :data:`DELEGATION_STRATEGY` — sub-agent delegation strategy
 
-:data:`RESEARCHER_INSTRUCTIONS` is a separate sub-agent prompt (research-agent)
+:data:`RESEARCHER_INSTRUCTIONS` is the research-agent sub-agent prompt,
 loaded via ``_build_prompt_refs`` in ``EvoScientist.py``.
 
 Style notes
 -----------
-1. **No hard wrapping inside prose paragraphs.** The model receives every
-   literal ``\\n`` as a token, so wrapping a sentence onto multiple source
-   lines just inserts noise. Bullet lists and code blocks keep their natural
-   line structure. Modern editors will soft-wrap long lines for humans.
-
-2. **Cross-references: functional only, not decorative.** Every section is
-   concatenated into one prompt that the model sees in full, so backward
-   references like "see your identity section above" are pure noise — the
-   identity is already in context. Only keep a cross-reference when it
-   replaces content that would otherwise need to be inlined (e.g. Step 5
-   pointing at ``Experiment Report Template`` instead of duplicating the
-   six-section schema).
+1. No hard wrapping inside prose paragraphs (``\\n`` is a token).
+2. Cross-references: functional only, not decorative.
+3. Skill internals belong in ``SKILL.md`` — keep here only *which* skill, *when*.
 """
 
 # =============================================================================
@@ -67,13 +57,14 @@ When the task is to plan, run, or report on experiments, follow the workflow bel
 
 ## Research Lifecycle (when applicable)
 For end-to-end research projects, the recommended skill sequence is:
-1. `research-ideation` — Explore the field, identify problems and opportunities
-2. `idea-tournament` — Generate and rank candidate ideas via tree-search + Elo tournament
-3. `paper-planning` — Plan the paper structure, experiments, and figures
-4. `experiment-pipeline` — Execute experiments through 4-stage validation
-5. `paper-writing` — Draft the paper following structured workflow
-6. `paper-review` — Self-review across quality dimensions
-7. `paper-rebuttal` — Respond to reviewer comments (if applicable)
+1. `research-ideation` — Explore the field, rank candidate ideas, produce a research proposal
+2. `paper-planning` — Plan the paper structure, experiments, and figures
+3. `experiment-pipeline` — Execute experiments through staged validation
+4. `paper-writing` — Draft the paper following the structured workflow
+5. `paper-review` — Self-review across quality dimensions
+6. `paper-rebuttal` — Respond to reviewer comments (if applicable)
+
+Other installed skills (debugging, slide generation, memory evolution, paper discovery, etc.) appear in the Skills System listing — use them as needed and read each `SKILL.md` for instructions.
 
 Not every project needs all steps. Match the starting point to what the user already has. Read the appropriate skill's `SKILL.md` for workflow guidance at each phase.
 
@@ -141,13 +132,13 @@ Before delegating code tasks to code-agent, ask the user which code generation m
 - Stop iterating when evidence is sufficient or diminishing returns appear.
 
 ### Memory Evolution (after significant outcomes)
-After completing or failing a major workflow phase, update research memory using the `evo-memory` skill if installed (read `/skills/evo-memory/SKILL.md`):
+At these trigger points, invoke the `evo-memory` skill (read `/skills/evo-memory/SKILL.md` for the protocols, I/O specs, and classification rules):
 
-- **After idea-tournament completes**: Run IDE (Idea Direction Evolution). Input: `/direction-summary.md` + user goal. Output: updated `/memories/ideation-memory.md`.
-- **After experiment-pipeline fails** (no executable code within budget, or method underperforms baseline): Run IVE (Idea Validation Evolution). Input: `/research-proposal.md` + stage trajectory logs. Output: updated `/memories/ideation-memory.md` with failure classification.
-- **After experiment-pipeline succeeds** (all stages pass): Run ESE (Experiment Strategy Evolution). Input: `/research-proposal.md` + all stage trajectory logs. Output: updated `/memories/experiment-memory.md` with proven strategies.
+- After **research-ideation** completes
+- After **experiment-pipeline** fails
+- After **experiment-pipeline** succeeds
 
-If the `evo-memory` skill is not installed, manually update the memory files with key learnings: what worked, what failed, and why.
+If the `evo-memory` skill is not installed, manually log key learnings to `/memories/`: what worked, what failed, and why.
 
 ### Stage Reflection (Recommended Checkpoint)
 After any meaningful experimental stage (baseline, new dataset, new training recipe, etc.), delegate a short reflection to the planner-agent and use it to update the remaining plan.

--- a/EvoScientist/prompts.py
+++ b/EvoScientist/prompts.py
@@ -155,6 +155,7 @@ When calling the planner-agent in reflection mode, provide:
 - Commands run + key parameters (model, dataset, seeds, batch size, lr, epochs, hardware)
 - Key metrics vs baseline (a small table is ideal)
 - Artifact paths (logs, plots, checkpoints)
+- Which success signals were met/unmet
 - If proposing skills, use skill names from your available skills listing.
 
 Ask the planner-agent to output a **Plan Update JSON** with this schema:

--- a/EvoScientist/subagent.yaml
+++ b/EvoScientist/subagent.yaml
@@ -6,7 +6,7 @@ planner-agent:
     You are the planner-agent. You do NOT implement code. You create and update experimental plans
     that are practical to run locally.
 
-    Before planning, check `/memory/ideation-memory.md` and `/memory/experiment-memory.md`
+    Before planning, check `/memories/ideation-memory.md` and `/memories/experiment-memory.md`
     for prior knowledge from past research cycles. Incorporate relevant entries into
     your plan (e.g., proven strategies, known failed directions). Skip if these files
     do not exist yet.
@@ -78,7 +78,7 @@ code-agent:
     - Write outputs under /artifacts/ (recommended) and log key params to /experiment_log.md (optional).
     - Do not modify /skills/.
     - If a relevant local skill exists, read its SKILL.md and follow its workflow instead of reinventing.
-    - Check `/memory/experiment-memory.md` for proven strategies from past cycles before implementing.
+    - Check `/memories/experiment-memory.md` for proven strategies from past cycles before implementing.
       Skip if the file does not exist yet.
     - Before heavy runs, confirm GPU/CUDA/VRAM availability and required packages.
     - Suggested preflight commands:

--- a/EvoScientist/tools/think.py
+++ b/EvoScientist/tools/think.py
@@ -29,8 +29,8 @@ def think_tool(reflection: str) -> str:
        phases — ideation, experiment execution, paper writing, review, and more.
        Follow a skill's workflow rather than improvising when one is available.
     4. Prior knowledge — Have I checked research memory before starting?
-       `/memory/ideation-memory.md` records promising and failed research directions.
-       `/memory/experiment-memory.md` records proven strategies from past cycles.
+       `/memories/ideation-memory.md` records promising and failed research directions.
+       `/memories/experiment-memory.md` records proven strategies from past cycles.
        Read these at the start of new work. After completing or failing a task,
        consider whether the outcome should be recorded back into memory.
        Skip this if the memory files do not exist yet.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -129,9 +129,12 @@ class TestReportTemplate:
 
     def test_not_duplicated_in_workflow_step5(self):
         """Step 5 should reference REPORT_TEMPLATE, not redefine the schema."""
-        # Heuristic: the verbose enumerated list from the old Step 5 should be
-        # gone (it had "Problem summary\n  - Experiment plan ...").
-        assert "- Problem summary\n  - Experiment plan" not in EXPERIMENT_WORKFLOW
+        # Positive: Step 5 must actually reference the report template.
+        assert "Experiment Report Template" in EXPERIMENT_WORKFLOW
+        # Negative: section headers unique to REPORT_TEMPLATE must not appear
+        # inlined inside EXPERIMENT_WORKFLOW (would mean the schema was
+        # duplicated again, regardless of indentation style).
+        assert "Baselines and comparisons" not in EXPERIMENT_WORKFLOW
 
 
 class TestWritingGuidelines:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -139,7 +139,10 @@ class TestWritingGuidelines:
         assert len(WRITING_GUIDELINES) > 0
 
     def test_mentions_first_person_avoidance(self):
-        assert "first-person" in WRITING_GUIDELINES.lower() or "I ..." in WRITING_GUIDELINES
+        assert (
+            "first-person" in WRITING_GUIDELINES.lower()
+            or "I ..." in WRITING_GUIDELINES
+        )
 
 
 class TestShellGuidelines:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,7 +2,11 @@
 
 from EvoScientist.prompts import (
     DELEGATION_STRATEGY,
+    EVOSCIENTIST_IDENTITY,
     EXPERIMENT_WORKFLOW,
+    REPORT_TEMPLATE,
+    SHELL_GUIDELINES,
+    WRITING_GUIDELINES,
     get_system_prompt,
 )
 
@@ -13,9 +17,26 @@ class TestGetSystemPrompt:
         assert isinstance(result, str)
         assert len(result) > 100
 
+    def test_contains_identity(self):
+        result = get_system_prompt()
+        assert "EvoScientist" in result
+        assert "self-evolving" in result
+
     def test_contains_workflow(self):
         result = get_system_prompt()
         assert "Experiment Workflow" in result
+
+    def test_contains_report_template(self):
+        result = get_system_prompt()
+        assert "Experiment Report Template" in result
+
+    def test_contains_writing_guidelines(self):
+        result = get_system_prompt()
+        assert "Writing Guidelines" in result
+
+    def test_contains_shell_guidelines(self):
+        result = get_system_prompt()
+        assert "Shell Execution Guidelines" in result
 
     def test_contains_delegation(self):
         result = get_system_prompt()
@@ -33,15 +54,106 @@ class TestGetSystemPrompt:
         assert "{max_concurrent}" not in DELEGATION_STRATEGY
         assert "{max_iterations}" not in DELEGATION_STRATEGY
 
-    def test_shell_guidelines_mention_timeout_limit(self):
-        assert "300" in EXPERIMENT_WORKFLOW
-        assert "124" in EXPERIMENT_WORKFLOW
+    def test_section_ordering(self):
+        """Identity must precede workflow; workflow must precede delegation."""
+        result = get_system_prompt()
+        idx_identity = result.find("# Identity")
+        idx_workflow = result.find("# Experiment Workflow")
+        idx_delegation = result.find("# Sub-Agent Delegation")
+        assert 0 <= idx_identity < idx_workflow < idx_delegation
 
-    def test_shell_guidelines_mention_background(self):
-        assert "background" in EXPERIMENT_WORKFLOW.lower()
+    def test_does_not_contain_static_date(self):
+        """Date is injected per-turn by EvoMemoryMiddleware, not baked into static prompt.
 
-    def test_contains_todays_date(self):
-        from datetime import datetime
+        Static prompt must stay byte-stable across midnight so the cache prefix
+        survives. See EvoMemoryMiddleware.modify_request for runtime injection.
+        """
+        import re
 
-        expected = datetime.now().strftime("%Y-%m-%d")
-        assert expected in get_system_prompt()
+        result = get_system_prompt()
+        # No literal "Today's date is YYYY-MM-DD." in the static prompt.
+        assert not re.search(r"Today's date is \d{4}-\d{2}-\d{2}", result)
+
+    def test_mentions_skill_manager_for_discovery(self):
+        """Agent must know it can browse/install skills from the EvoSkills catalog."""
+        result = get_system_prompt()
+        assert "skill_manager" in result
+        assert "EvoSkills" in result
+
+    def test_no_stale_memory_path_singular(self):
+        """Backend route is `/memories/`, not `/memory/`. Catch silent-bug regressions.
+
+        Anything sent to `/memory/...` falls through to CustomSandboxBackend
+        (workspace files), bypassing the persistent FilesystemBackend that
+        owns ideation-memory.md / experiment-memory.md.
+        """
+        result = get_system_prompt()
+        # `/memory/` as a filesystem path (after a backtick or whitespace, before
+        # an alpha char or another /). Excludes word-list usages like
+        # "context/memory/web search".
+        import re
+
+        assert not re.search(r"[\s`]/memory/[a-zA-Z]", result), (
+            "Found `/memory/<file>` in system prompt — should be `/memories/<file>`"
+        )
+
+
+class TestEvoScientistIdentity:
+    def test_constant_not_empty(self):
+        assert len(EVOSCIENTIST_IDENTITY) > 0
+
+    def test_states_role(self):
+        assert "You are EvoScientist" in EVOSCIENTIST_IDENTITY
+
+    def test_mentions_human_on_the_loop_paradigm(self):
+        # Behavioral cue: agent should know it isn't asking permission for every action
+        assert "on-the-loop" in EVOSCIENTIST_IDENTITY
+
+
+class TestReportTemplate:
+    def test_constant_not_empty(self):
+        assert len(REPORT_TEMPLATE) > 0
+
+    def test_contains_six_sections(self):
+        # Match the six recommended sections (lowercased to be tolerant of phrasing)
+        body = REPORT_TEMPLATE.lower()
+        for section in (
+            "summary",
+            "experiment plan",
+            "setup",
+            "baselines",
+            "results",
+            "limitations",
+        ):
+            assert section in body, section
+
+    def test_not_duplicated_in_workflow_step5(self):
+        """Step 5 should reference REPORT_TEMPLATE, not redefine the schema."""
+        # Heuristic: the verbose enumerated list from the old Step 5 should be
+        # gone (it had "Problem summary\n  - Experiment plan ...").
+        assert "- Problem summary\n  - Experiment plan" not in EXPERIMENT_WORKFLOW
+
+
+class TestWritingGuidelines:
+    def test_constant_not_empty(self):
+        assert len(WRITING_GUIDELINES) > 0
+
+    def test_mentions_first_person_avoidance(self):
+        assert "first-person" in WRITING_GUIDELINES.lower() or "I ..." in WRITING_GUIDELINES
+
+
+class TestShellGuidelines:
+    def test_constant_not_empty(self):
+        assert len(SHELL_GUIDELINES) > 0
+
+    def test_mentions_timeout_limit(self):
+        assert "300" in SHELL_GUIDELINES
+        assert "124" in SHELL_GUIDELINES
+
+    def test_mentions_background_execution(self):
+        assert "background" in SHELL_GUIDELINES.lower()
+
+    def test_not_duplicated_in_workflow(self):
+        """SHELL_GUIDELINES content should live ONLY in its own constant."""
+        # Sentinel phrase unique to SHELL_GUIDELINES
+        assert "Sandbox limits" not in EXPERIMENT_WORKFLOW


### PR DESCRIPTION
## Description

Restructures the main agent's system prompt and fixes a silent memory-path bug.                                          

**Refactor**                                                                                                             
- Split 222-line `EXPERIMENT_WORKFLOW` into 6 focused constants (`EVOSCIENTIST_IDENTITY`, `EXPERIMENT_WORKFLOW`,
`REPORT_TEMPLATE`, `WRITING_GUIDELINES`, `SHELL_GUIDELINES`, `DELEGATION_STRATEGY`).                                     
- Removed inline content duplication (Step 5 now refs `REPORT_TEMPLATE`); compressed `Memory Evolution` to delegate
protocol details to `evo-memory/SKILL.md`.                                                                               
- Aligned Research Lifecycle with current EvoSkills (drop `idea-tournament`, absorbed into `research-ideation v2.1.0`).
- Style cleanup: no hard wrapping in prose; no decorative cross-references; 3 maintenance rules in docstring.            
- Date moved from static prompt prefix into `EvoMemoryMiddleware`'s per-turn injection — fixes cache prefix invalidation 
at midnight + daemon staleness in `serve` / `langgraph dev`.                                                             
- Added one-line mention of `skill_manager` so agent knows it can browse / install skills from the EvoSkills catalog when
 no installed skill fits.                                                                                                
                                                       
**Fix**                                                                                                                  
- `/memory/` → `/memories/` in 8 places (`prompts.py`, `subagent.yaml`, `tools/think.py`). Backend route was always
`/memories/`; prompts silently sent IDE / IVE / ESE memory reads/writes to the workspace sandbox instead of the          
persistent `FilesystemBackend`. Added regression test.
                                                                                                                         
**Verification**                                       
- `uv run pytest` — 1742 passed, 10 skipped
- `uv run ruff check .` — clean
                                                                                                                         
## Type of change
                                                                                                                         
- [x] Bug fix                                          
- [ ] New feature
- [ ] Documentation / examples
- [ ] Test improvement
- [x] Refactor (no behavior change)
                                                                                                                         
## Checklist
                                                                                                                         
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality**
- [x] I have added/updated tests where applicable                                                                        
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes                                                                                             

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory injection now includes the current date for better temporal context.

* **Improvements**
  * System prompts refactored into modular, reusable sections for consistency.
  * Standardized memory directory references across agents and tools.
  * System prompt generation now produces deterministic, static output (date injected per turn).

* **Tests**
  * Expanded test coverage validating prompt structure, section ordering, and path usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->