### PR TITLE
fix: apply DeepSeek reasoning_content passback patch for custom-openai provider

### DIFF
--- a/EvoScientist/llm/context_window.py
+++ b/EvoScientist/llm/context_window.py
@@ -1,0 +1,165 @@
+"""Helpers for resolving model context windows across LangChain providers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+DEFAULT_CONTEXT_WINDOW_FALLBACK = 200_000
+
+# Patch table for new models that providers haven't registered profile data
+# for yet. Remove an entry once langchain/provider exposes max_input_tokens
+# via ``model.profile`` — the attribute-reading layer always wins.
+# Keys are matched against ``model.model_name`` (or ``model.model`` /
+# ``model.name``); lookup tries exact match first, then ``split('/')[-1]``
+# to also accept OpenRouter-style ``vendor/model`` IDs.
+_KNOWN_MODEL_CONTEXT_WINDOWS: dict[str, int] = {
+    # Qwen 3.6 open-source variants — exceptions to the ``qwen3.6`` family.
+    "qwen3.6-27b": 262_000,
+    "qwen3.6-35b-a3b": 262_000,
+    # Claude Haiku 4.5 — exception to the ``claude-`` family (200K, not 1M).
+    "claude-haiku-4-5": 200_000,
+}
+
+# Family-level fallbacks: tried only after exact-name lookup misses.
+# Each entry is (substring_to_match_in_lowercased_model_id, window).
+# Order matters — first match wins; put more specific patterns first.
+_KNOWN_MODEL_FAMILIES: list[tuple[str, int]] = [
+    # All Claude — 1M via the ``context-1m-2025-08-07`` beta header.
+    ("claude-", 1_000_000),
+    # OpenAI GPT-5.5 family — base, pro, future variants
+    ("gpt-5.5", 1_050_000),
+    # Moonshot Kimi K2 family — k2.5, k2.6, k2-thinking, k2-thinking-turbo
+    ("kimi-k2", 262_000),
+    # Zhipu GLM-5 family — base, 5.1, 5-turbo, 5v-turbo, etc.
+    ("glm-5", 203_000),
+    # DeepSeek V4 family — pro, flash, future variants
+    ("deepseek-v4", 1_050_000),
+    # Xiaomi MiMo v2.5 family — base, pro, future variants
+    ("mimo-v2.5", 1_050_000),
+    # Qwen 3.6 closed-source family — flash, plus, max-preview, etc.
+    # Open-source ``-<size>b`` variants are 262K — listed in the dict above.
+    ("qwen3.6", 1_000_000),
+]
+
+_DIRECT_WINDOW_ATTRS = (
+    "context_window",
+    "context_length",
+    "num_ctx",
+    "max_input_tokens",
+)
+_CONTAINER_ATTRS = (
+    "profile",
+    "context_management",
+    "model_kwargs",
+    "metadata",
+)
+_NAME_ATTRS = ("model_name", "model", "name")
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    """Best-effort coercion for positive integer-like values."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        if value > 0 and value.is_integer():
+            return int(value)
+        return None
+    if isinstance(value, str):
+        normalized = value.strip().replace(",", "").replace("_", "")
+        if normalized.isdigit():
+            parsed = int(normalized)
+            return parsed if parsed > 0 else None
+    return None
+
+
+def _resolve_from_mapping(mapping: Mapping[str, Any]) -> int | None:
+    """Resolve a context window from a metadata mapping."""
+    for key in _DIRECT_WINDOW_ATTRS:
+        if key in mapping:
+            resolved = _coerce_positive_int(mapping.get(key))
+            if resolved is not None:
+                return resolved
+    return None
+
+
+def _lookup_by_model_name(model_obj: Any) -> int | None:
+    """Return a patched context window by model name, if registered.
+
+    Lookup is case-insensitive. Matching order:
+        1. exact lowercased ``model_name`` value;
+        2. last ``/``-segment of the lowercased value (handles
+           OpenRouter-style ``vendor/model`` and SiliconFlow-style
+           ``Pro/vendor/Model`` IDs);
+        3. family-level substring patterns (e.g. all ``claude-*``).
+    """
+    for attr in _NAME_ATTRS:
+        value = getattr(model_obj, attr, None)
+        if not isinstance(value, str) or not value:
+            continue
+        lowered = value.lower()
+        if lowered in _KNOWN_MODEL_CONTEXT_WINDOWS:
+            return _KNOWN_MODEL_CONTEXT_WINDOWS[lowered]
+        short = lowered.split("/")[-1]
+        if short != lowered and short in _KNOWN_MODEL_CONTEXT_WINDOWS:
+            return _KNOWN_MODEL_CONTEXT_WINDOWS[short]
+        for pattern, window in _KNOWN_MODEL_FAMILIES:
+            if pattern in lowered:
+                return window
+    return None
+
+
+def get_context_window(model_obj: Any | None) -> int | None:
+    """Return the best available context-window value from a model object."""
+    if model_obj is None:
+        return None
+
+    for attr in _DIRECT_WINDOW_ATTRS:
+        resolved = _coerce_positive_int(getattr(model_obj, attr, None))
+        if resolved is not None:
+            return resolved
+
+    for attr in _CONTAINER_ATTRS:
+        candidate = getattr(model_obj, attr, None)
+        if isinstance(candidate, Mapping):
+            resolved = _resolve_from_mapping(candidate)
+            if resolved is not None:
+                return resolved
+
+    return _lookup_by_model_name(model_obj)
+
+
+def resolve_context_window(
+    model_obj: Any | None,
+    *,
+    fallback: int = DEFAULT_CONTEXT_WINDOW_FALLBACK,
+) -> int:
+    """Resolve a usable context window with a stable fallback."""
+    resolved = get_context_window(model_obj)
+    if resolved is not None:
+        return resolved
+    return fallback
+
+
+def apply_known_context_window(model: Any) -> None:
+    """Inject patched ``max_input_tokens`` into ``model.profile`` for new
+    models that providers haven't registered profile data for yet.
+
+    Without this, deepagents' ``SummarizationMiddleware`` falls back to a
+    hardcoded 170K trigger, ignoring the true (e.g. 1M) context window.
+    Real provider-supplied profile data always wins — we only fill gaps.
+    """
+    patched = _lookup_by_model_name(model)
+    if patched is None:
+        return
+    profile = getattr(model, "profile", None)
+    if isinstance(profile, dict) and "max_input_tokens" in profile:
+        return
+    base = profile if isinstance(profile, dict) else {}
+    new_profile = {**base, "max_input_tokens": patched}
+    try:
+        model.profile = new_profile
+    except Exception:
+        pass

--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -3,173 +3,49 @@
 This module provides a unified interface for creating chat model instances
 with support for multiple providers (Anthropic, OpenAI, Google GenAI, MiniMax
 (Anthropic-compatible), NVIDIA, SiliconFlow, OpenRouter, ZhipuAI, Volcengine,
-DashScope, DeepSeek, Ollama, and custom OpenAI/Anthropic-compatible endpoints) and
-convenient short names for common models.
+DashScope, DashScope-Code, DeepSeek, Ollama, and custom OpenAI/Anthropic-compatible
+endpoints) and convenient short names for common models.
 """
 
 from __future__ import annotations
 
 import os
-import re
 from typing import Any
 
 from langchain.chat_models import init_chat_model
 
-
-# ---------------------------------------------------------------------------
-# Patch: langchain-anthropic (>=1.3.4) calls .model_dump() on
-# context_management / container objects returned by the Anthropic SDK.
-# Proxies like ccproxy may return plain dicts which lack that method.
-# We wrap the class method to pre-convert dicts before the original runs.
-# ---------------------------------------------------------------------------
-def _patch_anthropic_proxy_compat() -> None:
-    try:
-        import types as _types
-
-        from langchain_anthropic.chat_models import ChatAnthropic as _CA
-
-        _orig = _CA._make_message_chunk_from_anthropic_event
-
-        def _safe(self: Any, event: Any, *args: Any, **kwargs: Any) -> Any:
-            for obj, attrs in [
-                (event, ("context_management",)),
-                (getattr(event, "delta", None), ("container",)),
-            ]:
-                if obj is None:
-                    continue
-                for attr in attrs:
-                    val = getattr(obj, attr, None)
-                    if isinstance(val, dict):
-                        d = val.copy()
-                        setattr(
-                            obj,
-                            attr,
-                            _types.SimpleNamespace(model_dump=lambda d=d, **kw: d),
-                        )
-            return _orig(self, event, *args, **kwargs)
-
-        _CA._make_message_chunk_from_anthropic_event = _safe
-    except Exception:
-        pass
-
-
-_patch_anthropic_proxy_compat()
-
-# ---------------------------------------------------------------------------
-# Patch: ccproxy Codex embeds thinking as <thinking>...</thinking> tags
-# inside the content string. Strip these so they don't appear in output.
-# ---------------------------------------------------------------------------
-_THINKING_TAG_RE = re.compile(r"<thinking>.*?</thinking>\s*", re.DOTALL)
-
-
-def strip_thinking_tags(content: str) -> str:
-    """Remove ``<thinking>...</thinking>`` tags from ccproxy response content."""
-    return _THINKING_TAG_RE.sub("", content)
-
-
-_SKIP_CONTENT_TYPES = frozenset({"thinking", "reasoning", "reasoning_content"})
-
-
-def _flatten_message_content(content: Any) -> str | Any:
-    """Convert list-of-blocks content to a plain string.
-
-    OpenAI-compatible APIs (DeepSeek, SiliconFlow, etc.) reject assistant
-    messages whose ``content`` is a list rather than a string.
-
-    Args:
-        content: Message content — either a string, a list of content blocks
-            (dicts with ``type`` and ``text`` keys), or another type.
-
-    Returns:
-        A plain string with text blocks joined by double newlines.
-        Thinking/reasoning blocks are skipped.  Non-list input is
-        returned unchanged.
-    """
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return content
-    parts: list[str] = []
-    for block in content:
-        if isinstance(block, dict):
-            if block.get("type") in _SKIP_CONTENT_TYPES:
-                continue
-            text = block.get("text")
-            if text:
-                parts.append(text)
-        elif isinstance(block, str):
-            parts.append(block)
-    return "\n\n".join(parts) if parts else ""
-
-
-def _patch_openai_compat_content(model: Any) -> None:
-    """Flatten list content to strings before OpenAI-compatible API calls.
-
-    Wraps ``_generate`` / ``_agenerate`` to prevent "invalid type: sequence,
-    expected a string" errors from strict APIs like DeepSeek.  Follows the
-    same monkey-patching pattern as ``_patch_anthropic_proxy_compat``.
-
-    Args:
-        model: A LangChain chat model instance to patch in-place.
-    """
-    import copy
-    import functools
-
-    from langchain_core.messages import BaseMessage
-
-    def _sanitize_messages(messages: list[BaseMessage]) -> list[BaseMessage]:
-        out: list[BaseMessage] = []
-        for msg in messages:
-            if isinstance(msg.content, list):
-                msg = copy.copy(msg)
-                msg.content = _flatten_message_content(msg.content)
-            out.append(msg)
-        return out
-
-    orig_generate = getattr(model, "_generate", None)
-    if orig_generate is None:
-        return
-
-    @functools.wraps(orig_generate)
-    def _patched_generate(
-        messages: list[BaseMessage], *args: Any, **kwargs: Any
-    ) -> Any:
-        return orig_generate(_sanitize_messages(messages), *args, **kwargs)
-
-    model._generate = _patched_generate
-
-    orig_agenerate = getattr(model, "_agenerate", None)
-    if orig_agenerate is not None:
-
-        @functools.wraps(orig_agenerate)
-        async def _patched_agenerate(
-            messages: list[BaseMessage], *args: Any, **kwargs: Any
-        ) -> Any:
-            return await orig_agenerate(_sanitize_messages(messages), *args, **kwargs)
-
-        model._agenerate = _patched_agenerate
+from .context_window import apply_known_context_window
+from .patches import (
+    _is_ccproxy_codex,
+    _patch_ccproxy_system_to_developer,
+    _patch_deepseek_reasoning_passback,
+    _patch_openai_compat_content,
+)
 
 
 _MINIMAX_ANTHROPIC_BASE_URL = "https://api.minimaxi.com/anthropic"
 _SILICONFLOW_BASE_URL = "https://api.siliconflow.cn/v1"
-_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _ZHIPU_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
 _ZHIPU_CODE_BASE_URL = "https://open.bigmodel.cn/api/coding/paas/v4"
 _VOLCENGINE_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3"
 _DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+_DASHSCOPE_CODE_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 
 _DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+_MOONSHOT_BASE_URL = "https://api.moonshot.cn/v1"
+_KIMI_CODING_BASE_URL = "https://api.kimi.com/coding/"
 
 # Providers routed through the OpenAI provider with a custom base_url.
 # Maps provider name → (base_url or None, env var for API key).
 _OPENAI_ROUTED_PROVIDERS: dict[str, tuple[str | None, str]] = {
     "deepseek": (_DEEPSEEK_BASE_URL, "DEEPSEEK_API_KEY"),
+    "moonshot": (_MOONSHOT_BASE_URL, "MOONSHOT_API_KEY"),
     "siliconflow": (_SILICONFLOW_BASE_URL, "SILICONFLOW_API_KEY"),
-    "openrouter": (_OPENROUTER_BASE_URL, "OPENROUTER_API_KEY"),
     "zhipu": (_ZHIPU_BASE_URL, "ZHIPU_API_KEY"),
     "zhipu-code": (_ZHIPU_CODE_BASE_URL, "ZHIPU_API_KEY"),
     "volcengine": (_VOLCENGINE_BASE_URL, "VOLCENGINE_API_KEY"),
     "dashscope": (_DASHSCOPE_BASE_URL, "DASHSCOPE_API_KEY"),
+    "dashscope-code": (_DASHSCOPE_CODE_BASE_URL, "DASHSCOPE_API_KEY"),
     "custom-openai": (
         None,
         "CUSTOM_OPENAI_API_KEY",
@@ -180,6 +56,7 @@ _OPENAI_ROUTED_PROVIDERS: dict[str, tuple[str | None, str]] = {
 # Maps provider name → (base_url or None, env var for API key).
 _ANTHROPIC_ROUTED_PROVIDERS: dict[str, tuple[str | None, str]] = {
     "minimax": (_MINIMAX_ANTHROPIC_BASE_URL, "MINIMAX_API_KEY"),
+    "kimi-coding": (_KIMI_CODING_BASE_URL, "KIMI_API_KEY"),
     "custom-anthropic": (None, "CUSTOM_ANTHROPIC_API_KEY"),
 }
 
@@ -429,20 +306,26 @@ def get_chat_model(
         base_url = os.environ.get("OPENAI_BASE_URL", "")
         if base_url:
             kwargs["base_url"] = base_url
-            _is_openai_proxy = "127.0.0.1" in base_url or "localhost" in base_url
+            _is_openai_proxy = _is_ccproxy_codex()
             if _is_openai_proxy:
-                kwargs.setdefault(
-                    "streaming", False
-                )  # ccproxy streaming format incompatible with langchain-openai
-                kwargs.setdefault(
-                    "use_responses_api", True
-                )  # ccproxy Chat Completions does not support tool calling; Responses API does
+                # Use Responses API for ccproxy: bypasses the format chain
+                # converter (Chat→Responses→Chat) which returns 502 on
+                # complex responses.  System messages are converted to
+                # developer role by _patch_ccproxy_system_to_developer().
+                kwargs.setdefault("use_responses_api", True)
+                # Streaming must stay ON for Responses API: ccproxy's
+                # StreamingBufferService loses output when assembling
+                # non-streaming responses.  (The old streaming=False was
+                # for Chat Completions tool_call duplication — not an issue
+                # with the Responses API SSE format.)
+                kwargs.pop("streaming", None)  # remove if set elsewhere
         api_key = os.environ.get("OPENAI_API_KEY", "")
         if api_key:
             kwargs["api_key"] = api_key
 
     # OpenAI-routed providers → route through OpenAI provider with base_url
     elif provider in _OPENAI_ROUTED_PROVIDERS:
+        _original_provider = provider
         base_url_default, api_key_env = _OPENAI_ROUTED_PROVIDERS[provider]
         if provider == "custom-openai":
             base_url = os.environ.get("CUSTOM_OPENAI_BASE_URL", "")
@@ -464,10 +347,26 @@ def get_chat_model(
         # from history, causing error 20015 on multi-turn requests.
         if provider == "siliconflow":
             kwargs.setdefault("extra_body", {})["enable_thinking"] = False
+        # Moonshot: disable thinking for all models to prevent LangChain from dropping
+        # reasoning_content, which causes multi-turn conversation errors (error 20015).
+        # Even native thinking models like kimi-k2-thinking operate in non-thinking mode.
+        if provider == "moonshot":
+            kwargs.setdefault("extra_body", {})["thinking"] = {"type": "disabled"}
         provider = "openai"
+
+    # OpenRouter → native ChatOpenRouter via init_chat_model.
+    elif provider == "openrouter":
+        _is_third_party = True
+        api_key = os.environ.get("OPENROUTER_API_KEY", "")
+        if api_key:
+            kwargs["api_key"] = api_key
+        # Enable reasoning; disable summary to avoid multi-turn schema errors.
+        effort = os.environ.get("EVOSCIENTIST_REASONING_EFFORT", "").strip() or "high"
+        kwargs.setdefault("reasoning", {"effort": effort, "summary": "disabled"})
 
     # Anthropic-routed providers → route through Anthropic provider with base_url
     elif provider in _ANTHROPIC_ROUTED_PROVIDERS:
+        _original_provider = provider
         base_url_default, api_key_env = _ANTHROPIC_ROUTED_PROVIDERS[provider]
         if provider == "custom-anthropic":
             base_url = os.environ.get("CUSTOM_ANTHROPIC_BASE_URL", "")
@@ -485,7 +384,9 @@ def get_chat_model(
         api_key = os.environ.get(api_key_env, "")
         if api_key:
             kwargs["api_key"] = api_key
-        _original_provider = provider
+        # Kimi Coding: set User-Agent for Claude Code compatibility.
+        if provider == "kimi-coding":
+            kwargs.setdefault("default_headers", {})["User-Agent"] = "claude-code/0.1.0"
         provider = "anthropic"
 
     elif provider == "ollama":
@@ -497,23 +398,41 @@ def get_chat_model(
 
     # User-level override for the OpenAI Responses API vs Chat Completions.
     # When "false", force Chat Completions and drop reasoning (which triggers
-    # the Responses API path in langchain-openai).
-    _responses_api_setting = (
-        os.environ.get("EVOSCIENTIST_USE_RESPONSES_API", "").strip().lower()
-    )
-    if _responses_api_setting == "false":
-        kwargs["use_responses_api"] = False
-        kwargs.pop("reasoning", None)
-    elif _responses_api_setting == "true":
-        kwargs["use_responses_api"] = True
+    # the Responses API path in langchain-openai). Only applies to OpenAI.
+    if provider == "openai":
+        _responses_api_setting = (
+            os.environ.get("EVOSCIENTIST_USE_RESPONSES_API", "").strip().lower()
+        )
+        if _responses_api_setting == "false":
+            kwargs["use_responses_api"] = False
+            kwargs.pop("reasoning", None)
+        elif _responses_api_setting == "true":
+            kwargs["use_responses_api"] = True
 
     chat_model = init_chat_model(model=model_id, model_provider=provider, **kwargs)
 
-    # Flatten list content to strings for OpenAI-compatible providers
+    # Flatten list content to strings for strict OpenAI-compatible providers
     # (DeepSeek, SiliconFlow, OpenRouter, custom-openai, etc.) and
     # native OpenAI through a proxy, to avoid "sequence expected string" errors.
-    if _is_third_party or _is_openai_proxy:
+    # Moonshot and Kimi Coding support standard format, no patch needed.
+    _no_patch_providers = {"moonshot", "kimi-coding"}
+    if (
+        _is_third_party or _is_openai_proxy
+    ) and _original_provider not in _no_patch_providers:
         _patch_openai_compat_content(chat_model)
+
+    # DeepSeek thinking mode requires reasoning_content passback in multi-turn
+    # + tool_use scenarios.
+    if _original_provider == "deepseek" or (
+        _original_provider == "custom-openai"
+        and "deepseek" in model_id.lower()
+    ):
+        _patch_deepseek_reasoning_passback(chat_model)
+
+    if _is_openai_proxy:
+        _patch_ccproxy_system_to_developer(chat_model)
+
+    apply_known_context_window(chat_model)
 
     return chat_model
 

--- a/EvoScientist/llm/patches.py
+++ b/EvoScientist/llm/patches.py
@@ -1,0 +1,707 @@
+"""Monkey-patches and utilities for third-party LangChain provider quirks.
+
+All patches follow the same pattern: wrap an existing method/function to
+fix upstream bugs, applied at import time or on first use.
+
+Patches:
+    - _patch_anthropic_proxy_compat: ccproxy dict→Pydantic model mismatch
+    - _patch_openai_compat_content: list content→string for strict APIs
+    - _patch_ccproxy_codex_compat: ccproxy model fixes + langchain None guard
+    - _patch_ccproxy_system_to_developer: system→developer role for ccproxy
+    - _patch_openai_capture_reasoning_content: capture provider
+      reasoning_content into AIMessage.additional_kwargs (module-level,
+      applied at import)
+    - _patch_deepseek_reasoning_passback: re-inject reasoning_content into
+      outgoing DeepSeek assistant messages for thinking-mode multi-turn /
+      tool_use scenarios
+
+Utilities:
+    - _is_ccproxy_codex: detect ccproxy Codex OAuth adapter
+    - _flatten_message_content: convert content blocks to plain string
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Patch: langchain-anthropic (>=1.3.4) calls .model_dump() on
+# context_management / container objects returned by the Anthropic SDK.
+# Proxies like ccproxy may return plain dicts which lack that method.
+# We wrap the class method to pre-convert dicts before the original runs.
+# ---------------------------------------------------------------------------
+def _patch_anthropic_proxy_compat() -> None:
+    try:
+        import types as _types
+
+        from langchain_anthropic.chat_models import ChatAnthropic as _CA
+
+        _orig = _CA._make_message_chunk_from_anthropic_event
+
+        def _safe(self: Any, event: Any, *args: Any, **kwargs: Any) -> Any:
+            for obj, attrs in [
+                (event, ("context_management",)),
+                (getattr(event, "delta", None), ("container",)),
+            ]:
+                if obj is None:
+                    continue
+                for attr in attrs:
+                    val = getattr(obj, attr, None)
+                    if isinstance(val, dict):
+                        d = val.copy()
+                        setattr(
+                            obj,
+                            attr,
+                            _types.SimpleNamespace(model_dump=lambda d=d, **kw: d),
+                        )
+            return _orig(self, event, *args, **kwargs)
+
+        _CA._make_message_chunk_from_anthropic_event = _safe
+    except Exception:
+        pass
+
+
+_patch_anthropic_proxy_compat()
+
+
+# ---------------------------------------------------------------------------
+# Patch: ccproxy-api 0.2.7 Codex compatibility.
+#
+# 1) ResponseObject.output is required but upstream may omit it → 502.
+#    Fix: make output default to [].
+# 2) CodexMessage.role only allows "user"/"assistant" → 400 on system msgs.
+#    Fix: widen to also accept "system" and "developer".
+# 3) langchain-openai iterates response.output which can be None after the
+#    proxy strips it.  Fix: guard in _construct_lc_result_from_responses_api.
+# ---------------------------------------------------------------------------
+def _patch_ccproxy_codex_compat() -> None:
+    """Patch ccproxy-api models for Responses API compatibility."""
+    # 1) Make ResponseObject.output optional (default=[])
+    try:
+        import ccproxy.llms.models.openai as _oai_mod
+
+        _OrigResponse = _oai_mod.ResponseObject
+
+        from pydantic import Field as _PydanticField
+
+        class _PatchedResponseObject(_OrigResponse):  # type: ignore[misc]
+            output: list = _PydanticField(default_factory=list)  # type: ignore[assignment]
+
+            model_config = _OrigResponse.model_config.copy()
+
+        _PatchedResponseObject.__name__ = "ResponseObject"
+        _PatchedResponseObject.__qualname__ = "ResponseObject"
+        _oai_mod.ResponseObject = _PatchedResponseObject  # type: ignore[misc]
+
+        # Also patch modules that import ResponseObject directly
+        for _mod_path in (
+            "ccproxy.llms.formatters.openai_to_openai.responses",
+            "ccproxy.llms.formatters.anthropic_to_openai.responses",
+        ):
+            try:
+                import importlib
+
+                _mod = importlib.import_module(_mod_path)
+                if hasattr(_mod, "ResponseObject"):
+                    _mod.ResponseObject = _PatchedResponseObject  # type: ignore[attr-defined]
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    # 2) Widen CodexMessage.role to accept system/developer
+    try:
+        from typing import Annotated, Literal
+
+        import ccproxy.plugins.codex.models as _codex_mod
+
+        _OrigMessage = _codex_mod.CodexMessage
+
+        from pydantic import Field as _Field
+
+        class _PatchedCodexMessage(_OrigMessage):  # type: ignore[misc]
+            role: Annotated[  # type: ignore[assignment]
+                Literal["user", "assistant", "system", "developer"],
+                _Field(description="Message role"),
+            ]
+
+        _PatchedCodexMessage.__name__ = "CodexMessage"
+        _PatchedCodexMessage.__qualname__ = "CodexMessage"
+        _codex_mod.CodexMessage = _PatchedCodexMessage  # type: ignore[misc]
+    except Exception:
+        pass
+
+    # 3) Fix StreamingBufferService returning response.completed event
+    #    whose output is None/empty, instead of using accumulated outputs.
+    try:
+        from ccproxy.llms.streaming.accumulators import ResponsesAccumulator
+
+        _orig_get = ResponsesAccumulator.get_completed_response
+
+        def _patched_get(self: Any) -> dict | None:
+            result = _orig_get(self)
+            if result is not None:
+                output = result.get("output")
+                if output is None:
+                    # output field lost — force rebuild from accumulated items
+                    return None
+            return result
+
+        ResponsesAccumulator.get_completed_response = _patched_get  # type: ignore[assignment]
+    except Exception:
+        pass
+
+    # 4) Guard langchain-openai against None output (final safety net)
+    try:
+        import langchain_openai.chat_models.base as _base
+
+        _orig_construct = _base._construct_lc_result_from_responses_api
+
+        def _safe(response: Any, *args: Any, **kwargs: Any) -> Any:
+            if response.output is None:
+                response.output = []
+            return _orig_construct(response, *args, **kwargs)
+
+        _base._construct_lc_result_from_responses_api = _safe
+    except Exception:
+        pass
+
+
+_patch_ccproxy_codex_compat()
+
+
+# ---------------------------------------------------------------------------
+# Utility: detect ccproxy's Codex adapter (as opposed to generic localhost).
+# ---------------------------------------------------------------------------
+def _is_ccproxy_codex() -> bool:
+    """Return True if the OpenAI endpoint is ccproxy's Codex adapter.
+
+    Checks for the ccproxy-specific markers set by ``setup_codex_env()``
+    in ``ccproxy_manager.py``: the sentinel API key and the ``/codex/v1``
+    path.  Plain localhost endpoints (vLLM, Ollama, etc.) are not affected.
+    """
+    base_url = os.environ.get("OPENAI_BASE_URL", "")
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    return (
+        ("127.0.0.1" in base_url or "localhost" in base_url)
+        and api_key == "ccproxy-oauth"
+        and "/codex/" in base_url
+    )
+
+
+# ---------------------------------------------------------------------------
+# Utility + Patch: Flatten list content to strings for OpenAI-compatible APIs.
+# DeepSeek, SiliconFlow, etc. reject assistant messages whose content is a
+# list rather than a string.
+# ---------------------------------------------------------------------------
+_SKIP_CONTENT_TYPES = frozenset({"thinking", "reasoning", "reasoning_content"})
+
+
+def _flatten_message_content(content: Any) -> str | Any:
+    """Convert list-of-blocks content to a plain string.
+
+    Args:
+        content: Message content — either a string, a list of content blocks
+            (dicts with ``type`` and ``text`` keys), or another type.
+
+    Returns:
+        A plain string with text blocks joined by double newlines.
+        Thinking/reasoning blocks are skipped.  Non-list input is
+        returned unchanged.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return content
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict):
+            if block.get("type") in _SKIP_CONTENT_TYPES:
+                continue
+            text = block.get("text")
+            if text:
+                parts.append(text)
+        elif isinstance(block, str):
+            parts.append(block)
+    return "\n\n".join(parts) if parts else ""
+
+
+def _patch_openai_compat_content(model: Any) -> None:
+    """Flatten list content to strings before OpenAI-compatible API calls.
+
+    Wraps ``_generate`` / ``_agenerate`` to prevent "invalid type: sequence,
+    expected a string" errors from strict APIs like DeepSeek.
+
+    Args:
+        model: A LangChain chat model instance to patch in-place.
+    """
+    import copy
+    import functools
+
+    from langchain_core.messages import BaseMessage
+
+    def _sanitize_messages(messages: list[BaseMessage]) -> list[BaseMessage]:
+        out: list[BaseMessage] = []
+        for msg in messages:
+            if isinstance(msg.content, list):
+                msg = copy.copy(msg)
+                msg.content = _flatten_message_content(msg.content)
+            out.append(msg)
+        return out
+
+    orig_generate = getattr(model, "_generate", None)
+    if orig_generate is None:
+        return
+
+    @functools.wraps(orig_generate)
+    def _patched_generate(
+        messages: list[BaseMessage], *args: Any, **kwargs: Any
+    ) -> Any:
+        return orig_generate(_sanitize_messages(messages), *args, **kwargs)
+
+    model._generate = _patched_generate
+
+    orig_agenerate = getattr(model, "_agenerate", None)
+    if orig_agenerate is not None:
+
+        @functools.wraps(orig_agenerate)
+        async def _patched_agenerate(
+            messages: list[BaseMessage], *args: Any, **kwargs: Any
+        ) -> Any:
+            return await orig_agenerate(_sanitize_messages(messages), *args, **kwargs)
+
+        model._agenerate = _patched_agenerate
+
+    # Also patch streaming paths — CLI/agent uses _stream/_astream, so without
+    # these the content flattening is bypassed during normal streaming calls.
+    orig_stream = getattr(model, "_stream", None)
+    if orig_stream is not None:
+
+        @functools.wraps(orig_stream)
+        def _patched_stream(
+            messages: list[BaseMessage], *args: Any, **kwargs: Any
+        ) -> Any:
+            return orig_stream(_sanitize_messages(messages), *args, **kwargs)
+
+        model._stream = _patched_stream
+
+    orig_astream = getattr(model, "_astream", None)
+    if orig_astream is not None:
+
+        @functools.wraps(orig_astream)
+        async def _patched_astream(
+            messages: list[BaseMessage], *args: Any, **kwargs: Any
+        ) -> Any:
+            async for chunk in orig_astream(
+                _sanitize_messages(messages), *args, **kwargs
+            ):
+                yield chunk
+
+        model._astream = _patched_astream
+
+
+# ---------------------------------------------------------------------------
+# Patch: ccproxy Codex Responses API rejects "system" role messages.
+# Convert SystemMessage to use "developer" role via langchain-openai's
+# __openai_role__ mechanism.
+# ---------------------------------------------------------------------------
+def _patch_ccproxy_system_to_developer(model: Any) -> None:
+    """Convert SystemMessage role from 'system' to 'developer' for ccproxy.
+
+    ccproxy's Responses API endpoint rejects system role messages with
+    400 "System messages are not allowed".  LangChain's ``langchain_openai``
+    checks ``additional_kwargs["__openai_role__"]`` and uses that value as
+    the message role when serializing to the API.
+
+    Args:
+        model: A LangChain chat model instance to patch in-place.
+    """
+    import copy
+    import functools
+
+    from langchain_core.messages import BaseMessage, SystemMessage
+
+    def _system_to_developer(messages: list[BaseMessage]) -> list[BaseMessage]:
+        out: list[BaseMessage] = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                if msg.additional_kwargs.get("__openai_role__") != "developer":
+                    msg = copy.copy(msg)
+                    msg.additional_kwargs = {
+                        **msg.additional_kwargs,
+                        "__openai_role__": "developer",
+                    }
+            out.append(msg)
+        return out
+
+    orig_generate = getattr(model, "_generate", None)
+    if orig_generate is None:
+        return
+
+    @functools.wraps(orig_generate)
+    def _patched_generate(
+        messages: list[BaseMessage], *args: Any, **kwargs: Any
+    ) -> Any:
+        return orig_generate(_system_to_developer(messages), *args, **kwargs)
+
+    model._generate = _patched_generate
+
+    orig_agenerate = getattr(model, "_agenerate", None)
+    if orig_agenerate is not None:
+
+        @functools.wraps(orig_agenerate)
+        async def _patched_agenerate(
+            messages: list[BaseMessage], *args: Any, **kwargs: Any
+        ) -> Any:
+            return await orig_agenerate(_system_to_developer(messages), *args, **kwargs)
+
+        model._agenerate = _patched_agenerate
+
+    orig_stream = getattr(model, "_stream", None)
+    if orig_stream is not None:
+
+        @functools.wraps(orig_stream)
+        def _patched_stream(
+            messages: list[BaseMessage], *args: Any, **kwargs: Any
+        ) -> Any:
+            return orig_stream(_system_to_developer(messages), *args, **kwargs)
+
+        model._stream = _patched_stream
+
+    orig_astream = getattr(model, "_astream", None)
+    if orig_astream is not None:
+
+        @functools.wraps(orig_astream)
+        async def _patched_astream(
+            messages: list[BaseMessage], *args: Any, **kwargs: Any
+        ) -> Any:
+            async for chunk in orig_astream(
+                _system_to_developer(messages), *args, **kwargs
+            ):
+                yield chunk
+
+        model._astream = _patched_astream
+
+
+# ---------------------------------------------------------------------------
+# Patch (module-level): langchain-openai's _convert_dict_to_message and
+# _convert_delta_to_message_chunk discard provider-specific fields like
+# `reasoning_content`. We monkey-patch them to capture reasoning_content
+# into AIMessage.additional_kwargs so downstream code (incl. our passback
+# patch) can find it. Benign for non-DeepSeek providers — they just don't
+# return this field, so the patch is a no-op for them.
+# ---------------------------------------------------------------------------
+_openai_capture_patched = False
+
+
+def _patch_openai_capture_reasoning_content() -> None:
+    global _openai_capture_patched
+    if _openai_capture_patched:
+        return
+    try:
+        import langchain_openai.chat_models.base as _base
+
+        _orig_dict_to_msg = _base._convert_dict_to_message
+        _orig_delta_to_chunk = _base._convert_delta_to_message_chunk
+
+        def _patched_dict_to_msg(_dict, *args, **kwargs):
+            msg = _orig_dict_to_msg(_dict, *args, **kwargs)
+            rc = _dict.get("reasoning_content") if isinstance(_dict, dict) else None
+            if isinstance(rc, str) and rc and hasattr(msg, "additional_kwargs"):
+                msg.additional_kwargs["reasoning_content"] = rc
+            return msg
+
+        def _patched_delta_to_chunk(_dict, *args, **kwargs):
+            chunk = _orig_delta_to_chunk(_dict, *args, **kwargs)
+            rc = _dict.get("reasoning_content") if isinstance(_dict, dict) else None
+            if isinstance(rc, str) and rc and hasattr(chunk, "additional_kwargs"):
+                # Per-chunk: stash this delta's reasoning_content on the chunk.
+                # Cross-chunk accumulation is handled by AIMessageChunk.__add__
+                # via merge_dicts (string values in additional_kwargs concatenate).
+                chunk.additional_kwargs["reasoning_content"] = (
+                    chunk.additional_kwargs.get("reasoning_content", "") + rc
+                )
+            return chunk
+
+        _base._convert_dict_to_message = _patched_dict_to_msg
+        _base._convert_delta_to_message_chunk = _patched_delta_to_chunk
+        _openai_capture_patched = True
+    except Exception:
+        pass
+
+
+_patch_openai_capture_reasoning_content()
+
+
+# ---------------------------------------------------------------------------
+# Patch: DeepSeek thinking mode requires reasoning_content to be passed back
+# in all assistant messages for multi-turn + tool_use scenarios.
+# langchain-openai's _convert_message_to_dict drops this field, causing
+# HTTP 400 "The reasoning_content in the thinking mode must be passed back".
+# Mirrors langchain-ai/langchain PR #34516 (which patches langchain-deepseek;
+# we apply equivalent logic to a langchain-openai ChatOpenAI instance).
+# ---------------------------------------------------------------------------
+def _patch_deepseek_reasoning_passback(model: Any) -> None:
+    """Inject reasoning_content into outgoing payload assistant messages.
+
+    DeepSeek V4 thinking mode + tool_use requires every historical assistant
+    message to carry its reasoning_content as a top-level field (sibling to
+    content / tool_calls).  Without this, multi-turn requests fail with 400.
+
+    For assistant messages where no reasoning_content was captured (e.g.
+    history left over from another provider, from DeepSeek Flash, or from an
+    older EvoSci version that ran before the capture patch landed), we
+    inject an empty string.  This satisfies DeepSeek's format requirement
+    in thinking mode.  Non-thinking DeepSeek endpoints are believed to
+    accept the extra field without complaint based on observed behavior,
+    but this has not been independently audited; if a future DeepSeek
+    release rejects empty reasoning_content on non-thinking models, this
+    fallback would need a per-call thinking-mode check instead of a blanket
+    inject.  The check is intentionally not gated on model name: this
+    function is only mounted when provider == "deepseek" (see
+    EvoScientist/llm/models.py), so all callers are DeepSeek endpoints.
+
+    Args:
+        model: A langchain-openai ChatOpenAI instance configured for DeepSeek.
+    """
+    import functools
+
+    from langchain_core.messages import AIMessage
+
+    orig = getattr(model, "_get_request_payload", None)
+    if orig is None:
+        return
+
+    import logging as _logging
+
+    _logger = _logging.getLogger(__name__)
+
+    @functools.wraps(orig)
+    def _patched(input_: Any, *, stop: Any = None, **kwargs: Any) -> dict:
+        try:
+            lc_messages = model._convert_input(input_).to_messages()
+        except Exception:
+            _logger.warning(
+                "DeepSeek passback patch: _convert_input failed, "
+                "falling back to unpatched payload (reasoning_content "
+                "will not be injected)",
+                exc_info=True,
+            )
+            return orig(input_, stop=stop, **kwargs)
+
+        ai_rcs: list[str | None] = [
+            m.additional_kwargs.get("reasoning_content")
+            for m in lc_messages
+            if isinstance(m, AIMessage)
+        ]
+
+        payload = orig(input_, stop=stop, **kwargs)
+        msgs = payload.get("messages")
+        if not isinstance(msgs, list):
+            return payload
+
+        ai_idx = 0
+        for msg in msgs:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            rc = ai_rcs[ai_idx] if ai_idx < len(ai_rcs) else None
+            if rc:
+                msg["reasoning_content"] = rc
+            elif "reasoning_content" not in msg:
+                # Empty-string fallback for ALL DeepSeek models (not just
+                # reasoner). Required when history contains AI messages that
+                # came from a different provider (Anthropic / OpenAI /
+                # DeepSeek Flash) or from an older EvoSci that didn't capture
+                # reasoning_content. Empirically tolerated by non-thinking
+                # DeepSeek endpoints; see docstring for the audit caveat.
+                msg["reasoning_content"] = ""
+            ai_idx += 1
+
+        return payload
+
+    model._get_request_payload = _patched
+
+
+# ---------------------------------------------------------------------------
+# Patch: forward CLI's live (model, model_provider) into deepagents'
+# start_async_task / update_async_task tool calls so the deployed graph
+# (running in a separate ``langgraph dev`` subprocess) re-resolves the
+# chat model per run.
+#
+# Without this, async sub-agents stay on the model their graph was compiled
+# with at langgraph dev boot — `/model` switches in the CLI never reach
+# them because they live in another process.
+#
+# Mechanism: wrap deepagents' ``_build_start_tool`` and ``_build_update_tool``
+# factories. Each wrapped factory calls the original with a proxied client
+# cache that intercepts ``runs.create(...)`` calls only and injects
+# ``config={"configurable": {"model": <cfg.model>, "model_provider": <cfg.provider>}}``.
+# All other client methods (``threads.create``, ``runs.get``, ``runs.cancel``,
+# ``runs.join_stream``) pass through unchanged. The deployed graph picks up
+# ``configurable.model`` via ``ConfigurableModelMiddleware``.
+#
+# Reads ``_ensure_config()`` at tool-call time (not patch time) so a
+# ``/model`` switch in the CLI is reflected on the very next async tool
+# call without an agent rebuild.
+#
+# Upstream PR opportunity: passing ``config`` through ``client.runs.create``
+# is generic functionality; worth contributing back to ``langchain-ai/deepagents``
+# so this patch can be retired.
+# ---------------------------------------------------------------------------
+_model_passthrough_patched = False
+
+
+def _read_cfg_configurable() -> dict[str, str]:
+    """Read live ``(model, provider)`` from EvoScientist config.
+
+    Returns a dict suitable for inserting under
+    ``RunnableConfig.configurable``. Empty dict on any failure (so the
+    patch degrades to a no-op rather than breaking async tool calls).
+    """
+    try:
+        from EvoScientist.EvoScientist import _ensure_config
+
+        cfg = _ensure_config()
+    except Exception:
+        return {}
+
+    out: dict[str, str] = {}
+    model = getattr(cfg, "model", None)
+    provider = getattr(cfg, "provider", None)
+    if isinstance(model, str) and model:
+        out["model"] = model
+    if isinstance(provider, str) and provider:
+        out["model_provider"] = provider
+    return out
+
+
+def _merge_runs_config_kwargs(kwargs: dict) -> dict:
+    """Merge the live model override into ``kwargs`` for ``runs.create``.
+
+    Preserves any caller-supplied ``config.configurable`` keys. EvoScientist's
+    keys take precedence on conflict (callers shouldn't be passing model
+    overrides — the CLI is the source of truth).
+    """
+    overrides = _read_cfg_configurable()
+    if not overrides:
+        return kwargs
+    existing = kwargs.get("config")
+    if not isinstance(existing, dict):
+        existing = {}
+    existing_configurable = existing.get("configurable")
+    if not isinstance(existing_configurable, dict):
+        existing_configurable = {}
+    merged_configurable = {**existing_configurable, **overrides}
+    kwargs = dict(kwargs)
+    kwargs["config"] = {**existing, "configurable": merged_configurable}
+    return kwargs
+
+
+class _SyncRunsProxy:
+    """Wraps a sync ``RunsClient`` and injects config into ``create`` only."""
+
+    def __init__(self, real: Any) -> None:
+        object.__setattr__(self, "_real", real)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._real.create(**_merge_runs_config_kwargs(kwargs))
+
+
+class _AsyncRunsProxy:
+    """Wraps an async ``RunsClient`` and injects config into ``create`` only."""
+
+    def __init__(self, real: Any) -> None:
+        object.__setattr__(self, "_real", real)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+    async def create(self, **kwargs: Any) -> Any:
+        return await self._real.create(**_merge_runs_config_kwargs(kwargs))
+
+
+class _ClientProxy:
+    """Lightweight proxy that swaps ``client.runs`` for a runs proxy.
+
+    Read-only forwarding: only ``__getattr__`` is overridden. Attribute
+    *writes* on the proxy land on the proxy itself, NOT on the wrapped real
+    client. Current deepagents only reads ``.threads`` / ``.runs``, so this
+    is safe — but if a future caller tries ``client.foo = bar`` through the
+    proxy, the write will be silently lost. ``object.__setattr__`` in
+    ``__init__`` is used solely to avoid infinite recursion when seeding
+    the internal slots.
+
+    ``client.runs`` is a stable attribute set in
+    ``langgraph_sdk.client.LangGraphClient.__init__`` (``self.runs =
+    RunsClient(...)``) — not a property or lazy initializer — so the wrapped
+    runs proxy is built once at ``__init__`` time and reused on every
+    ``proxy.runs`` access. This avoids the previous behavior of selecting
+    sync/async and instantiating a new ``_RunsProxy`` per attribute access.
+    """
+
+    def __init__(self, real: Any, *, is_async: bool) -> None:
+        runs_proxy_cls = _AsyncRunsProxy if is_async else _SyncRunsProxy
+        object.__setattr__(self, "_real", real)
+        object.__setattr__(self, "_runs_proxy", runs_proxy_cls(real.runs))
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "runs":
+            return self._runs_proxy
+        return getattr(self._real, name)
+
+
+class _ClientCacheProxy:
+    """Proxy a ``_ClientCache`` so callers receive config-injecting clients."""
+
+    def __init__(self, real: Any) -> None:
+        self._real = real
+
+    def get_sync(self, name: str) -> Any:
+        return _ClientProxy(self._real.get_sync(name), is_async=False)
+
+    def get_async(self, name: str) -> Any:
+        return _ClientProxy(self._real.get_async(name), is_async=True)
+
+
+def _patch_deepagents_model_passthrough() -> None:
+    """Wrap deepagents' async-launch tool factories to inject CLI model.
+
+    Idempotent: re-invocation is a no-op once the patch is active. Safe to
+    call from ``_maybe_swap_async_subagents`` on every CLI startup; both
+    that hook and this patch turn on together when async sub-agents are
+    enabled.
+    """
+    global _model_passthrough_patched
+    if _model_passthrough_patched:
+        return
+
+    try:
+        from deepagents.middleware import async_subagents as ds_mod
+    except ImportError:
+        return
+
+    # Defensive ``getattr`` lookups mirror the rest of this file (lines 254,
+    # 266, 279, 290, 339, 351, 362, 373, 473): a deepagents update that
+    # renames or removes either private helper degrades to a no-op instead
+    # of raising ``AttributeError`` at CLI startup.
+    orig_build_start = getattr(ds_mod, "_build_start_tool", None)
+    orig_build_update = getattr(ds_mod, "_build_update_tool", None)
+    if orig_build_start is None or orig_build_update is None:
+        return
+
+    def _patched_build_start(
+        agent_map: Any, clients: Any, tool_description: str
+    ) -> Any:
+        return orig_build_start(agent_map, _ClientCacheProxy(clients), tool_description)
+
+    def _patched_build_update(agent_map: Any, clients: Any) -> Any:
+        return orig_build_update(agent_map, _ClientCacheProxy(clients))
+
+    ds_mod._build_start_tool = _patched_build_start
+    ds_mod._build_update_tool = _patched_build_update
+    _model_passthrough_patched = True

--- a/EvoScientist/stream/events.py
+++ b/EvoScientist/stream/events.py
@@ -603,7 +603,7 @@ def _process_chunk_content(
     if isinstance(content, str):
         if content:
             # Strip ccproxy <thinking>...</thinking> tags from content
-            from ..llm.models import strip_thinking_tags
+            from ..llm.patches import strip_thinking_tags
 
             cleaned = strip_thinking_tags(content)
             if cleaned:


### PR DESCRIPTION
When using DeepSeek models through the `custom-openai` provider (e.g. via OpenCode zen proxy or any OpenAI-compatible proxy), the `reasoning_content` passback patch was skipped because the gate only checked `_original_provider == "deepseek"`.

With `custom-openai`, `_original_provider` is `"custom-openai"`, so the patch was never applied — causing HTTP 400 errors from DeepSeek's API when thinking mode is enabled and the model performs tool calls.

**Fix:** Extend the gate to also apply the patch when `_original_provider == "custom-openai"` **and** the model name contains `"deepseek"`.

---

**Note:** `patches.py` and `context_window.py` were extracted from the installed site-package module (v0.1.0) which already had these patches applied. The `main` branch had these functions inlined in `models.py` — they have been moved to the new module files without behavioral changes. The actual new logic is the DeepSeek passback infrastructure (`_patch_openai_capture_reasoning_content`, `_patch_deepseek_reasoning_passback`) and the `custom-openai` gate extension.