### PR TITLE
fix/cli hitl

### DIFF
--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -23,7 +23,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware import AgentMiddleware, HumanInTheLoopMiddleware
 
 from . import paths as _paths_mod
 from .config import apply_config_to_env, get_effective_config
@@ -503,16 +503,16 @@ def create_cli_agent(
 
         mw.insert(0, AskUserMiddleware())
 
+    # HITL on main agent only — passing `interrupt_on=` to create_deep_agent
+    # would propagate it to every subagent, breaking parallel execute calls
+    # (multi-pending-interrupt LangGraph error).
+    if not cfg.auto_approve:
+        mw.append(HumanInTheLoopMiddleware(interrupt_on={"execute": True}))
+
     # Re-load MCP tools from current config (picks up /mcp add changes)
     kwargs = load_mcp_and_build_kwargs(be, mw, on_mcp_progress=on_mcp_progress)
-
-    # HITL: gate shell execution for user approval
-    _interrupt_on: dict[str, bool] | None = None
-    if not cfg.auto_approve:
-        _interrupt_on = {"execute": True}
 
     return create_deep_agent(
         **kwargs,
         checkpointer=checkpointer,
-        interrupt_on=_interrupt_on,
     ).with_config({"recursion_limit": 1000})

--- a/EvoScientist/stream/display.py
+++ b/EvoScientist/stream/display.py
@@ -977,8 +977,17 @@ def _prompt_hitl_approval(action_requests: list) -> list[dict] | None:
     """Display approval prompt and get user decision.
 
     Returns list of decisions if approved, None if rejected.
+
+    Uses ``questionary.select()`` for arrow-key navigation, matching the
+    style used by ``_resolve_ask_user_prompt``. Imports are lazy so the
+    auto-approve / shell-allow-list fast paths in ``_resolve_hitl_approval``
+    don't pay for them.
     """
     global _session_auto_approve
+
+    import questionary  # type: ignore[import-untyped]
+
+    from ..cli.widgets.thread_selector import PICKER_STYLE as _PICKER_STYLE
 
     console.print()
     panel_text = Text()
@@ -993,10 +1002,6 @@ def _prompt_hitl_approval(action_requests: list) -> list[dict] | None:
         if panel_text.plain:
             panel_text.append("\n")
         panel_text.append(f"  {i + 1}. {desc}", style="yellow")
-    panel_text.append("\n\n")
-    panel_text.append(
-        "  [1] Approve  [2] Reject  [3] Approve all (session)", style="dim"
-    )
 
     console.print(
         Panel(
@@ -1007,20 +1012,36 @@ def _prompt_hitl_approval(action_requests: list) -> list[dict] | None:
         )
     )
 
+    n = len(action_requests)
+    if n <= 1:
+        approve_label = "Approve"
+        reject_label = "Reject"
+    else:
+        approve_label = f"Approve all {n}"
+        reject_label = f"Reject all {n}"
+    auto_label = "Approve all (session)"
+
     try:
-        choice = input("  Choose [1/2/3, Enter=Approve]: ").strip() or "1"
+        selected = questionary.select(
+            "Approval required",
+            choices=[approve_label, reject_label, auto_label],
+            style=_PICKER_STYLE,
+        ).ask()
     except (EOFError, KeyboardInterrupt):
         console.print("[dim]  Rejected.[/dim]")
         return None
 
-    if choice == "1":
-        return [{"type": "approve"} for _ in action_requests]
-    elif choice == "3":
-        _session_auto_approve = True
-        return [{"type": "approve"} for _ in action_requests]
-    else:
+    if selected is None:  # Ctrl+C inside questionary
         console.print("[dim]  Rejected.[/dim]")
         return None
+
+    if selected == approve_label:
+        return [{"type": "approve"} for _ in action_requests]
+    if selected == auto_label:
+        _session_auto_approve = True
+        return [{"type": "approve"} for _ in action_requests]
+    console.print("[dim]  Rejected.[/dim]")
+    return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Two related CLI HITL fixes.

### 1. Subagent no longer inherits HITL from main agent (the real fix)

**Bug**: when the agent dispatches 2+ parallel subagents (via `task`) that each call `execute`, LangGraph raises:

> When there are multiple pending interrupts, you must specify the interrupt id when resuming.

**Root cause**: DeepAgents 0.5.5 (`graph.py:540, 557-558, 613-614`) propagates the top-level `interrupt_on={"execute": True}` we pass to `create_deep_agent(...)` into every declarative subagent **and** the auto-injected `general-purpose` subagent. Parallel subagents then produce multiple pending interrupts in the same checkpoint, which a single resume decision cannot disambiguate.

**Fix** (`EvoScientist/EvoScientist.py:create_cli_agent`): stop passing `interrupt_on=` to `create_deep_agent`. Append the middleware directly to the main agent's stack instead:

```python
if not cfg.auto_approve:
    mw.append(HumanInTheLoopMiddleware(interrupt_on={"execute": True}))
```

With top-level `interrupt_on=None`, `graph.py:540` and `graph.py:613-614` both short-circuit, so subagents skip HITL entirely. Main agent still gets the same gate via the manually-appended middleware (deepagents itself does this at `graph.py:671-672`).

Subagent shell commands remain protected by `CustomSandboxBackend` static checks (blocks `sudo` / `chmod` / `dd` / path traversal, 300s timeout, 100KB cap). Semantic model: user authorizes the high-level `task` goal → subagents run detailed commands freely under sandbox guards.

Runtime verified: `agent.nodes` contains exactly 1 `HumanInTheLoopMiddleware.after_model` hook, on the main agent only.

### 2. Rich CLI approve prompt uses `questionary` (UX parity with `ask_user`)

`_prompt_hitl_approval` in `stream/display.py` previously used raw `input("Choose [1/2/3, Enter=Approve]: ")` — no arrow-key nav, no highlighted cursor, broken backspace on macOS + CJK IME. The `ask_user` flow had the same problem and was migrated to `questionary` earlier; this brings approve in line.

Replaced the `input()` call with `questionary.select(...)` using the shared `PICKER_STYLE`. Function signature, return contract, and the `_session_auto_approve` global side-effect are preserved. Choice labels adapt to count (`n=1` → `Approve / Reject / Approve all (session)`; `n>1` → `Approve all N / Reject all N / ...`). Ctrl+C and `questionary` returning `None` both fall through to the existing reject path.

Textual TUI `ApprovalWidget` was already arrow-key-driven, untouched.

## Type of change

- [x] Bug fix
- [ ] New feature — link issue: #
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable — existing function-level mock in `tests/test_hitl.py` (`patch("EvoScientist.stream.display._prompt_hitl_approval")`) preserves the questionary refactor; subagent HITL inheritance is a wiring change (no test added — caught at runtime against the multi-interrupt repro)
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes — 1808 passed, 5 skipped (Python 3.11)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved human-in-the-loop approval interface with interactive selection and dynamic action labels showing task counts.

* **Bug Fixes**
  * Enhanced keyboard interrupt handling during approval workflows for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->