### PR TITLE
fix(deepseek): add empty-string fallback for reasoning_content in cro…

### DIFF
--- a/EvoScientist/llm/patches.py
+++ b/EvoScientist/llm/patches.py
@@ -481,8 +481,18 @@ def _patch_deepseek_reasoning_passback(model: Any) -> None:
     message to carry its reasoning_content as a top-level field (sibling to
     content / tool_calls).  Without this, multi-turn requests fail with 400.
 
-    For deepseek-reasoner models, also injects an empty reasoning_content
-    when none is present (DeepSeek API requires the field even if empty).
+    For assistant messages where no reasoning_content was captured (e.g.
+    history left over from another provider, from DeepSeek Flash, or from an
+    older EvoSci version that ran before the capture patch landed), we
+    inject an empty string.  This satisfies DeepSeek's format requirement
+    in thinking mode.  Non-thinking DeepSeek endpoints are believed to
+    accept the extra field without complaint based on observed behavior,
+    but this has not been independently audited; if a future DeepSeek
+    release rejects empty reasoning_content on non-thinking models, this
+    fallback would need a per-call thinking-mode check instead of a blanket
+    inject.  The check is intentionally not gated on model name: this
+    function is only mounted when provider == "deepseek" (see
+    EvoScientist/llm/models.py), so all callers are DeepSeek endpoints.
 
     Args:
         model: A langchain-openai ChatOpenAI instance configured for DeepSeek.
@@ -523,7 +533,6 @@ def _patch_deepseek_reasoning_passback(model: Any) -> None:
         if not isinstance(msgs, list):
             return payload
 
-        is_reasoner = "deepseek-reasoner" in str(getattr(model, "model_name", ""))
         ai_idx = 0
         for msg in msgs:
             if not isinstance(msg, dict) or msg.get("role") != "assistant":
@@ -531,7 +540,13 @@ def _patch_deepseek_reasoning_passback(model: Any) -> None:
             rc = ai_rcs[ai_idx] if ai_idx < len(ai_rcs) else None
             if rc:
                 msg["reasoning_content"] = rc
-            elif is_reasoner and "reasoning_content" not in msg:
+            elif "reasoning_content" not in msg:
+                # Empty-string fallback for ALL DeepSeek models (not just
+                # reasoner). Required when history contains AI messages that
+                # came from a different provider (Anthropic / OpenAI /
+                # DeepSeek Flash) or from an older EvoSci that didn't capture
+                # reasoning_content. Empirically tolerated by non-thinking
+                # DeepSeek endpoints; see docstring for the audit caveat.
                 msg["reasoning_content"] = ""
             ai_idx += 1
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -879,7 +879,7 @@ class TestPatchDeepseekReasoningPassback:
 
         assert payload["messages"][1]["reasoning_content"] == ""
 
-    def test_no_injection_for_non_reasoner_without_rc(self):
+    def test_empty_fallback_for_non_reasoner_without_rc(self):
         from langchain_core.messages import AIMessage, HumanMessage
 
         from EvoScientist.llm.patches import _patch_deepseek_reasoning_passback
@@ -894,7 +894,9 @@ class TestPatchDeepseekReasoningPassback:
         ]
         payload = model._get_request_payload(messages)
 
-        assert "reasoning_content" not in payload["messages"][1]
+        # Empty-string fallback applies to ALL DeepSeek models (not just
+        # reasoner) so cross-provider history doesn't trigger 400.
+        assert payload["messages"][1]["reasoning_content"] == ""
 
     def test_handles_multiple_ai_messages(self):
         from langchain_core.messages import AIMessage, HumanMessage
@@ -986,7 +988,7 @@ class TestPatchDeepseekReasoningPassback:
         from EvoScientist.llm.patches import _patch_deepseek_reasoning_passback
 
         model = self._make_model(
-            model_name="deepseek-v4-pro",  # NOT reasoner — empty fallback off
+            model_name="deepseek-v4-pro",
             payload_messages=[
                 {"role": "user", "content": "q1"},
                 {"role": "assistant", "content": "a1"},  # no rc
@@ -1009,8 +1011,8 @@ class TestPatchDeepseekReasoningPassback:
         ]
         payload = model._get_request_payload(messages)
 
-        # First AI msg: no rc → not injected (V4 Pro doesn't get empty fallback)
-        assert "reasoning_content" not in payload["messages"][1]
+        # First AI msg: no rc → empty-string fallback (covers cross-model switch)
+        assert payload["messages"][1]["reasoning_content"] == ""
         # Second AI msg: has rc → injected
         assert payload["messages"][3]["reasoning_content"] == "rc2"
 
@@ -1044,6 +1046,37 @@ class TestPatchDeepseekReasoningPassback:
         payload = model._get_request_payload([HumanMessage("hi")])
         assert "input" in payload
         assert "messages" not in payload
+
+    def test_cross_provider_switch_history(self):
+        """User chats with Anthropic/OpenAI then switches to DeepSeek V4 Pro.
+
+        Historical AI messages have no reasoning_content (the previous
+        provider never produced it). The patch must inject an empty-string
+        fallback so DeepSeek doesn't 400 on
+        "reasoning_content must be passed back to the API".
+        """
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        from EvoScientist.llm.patches import _patch_deepseek_reasoning_passback
+
+        model = self._make_model(
+            model_name="deepseek-v4-pro",
+            payload_messages=[
+                {"role": "user", "content": "earlier question to anthropic"},
+                {"role": "assistant", "content": "anthropic answer"},
+                {"role": "user", "content": "now ask deepseek pro"},
+            ],
+        )
+        _patch_deepseek_reasoning_passback(model)
+
+        messages = [
+            HumanMessage("earlier question to anthropic"),
+            AIMessage(content="anthropic answer"),  # no reasoning_content
+            HumanMessage("now ask deepseek pro"),
+        ]
+        payload = model._get_request_payload(messages)
+
+        assert payload["messages"][1]["reasoning_content"] == ""
 
 
 # =============================================================================


### PR DESCRIPTION
## Description

Fixes a 400 error from DeepSeek V4 Pro thinking mode (`deepseek-chat`) when the conversation history contains assistant messages from another provider, from DeepSeek Flash, or from a session that predates the `reasoning_content` capture patch.

**Trigger scenarios** (any one is enough to break):
- User chats with Anthropic / OpenAI for a few turns, then switches to DeepSeek V4 Pro
- `/resume` of a thread previously driven by a non-thinking model
- Resuming a thread created on an older EvoSci version (before the capture patch landed)

**Error before this fix**:
```
HTTP 400: The reasoning_content in the thinking mode must be passed back to the API.
```

### Root cause

`_patch_deepseek_reasoning_passback` in `EvoScientist/llm/patches.py` only injected an empty-string fallback for `deepseek-reasoner` model names. For `deepseek-chat` (V4 Pro) in thinking mode, when an assistant message had no captured `reasoning_content` in `additional_kwargs`, the patch left the field absent — and DeepSeek's server requires the field to exist on every assistant message.

### Fix

Drop the `is_reasoner` gate. Empty-string fallback now applies to every assistant message that lacks `reasoning_content`, regardless of which DeepSeek model is making the call. This is safe because the patch is mounted **only** when `provider == "deepseek"` (`models.py:464-465`), so all callers are guaranteed DeepSeek endpoints.

**Behavior summary**:
| Scenario | Before | After |
|----------|--------|-------|
| Pure DeepSeek Pro session | ✅ works (every msg has captured rc) | ✅ unchanged — empty fallback never fires |
| Switch from Anthropic/OpenAI/Flash → Pro | ❌ 400 | ✅ works (empty rc injected for legacy msgs) |
| `/resume` thread from another model | ❌ 400 | ✅ works |
| Non-thinking DeepSeek (Flash, plain chat) | ✅ works | ✅ unchanged (server ignores extra field) |
| Anthropic / OpenAI / other providers | n/a | n/a (patch not mounted) |

### Files changed

- `EvoScientist/llm/patches.py` — drop `is_reasoner` gate; expand docstring + inline comment to document the rationale and the audit caveat for non-thinking DeepSeek tolerance
- `tests/test_llm.py` — rename `test_no_injection_for_non_reasoner_without_rc` → `test_empty_fallback_for_non_reasoner_without_rc` (assertion flipped); update `test_mixed_ai_messages_with_and_without_rc`; add `test_cross_provider_switch_history` covering the real-world trigger scenario

## Type of change

- [x] Bug fix
- [ ] New feature — link issue: #<!-- issue number -->
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes (1772 passed, 5 skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * DeepSeek assistant messages now consistently include the required reasoning_content field across all model variants and conversation history scenarios. The model-specific variant filtering mechanism has been removed to ensure universal coverage. Test suite enhanced to verify this behavior across all endpoint configurations, historical message patterns, and cross-provider switching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->