### PR TITLE
feat(llm): add dashscope-code provider for Alibaba Coding Plan keys

### DIFF
--- a/EvoScientist/config/onboard.py
+++ b/EvoScientist/config/onboard.py
@@ -496,6 +496,44 @@ def validate_dashscope_key(api_key: str) -> tuple[bool, str]:
         return False, f"Error: {e}"
 
 
+def validate_dashscope_code_key(api_key: str) -> tuple[bool, str]:
+    """Validate a DashScope Coding Plan API key (sk-sp-* subscription keys).
+
+    The coding endpoint at coding.dashscope.aliyuncs.com does not expose
+    /models (returns 404), so validation issues a minimal chat completion
+    instead of the usual models.list() probe.
+
+    Returns:
+        Tuple of (is_valid, message).
+    """
+    if not api_key:
+        return True, "Skipped (no key provided)"
+
+    try:
+        import openai
+
+        client = openai.OpenAI(
+            api_key=api_key,
+            base_url="https://coding.dashscope.aliyuncs.com/v1",
+        )
+        client.chat.completions.create(
+            model="qwen3-coder-plus",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1,
+        )
+        return True, "Valid"
+    except Exception as e:
+        error_str = str(e).lower()
+        if (
+            "401" in error_str
+            or "unauthorized" in error_str
+            or "invalid_api_key" in error_str
+            or "authentication" in error_str
+        ):
+            return False, "Invalid API key"
+        return False, f"Error: {e}"
+
+
 def validate_moonshot_key(api_key: str) -> tuple[bool, str]:
     """Validate a Moonshot API key by making a test request.
 
@@ -777,6 +815,10 @@ def _step_provider(config: EvoScientistConfig) -> str:
             value="dashscope",
         ),
         Choice(
+            title="DashScope Coding Plan (阿里云代码计划 — Qwen models)",
+            value="dashscope-code",
+        ),
+        Choice(
             title="DeepSeek (DeepSeek-R1, DeepSeek-V3)",
             value="deepseek",
         ),
@@ -937,6 +979,11 @@ def _provider_key_info(config: EvoScientistConfig, provider: str):
             "DashScope",
             config.dashscope_api_key or os.environ.get("DASHSCOPE_API_KEY", ""),
             validate_dashscope_key,
+        ),
+        "dashscope-code": (
+            "DashScope Coding Plan",
+            config.dashscope_api_key or os.environ.get("DASHSCOPE_API_KEY", ""),
+            validate_dashscope_code_key,
         ),
         "moonshot": (
             "Moonshot",
@@ -3258,6 +3305,7 @@ def run_onboard(skip_validation: bool = False) -> bool:
             "zhipu-code": "zhipu_api_key",
             "volcengine": "volcengine_api_key",
             "dashscope": "dashscope_api_key",
+            "dashscope-code": "dashscope_api_key",
             "moonshot": "moonshot_api_key",
             "kimi-coding": "kimi_api_key",
             "custom-openai": "custom_openai_api_key",

--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -3,8 +3,8 @@
 This module provides a unified interface for creating chat model instances
 with support for multiple providers (Anthropic, OpenAI, Google GenAI, MiniMax
 (Anthropic-compatible), NVIDIA, SiliconFlow, OpenRouter, ZhipuAI, Volcengine,
-DashScope, DeepSeek, Ollama, and custom OpenAI/Anthropic-compatible endpoints) and
-convenient short names for common models.
+DashScope, DashScope-Code, DeepSeek, Ollama, and custom OpenAI/Anthropic-compatible
+endpoints) and convenient short names for common models.
 """
 
 from __future__ import annotations
@@ -29,6 +29,7 @@ _ZHIPU_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
 _ZHIPU_CODE_BASE_URL = "https://open.bigmodel.cn/api/coding/paas/v4"
 _VOLCENGINE_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3"
 _DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+_DASHSCOPE_CODE_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 
 _DEEPSEEK_BASE_URL = "https://api.deepseek.com"
 _MOONSHOT_BASE_URL = "https://api.moonshot.cn/v1"
@@ -44,6 +45,7 @@ _OPENAI_ROUTED_PROVIDERS: dict[str, tuple[str | None, str]] = {
     "zhipu-code": (_ZHIPU_CODE_BASE_URL, "ZHIPU_API_KEY"),
     "volcengine": (_VOLCENGINE_BASE_URL, "VOLCENGINE_API_KEY"),
     "dashscope": (_DASHSCOPE_BASE_URL, "DASHSCOPE_API_KEY"),
+    "dashscope-code": (_DASHSCOPE_CODE_BASE_URL, "DASHSCOPE_API_KEY"),
     "custom-openai": (
         None,
         "CUSTOM_OPENAI_API_KEY",
@@ -174,6 +176,10 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("qwen3-235b", "qwen3-235b-a22b", "dashscope"),
     ("qwen-max", "qwen-max", "dashscope"),
     ("qwq-plus", "qwq-plus", "dashscope"),
+    ("qwen3-coder", "qwen3-coder-plus", "dashscope-code"),
+    ("qwen3-coder-next", "qwen3-coder-next", "dashscope-code"),
+    ("qwen3-max", "qwen3-max", "dashscope-code"),
+    ("qwen3.5-plus", "qwen3.5-plus", "dashscope-code"),
     # DeepSeek
     ("deepseek-v4-pro", "deepseek-v4-pro", "deepseek"),
     ("deepseek-v4-flash", "deepseek-v4-flash", "deepseek"),

--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -171,15 +171,16 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("doubao-seed-1.6", "doubao-seed-1.6", "volcengine"),
     ("doubao-1.5-pro", "doubao-1.5-pro-256k", "volcengine"),
     ("doubao-1.5-thinking-pro", "doubao-1.5-thinking-pro", "volcengine"),
-    # DashScope (阿里云 — Qwen models)
-    ("qwen3-coder", "qwen3-coder-plus", "dashscope"),
-    ("qwen3-235b", "qwen3-235b-a22b", "dashscope"),
-    ("qwen-max", "qwen-max", "dashscope"),
-    ("qwq-plus", "qwq-plus", "dashscope"),
+    # DashScope Coding Plan (阿里云代码计划 — subscription sk-sp-* endpoint)
     ("qwen3-coder", "qwen3-coder-plus", "dashscope-code"),
     ("qwen3-coder-next", "qwen3-coder-next", "dashscope-code"),
     ("qwen3-max", "qwen3-max", "dashscope-code"),
     ("qwen3.5-plus", "qwen3.5-plus", "dashscope-code"),
+    # DashScope (阿里云 — Qwen models, default for simple lookups)
+    ("qwen3-coder", "qwen3-coder-plus", "dashscope"),
+    ("qwen3-235b", "qwen3-235b-a22b", "dashscope"),
+    ("qwen-max", "qwen-max", "dashscope"),
+    ("qwq-plus", "qwq-plus", "dashscope"),
     # DeepSeek
     ("deepseek-v4-pro", "deepseek-v4-pro", "deepseek"),
     ("deepseek-v4-flash", "deepseek-v4-flash", "deepseek"),

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -42,6 +42,7 @@ class TestModelsRegistry:
         assert "zhipu-code" in providers
         assert "volcengine" in providers
         assert "dashscope" in providers
+        assert "dashscope-code" in providers
         assert "deepseek" in providers
         assert "moonshot" in providers
         assert "kimi-coding" in providers
@@ -60,6 +61,7 @@ class TestModelsRegistry:
             "zhipu-code",
             "volcengine",
             "dashscope",
+            "dashscope-code",
             "custom-openai",
             "custom-anthropic",
             "deepseek",
@@ -517,6 +519,21 @@ class TestThirdPartyRouting:
             == "https://dashscope.aliyuncs.com/compatible-mode/v1"
         )
         assert call_kwargs["api_key"] == "ds-key-456"
+
+    @patch("EvoScientist.llm.models.init_chat_model")
+    def test_dashscope_code_routes_through_openai(self, mock_init, monkeypatch):
+        """DashScope-Code (sk-sp-* subscription keys) routes through OpenAI
+        with the coding.dashscope.aliyuncs.com base URL, reusing DASHSCOPE_API_KEY.
+        """
+        mock_init.return_value = "mock_model"
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-sp-key-789")
+
+        get_chat_model("qwen3-coder", provider="dashscope-code")
+
+        call_kwargs = mock_init.call_args[1]
+        assert call_kwargs["model_provider"] == "openai"
+        assert call_kwargs["base_url"] == "https://coding.dashscope.aliyuncs.com/v1"
+        assert call_kwargs["api_key"] == "sk-sp-key-789"
 
     @patch("EvoScientist.llm.models.init_chat_model")
     def test_minimax_routes_through_anthropic(self, mock_init, monkeypatch):


### PR DESCRIPTION
## Description

Adds a `dashscope-code` provider so Alibaba Cloud Bailian "Coding Plan" subscription keys (`sk-sp-*`) work out of the box by reusing `DASHSCOPE_API_KEY`. These keys are rejected by the standard `dashscope` endpoint and only work against `https://coding.dashscope.aliyuncs.com/v1`. Standard `dashscope` (`sk-*`) users see no behaviour change.

Follows the existing `zhipu` / `zhipu-code` and `moonshot` / `kimi-coding` precedents: a sibling provider entry rather than prefix-based magic, so the routing decision lives in config where it's easy to inspect and override.

Closes #224

## Type of change

- [ ] Bug fix
- [x] New feature — #224
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a DashScope Coding Plan provider in onboarding.
  * New API key validation for DashScope coding subscriptions.
  * Entered DashScope coding keys are saved to the existing configuration.
  * Extended model routing to cover Qwen code-oriented variants (e.g., qwen3-coder, qwen3-max, qwen3.5-plus).

* **Tests**
  * Added tests to verify DashScope Coding Plan provider routing and key usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvoScientist/EvoScientist/pull/225)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->