### PR TITLE
chore(minimax): drop M2.5 entries now that M3 is available

### DIFF
--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -111,8 +111,6 @@ _MODEL_ENTRIES: list[tuple[str, str, str]] = [
     ("minimax-m3", "MiniMax-M3", "minimax"),
     ("minimax-m2.7", "MiniMax-M2.7", "minimax"),
     ("minimax-m2.7-highspeed", "MiniMax-M2.7-highspeed", "minimax"),
-    ("minimax-m2.5", "MiniMax-M2.5", "minimax"),
-    ("minimax-m2.5-highspeed", "MiniMax-M2.5-highspeed", "minimax"),
     # NVIDIA
     ("nemotron-super", "nvidia/nemotron-3-super-120b-a12b", "nvidia"),
     ("nemotron-nano", "nvidia/nemotron-3-nano-30b-a3b", "nvidia"),

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -541,7 +541,7 @@ class TestThirdPartyRouting:
         mock_init.return_value = "mock_model"
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-key-123")
 
-        get_chat_model("MiniMax-M2.5", provider="minimax")
+        get_chat_model("MiniMax-M3", provider="minimax")
 
         call_kwargs = mock_init.call_args[1]
         assert call_kwargs["model_provider"] == "anthropic"
@@ -555,7 +555,7 @@ class TestThirdPartyRouting:
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-key-123")
         monkeypatch.setenv("MINIMAX_BASE_URL", "https://api.minimax.io/anthropic")
 
-        get_chat_model("MiniMax-M2.5", provider="minimax")
+        get_chat_model("MiniMax-M3", provider="minimax")
 
         call_kwargs = mock_init.call_args[1]
         assert call_kwargs["base_url"] == "https://api.minimax.io/anthropic"
@@ -566,7 +566,7 @@ class TestThirdPartyRouting:
         mock_init.return_value = "mock_model"
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
 
-        get_chat_model("MiniMax-M2.5", provider="minimax")
+        get_chat_model("MiniMax-M3", provider="minimax")
 
         call_kwargs = mock_init.call_args[1]
         assert "thinking" in call_kwargs
@@ -578,22 +578,22 @@ class TestThirdPartyRouting:
         mock_init.return_value = "mock_model"
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
 
-        get_chat_model("minimax-m2.5", provider="minimax")
+        get_chat_model("minimax-m3", provider="minimax")
 
         call_kwargs = mock_init.call_args[1]
-        assert call_kwargs["model"] == "MiniMax-M2.5"
+        assert call_kwargs["model"] == "MiniMax-M3"
         assert call_kwargs["model_provider"] == "anthropic"
 
     @patch("EvoScientist.llm.models.init_chat_model")
     def test_minimax_highspeed_model(self, mock_init, monkeypatch):
-        """MiniMax M2.5-highspeed model should resolve correctly."""
+        """MiniMax M2.7-highspeed model should resolve correctly."""
         mock_init.return_value = "mock_model"
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
 
-        get_chat_model("minimax-m2.5-highspeed", provider="minimax")
+        get_chat_model("minimax-m2.7-highspeed", provider="minimax")
 
         call_kwargs = mock_init.call_args[1]
-        assert call_kwargs["model"] == "MiniMax-M2.5-highspeed"
+        assert call_kwargs["model"] == "MiniMax-M2.7-highspeed"
         assert call_kwargs["model_provider"] == "anthropic"
         assert call_kwargs["base_url"] == "https://api.minimaxi.com/anthropic"
 
@@ -636,23 +636,21 @@ class TestMiniMaxProvider:
         assert "minimax" not in _OPENAI_ROUTED_PROVIDERS
 
     def test_minimax_models_registered(self):
-        """MiniMax should have 5 direct model entries in _MODEL_ENTRIES."""
+        """MiniMax should have 3 direct model entries in _MODEL_ENTRIES."""
         minimax_models = get_models_for_provider("minimax")
-        assert len(minimax_models) == 5
+        assert len(minimax_models) == 3
         model_names = {name for name, _ in minimax_models}
         assert "minimax-m3" in model_names
         assert "minimax-m2.7" in model_names
         assert "minimax-m2.7-highspeed" in model_names
-        assert "minimax-m2.5" in model_names
-        assert "minimax-m2.5-highspeed" in model_names
 
     def test_minimax_model_ids_correct(self):
         """MiniMax model IDs should match the official API model names."""
         minimax_models = get_models_for_provider("minimax")
         model_dict = dict(minimax_models)
+        assert model_dict["minimax-m3"] == "MiniMax-M3"
         assert model_dict["minimax-m2.7"] == "MiniMax-M2.7"
-        assert model_dict["minimax-m2.5"] == "MiniMax-M2.5"
-        assert model_dict["minimax-m2.5-highspeed"] == "MiniMax-M2.5-highspeed"
+        assert model_dict["minimax-m2.7-highspeed"] == "MiniMax-M2.7-highspeed"
 
     def test_minimax_short_name_in_models_dict(self):
         """MiniMax short names should be accessible via the MODELS dict."""

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -20,17 +20,17 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestMiniMaxIntegration:
-    def test_minimax_m25_chat_completion(self):
-        """Test that MiniMax M2.5 can produce a chat completion."""
-        model = get_chat_model("minimax-m2.5", provider="minimax", temperature=0)
+    def test_minimax_m3_chat_completion(self):
+        """Test that MiniMax M3 can produce a chat completion."""
+        model = get_chat_model("minimax-m3", provider="minimax", temperature=0)
         response = model.invoke("Reply with exactly: hello")
         assert response.content
         assert len(response.content) > 0
 
-    def test_minimax_m25_highspeed_chat_completion(self):
-        """Test that MiniMax M2.5-highspeed can produce a chat completion."""
+    def test_minimax_m27_highspeed_chat_completion(self):
+        """Test that MiniMax M2.7-highspeed can produce a chat completion."""
         model = get_chat_model(
-            "minimax-m2.5-highspeed", provider="minimax", temperature=0
+            "minimax-m2.7-highspeed", provider="minimax", temperature=0
         )
         response = model.invoke("Reply with exactly: world")
         assert response.content
@@ -38,7 +38,7 @@ class TestMiniMaxIntegration:
 
     def test_minimax_with_full_model_id(self):
         """Test using the full model ID directly."""
-        model = get_chat_model("MiniMax-M2.5", provider="minimax", temperature=0)
+        model = get_chat_model("MiniMax-M3", provider="minimax", temperature=0)
         response = model.invoke("What is 2+2? Answer with just the number.")
         assert response.content
         assert "4" in response.content


### PR DESCRIPTION
## Summary

Now that `MiniMax-M3` is the current-generation minimax model (added in d53bfa3) and `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` cover the previous generation, the older `MiniMax-M2.5` SKUs in the minimax direct-provider registry just add noise to the model picker without offering capabilities not already available through M3 or M2.7.

This PR removes the two `M2.5` entries from the `minimax` section of `_MODEL_ENTRIES` and updates the affected tests.

## Changes

- `EvoScientist/llm/models.py`: drop `MiniMax-M2.5` and `MiniMax-M2.5-highspeed` from the `minimax` direct-API block. The `nvidia` and `siliconflow` rows that also reference `minimax-m2.5` upstream are left as-is — they belong to other providers and still ship the SKU.
- `tests/test_llm.py`:
  - `TestMiniMaxProvider::test_minimax_models_registered` now expects 3 direct entries (M3, M2.7, M2.7-highspeed) instead of 5.
  - `TestMiniMaxProvider::test_minimax_model_ids_correct` swaps the M2.5 assertions for M3 / M2.7-highspeed.
  - The four `TestThirdPartyRouting` cases that hard-coded `MiniMax-M2.5` / `minimax-m2.5` use `MiniMax-M3` / `minimax-m3` instead; `test_minimax_highspeed_model` switches to `M2.7-highspeed`.
- `tests/test_minimax_integration.py`: swap the three M2.5 live-API smoke tests over to M3 so the (skipped-without-key) suite exercises the new default.

## Verification

```
$ python -m pytest tests/test_llm.py::TestMiniMaxProvider tests/test_llm.py::TestThirdPartyRouting -v
============================== 22 passed in 2.30s ==============================

$ python -m pytest tests/test_minimax_integration.py -v
============================== 4 skipped in 2.10s ==============================  # MINIMAX_API_KEY not set

$ ruff check EvoScientist/llm/models.py tests/test_llm.py tests/test_minimax_integration.py
All checks passed!
```

Note: `pytest` and `ruff check .` both run cleanly across the touched files; the wider suite was not exercised here because `uv sync --dev` was blocked on cache locks in this environment, but the changes are scoped to the minimax registry plus its own tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Minimax-M3, Minimax-M2.7, and Minimax-M2.7-highspeed models; removed Minimax-M2.5 variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->