### PR TITLE
refactor(agent): make create_cli_agent(config=, chat_model=) pure

### DIFF
--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -68,16 +68,50 @@ _EvoScientist_agent = None
 # =============================================================================
 
 
+def set_active_config(cfg) -> None:
+    """Commit *cfg* as the active module config.
+
+    Public commit path for callers (e.g. ``/model``) that built an agent on
+    the pure ``create_cli_agent(config=..., chat_model=...)`` path and now
+    want it to become the session-wide active config.  This is the write half
+    of ``_ensure_config(cfg)`` extracted so the pure path can defer the commit
+    until the agent has been built successfully.
+    """
+    global _config
+    _config = cfg
+    apply_config_to_env(cfg)
+
+
+def _apply_env_from_config(cfg) -> None:
+    """Apply *cfg*'s API-key env vars without caching it as ``_config``.
+
+    ``apply_config_to_env`` is set-if-unset (guards on ``not
+    os.environ.get(...)``), so this is idempotent and safe to call on the pure
+    path, where no module globals may be written.
+    """
+    apply_config_to_env(cfg)
+
+
 def _ensure_config(config=None):
     """Return cached config.  If *config* is passed, cache and use it."""
-    global _config
     if config is not None:
-        _config = config
-        apply_config_to_env(_config)
+        set_active_config(config)
     if _config is None:
-        _config = get_effective_config()
-        apply_config_to_env(_config)
+        set_active_config(get_effective_config())
     return _config
+
+
+def _build_chat_model(cfg):
+    """Build a chat model from *cfg* without writing any module globals.
+
+    Pure-construction counterpart to ``_ensure_chat_model``: used by ``/model``
+    to verify a switch before committing, and threaded into
+    ``create_cli_agent(chat_model=...)`` so the new agent binds the requested
+    model without touching the cached ``_chat_model``.
+    """
+    from .llm import get_chat_model
+
+    return get_chat_model(model=cfg.model, provider=cfg.provider)
 
 
 def _replace_chat_model(instance, key: tuple[str | None, str | None]) -> None:
@@ -105,15 +139,10 @@ def _ensure_chat_model():
     into the new agent without requiring callers to interleave
     ``set_chat_model()`` calls in any particular order.
     """
-    from .llm import get_chat_model
-
     cfg = _ensure_config()
     key = (cfg.model, cfg.provider)
     if _chat_model is None or _chat_model_key != key:
-        _replace_chat_model(
-            get_chat_model(model=cfg.model, provider=cfg.provider),
-            key,
-        )
+        _replace_chat_model(_build_chat_model(cfg), key)
     return _chat_model
 
 
@@ -133,6 +162,18 @@ def set_chat_model(model: str, provider: str | None = None):
     if _chat_model is None or _chat_model_key != key:
         _replace_chat_model(get_chat_model(model=model, provider=provider), key)
     return _chat_model
+
+
+def set_chat_model_instance(instance, key: tuple[str | None, str | None]) -> None:
+    """Commit an already-built chat model *instance* as the active model.
+
+    Companion to ``set_active_config`` for the pure path: installs a model that
+    ``_build_chat_model`` already constructed (e.g. during a ``/model`` verify)
+    without rebuilding it, keeping ``_chat_model`` / ``_chat_model_key`` /
+    ``_EvoScientist_agent`` in sync via ``_replace_chat_model``.  Unlike
+    ``set_chat_model``, the caller owns the ``(model, provider)`` *key*.
+    """
+    _replace_chat_model(instance, key)
 
 
 # =============================================================================
@@ -186,12 +227,16 @@ def _load_mcp_tools_cached(on_progress=None) -> dict[str, list]:
 # =============================================================================
 
 
-def _inject_subagent_middleware(subs: list[dict]) -> None:
+def _inject_subagent_middleware(subs: list[dict], *, chat_model=None) -> None:
     """Ensure every subagent gets error handling and context management middleware.
 
     Without this, subagent tool errors are caught by LangGraph's default
     ToolNode handler which produces terse messages without tracebacks or
     retry guidance — reducing the subagent's ability to self-recover.
+
+    *chat_model*, when provided, is forwarded to the subagents'
+    ``create_context_editing_middleware`` so the pure ``create_cli_agent``
+    path doesn't fall back to the global-writing ``_ensure_chat_model()``.
     """
     from .middleware import (
         ContextOverflowMapperMiddleware,
@@ -203,9 +248,10 @@ def _inject_subagent_middleware(subs: list[dict]) -> None:
     for sa in subs:
         sa.setdefault("middleware", []).extend(
             [
-                # No ``model=`` — subagents share the main agent's model,
-                # so defer to the factory's ``_ensure_chat_model()`` fallback.
-                create_context_editing_middleware(),
+                # Subagents share the main agent's model: use the threaded
+                # ``chat_model`` on the pure path, else defer to the factory's
+                # ``_ensure_chat_model()`` fallback (when ``chat_model=None``).
+                create_context_editing_middleware(chat_model),
                 create_runtime_context_middleware(),
                 ToolErrorHandlerMiddleware(),
                 ContextOverflowMapperMiddleware(),
@@ -213,7 +259,9 @@ def _inject_subagent_middleware(subs: list[dict]) -> None:
         )
 
 
-def _maybe_swap_async_subagents(subs: list, middleware: list | None = None) -> list:
+def _maybe_swap_async_subagents(
+    subs: list, middleware: list | None = None, *, cfg=None
+) -> list:
     """Replace ``_async``-flagged sub-agents with ``AsyncSubAgent`` specs when enabled.
 
     Reads the ``_async`` field carried through by ``utils.load_subagents._build_one``
@@ -235,7 +283,7 @@ def _maybe_swap_async_subagents(subs: list, middleware: list | None = None) -> l
     appends ``AsyncWatcherMiddleware`` so launches spawn an
     ``async_notifier`` watcher.
     """
-    cfg = _ensure_config()
+    cfg = cfg if cfg is not None else _ensure_config()
     if not getattr(cfg, "enable_async_subagents", False):
         # Async fully disabled — strip the internal flag before handoff.
         for s in subs:
@@ -312,7 +360,7 @@ def _maybe_swap_async_subagents(subs: list, middleware: list | None = None) -> l
     return out
 
 
-def _build_base_kwargs(base_backend, base_middleware):
+def _build_base_kwargs(base_backend, base_middleware, *, cfg=None, chat_model=None):
     """Build agent kwargs *without* MCP (fast, no subprocess spawning)."""
     from .tools import skill_manager, tavily_search, think_tool
     from .utils import load_subagents
@@ -326,11 +374,11 @@ def _build_base_kwargs(base_backend, base_middleware):
         SUBAGENTS_CONFIG,
         tool_registry=tool_registry,
     )
-    _inject_subagent_middleware(subs)
-    subs = _maybe_swap_async_subagents(subs, base_middleware)
+    _inject_subagent_middleware(subs, chat_model=chat_model)
+    subs = _maybe_swap_async_subagents(subs, base_middleware, cfg=cfg)
     return {
         "name": "EvoScientist",
-        "model": _ensure_chat_model(),
+        "model": chat_model if chat_model is not None else _ensure_chat_model(),
         "tools": list(base_tools),
         "backend": base_backend,
         "subagents": subs,
@@ -340,7 +388,9 @@ def _build_base_kwargs(base_backend, base_middleware):
     }
 
 
-def load_mcp_and_build_kwargs(base_backend, base_middleware, *, on_mcp_progress=None):
+def load_mcp_and_build_kwargs(
+    base_backend, base_middleware, *, on_mcp_progress=None, cfg=None, chat_model=None
+):
     """Load MCP tools (cached by config) and build agent kwargs.
 
     Re-connects to MCP servers only when the effective MCP config changes.
@@ -349,13 +399,19 @@ def load_mcp_and_build_kwargs(base_backend, base_middleware, *, on_mcp_progress=
     Args:
         on_mcp_progress: Optional per-server progress callback.  Forwarded
             to the MCP loader so UIs can render live status.
+        cfg: Explicit config to thread through instead of reading the cached
+            ``_config``.  Used by the pure ``create_cli_agent`` path.
+        chat_model: Explicit chat model to bind instead of
+            ``_ensure_chat_model()`` (which would write module globals).
     """
     from .tools import skill_manager, tavily_search, think_tool
     from .utils import load_subagents
 
     mcp_by_agent = _load_mcp_tools_cached(on_progress=on_mcp_progress)
     if not mcp_by_agent:
-        return _build_base_kwargs(base_backend, base_middleware)
+        return _build_base_kwargs(
+            base_backend, base_middleware, cfg=cfg, chat_model=chat_model
+        )
 
     tool_registry = {"think_tool": think_tool}
     if os.environ.get("TAVILY_API_KEY"):
@@ -375,7 +431,7 @@ def load_mcp_and_build_kwargs(base_backend, base_middleware, *, on_mcp_progress=
         tool_registry=registry,
     )
 
-    _inject_subagent_middleware(subs)
+    _inject_subagent_middleware(subs, chat_model=chat_model)
 
     # Inject MCP tools into subagents by name
     for sa in subs:
@@ -384,11 +440,11 @@ def load_mcp_and_build_kwargs(base_backend, base_middleware, *, on_mcp_progress=
 
     # Swap selected sub-agents to AsyncSubAgent (must happen AFTER MCP injection
     # since async sub-agents are remote graphs that load their own tools).
-    subs = _maybe_swap_async_subagents(subs, base_middleware)
+    subs = _maybe_swap_async_subagents(subs, base_middleware, cfg=cfg)
 
     return {
         "name": "EvoScientist",
-        "model": _ensure_chat_model(),
+        "model": chat_model if chat_model is not None else _ensure_chat_model(),
         "tools": base_tools + mcp_main,
         "backend": base_backend,
         "subagents": subs,
@@ -443,6 +499,8 @@ def _get_default_middleware(
     *,
     for_async_subagent: bool = False,
     workspace_dir: str | Path | None = None,
+    cfg=None,
+    chat_model=None,
 ):
     """Build the default middleware list.
 
@@ -457,6 +515,9 @@ def _get_default_middleware(
             ``subagents/_factory.py`` deliberately skips ``interrupt_on=`` on
             the deepagents level. Defaults to False (full middleware list)
             for the CLI's in-process agent.
+        cfg: Explicit config to use instead of the cached ``_config``.
+        chat_model: Explicit model to bind instead of ``_ensure_chat_model()``
+            (avoids writing module globals on the pure path).
     """
     from .middleware import (
         ConfigurableModelMiddleware,
@@ -471,10 +532,10 @@ def _get_default_middleware(
         load_fallback_chain,
     )
 
-    cfg = _ensure_config()
+    cfg = cfg if cfg is not None else _ensure_config()
     if cfg.model_fallbacks:
         load_fallback_chain(cfg.model_fallbacks)
-    model = _ensure_chat_model()
+    model = chat_model if chat_model is not None else _ensure_chat_model()
     memory_dir = str(_paths_mod.MEMORIES_DIR)
     # ``ConfigurableModelMiddleware`` is placed first so it wraps
     # ``ModelFallbackMiddleware``: a configurable.model override sets the
@@ -588,6 +649,7 @@ def create_cli_agent(
     workspace_dir: str | None = None,
     checkpointer=None,
     config=None,
+    chat_model=None,
     *,
     on_mcp_progress=None,
 ):
@@ -597,6 +659,14 @@ def create_cli_agent(
     ``paths.WORKSPACE_ROOT`` (or the explicit *workspace_dir*), so
     runtime ``set_workspace_root()`` changes are always respected.
 
+    **Pure path:** when *both* ``config`` and ``chat_model`` are explicit, this
+    writes none of the cached config/model module globals (``_config``,
+    ``_chat_model``, ``_chat_model_key``, ``_EvoScientist_agent``) — the agent
+    is built purely from the passed-in locals.  The caller commits the switch
+    on success via ``set_active_config`` / ``set_chat_model_instance`` (see
+    ``/model``).  Otherwise the existing module-global path runs (langgraph
+    dev, notebooks, and CLI startup, which pass ``config=`` only).
+
     Args:
         workspace_dir: Per-session workspace directory. If ``None``,
             defaults to the current ``paths.WORKSPACE_ROOT``.
@@ -605,6 +675,9 @@ def create_cli_agent(
         config: Optional pre-loaded ``EvoScientistConfig``.  If ``None``,
             loads from file/env/defaults.  Passing this avoids double
             loading when the CLI has already loaded config.
+        chat_model: Optional pre-built chat model.  Only triggers the pure
+            path when ``config`` is also explicit; otherwise it is ignored in
+            favor of the ``_ensure_chat_model()`` fallback.
     """
     import os as _os
 
@@ -614,7 +687,16 @@ def create_cli_agent(
     from . import paths as _paths
     from .backends import CustomSandboxBackend, MergedSkillsBackend
 
-    cfg = _ensure_config(config)
+    # Pure path only when BOTH config and chat_model are explicit: build from
+    # locals and write no module globals. Otherwise keep the legacy
+    # global-writing behavior — callers that pass config= only (CLI startup,
+    # langgraph dev) rely on it to seat the active config/model.
+    if config is not None and chat_model is not None:
+        cfg = config
+        _apply_env_from_config(cfg)
+    else:
+        cfg = _ensure_config(config)
+        chat_model = None
 
     if checkpointer is None:
         from langgraph.checkpoint.memory import InMemorySaver
@@ -665,7 +747,9 @@ def create_cli_agent(
     # Delegate middleware construction to the single source of truth so the
     # CLI agent never drifts from the default chain. Anything CLI-specific
     # (e.g. ``HumanInTheLoopMiddleware``) is appended below.
-    mw: list[AgentMiddleware] = _get_default_middleware(workspace_dir=workspace_dir)
+    mw: list[AgentMiddleware] = _get_default_middleware(
+        workspace_dir=workspace_dir, cfg=cfg, chat_model=chat_model
+    )
 
     # HITL on main agent only — passing `interrupt_on=` to create_deep_agent
     # would propagate it to every subagent, breaking parallel execute calls
@@ -678,7 +762,9 @@ def create_cli_agent(
         )
 
     # Re-load MCP tools from current config (picks up /mcp add changes)
-    kwargs = load_mcp_and_build_kwargs(be, mw, on_mcp_progress=on_mcp_progress)
+    kwargs = load_mcp_and_build_kwargs(
+        be, mw, on_mcp_progress=on_mcp_progress, cfg=cfg, chat_model=chat_model
+    )
 
     return create_deep_agent(
         **kwargs,

--- a/EvoScientist/cli/agent.py
+++ b/EvoScientist/cli/agent.py
@@ -62,6 +62,7 @@ def _load_agent(
     workspace_dir: str | None = None,
     checkpointer=None,
     config=None,
+    chat_model=None,
     *,
     on_mcp_progress=None,
 ):
@@ -73,6 +74,9 @@ def _load_agent(
             Falls back to ``InMemorySaver`` when ``None``.
         config: Optional pre-loaded ``EvoScientistConfig``.  Forwarded to
             ``create_cli_agent`` to avoid double config loading.
+        chat_model: Optional pre-built chat model.  Forwarded to
+            ``create_cli_agent``; combined with an explicit ``config`` it
+            selects the pure (no module-global write) build path.
         on_mcp_progress: Optional per-server MCP progress callback.
             Signature ``(event, server_name, detail) -> None``.
     """
@@ -82,5 +86,6 @@ def _load_agent(
         workspace_dir=workspace_dir,
         checkpointer=checkpointer,
         config=config,
+        chat_model=chat_model,
         on_mcp_progress=on_mcp_progress,
     )

--- a/EvoScientist/commands/implementation/model.py
+++ b/EvoScientist/commands/implementation/model.py
@@ -143,71 +143,43 @@ class ModelCommand(Command):
     ) -> None:
         import copy
 
-        from ... import EvoScientist as _mod
         from ...cli.agent import _load_agent
-        from ...EvoScientist import _ensure_config, set_chat_model
+        from ...EvoScientist import (
+            _build_chat_model,
+            _ensure_config,
+            set_active_config,
+            set_chat_model_instance,
+        )
 
         cfg = _ensure_config()
 
-        # Build a temporary config to verify the agent can be created
-        # before mutating any global state.
+        # Build a temporary config + its chat model and verify the agent can be
+        # built before committing anything. ``create_cli_agent(config=...,
+        # chat_model=...)`` is pure (issue #183) — it writes none of the cached
+        # config/model module globals — so a failure below leaves the session
+        # on the original model with no snapshot/restore needed.
         temp_cfg = copy.copy(cfg)
         temp_cfg.model = model_name
         temp_cfg.provider = provider
 
-        # create_cli_agent(config=temp_cfg) calls _ensure_config and
-        # _ensure_chat_model before finishing, so a failure further
-        # down (middleware build, MCP reconnect, deepagents wiring)
-        # would leave the session pointing at the new model. Snapshot
-        # the four globals those helpers write so we can restore on
-        # error. Best-effort: references already captured by concurrent
-        # readers (e.g. a channel thread mid-turn) are not retroactively
-        # patched, but /model is user-initiated from an idle prompt in
-        # practice.
-        snap = (
-            _mod._config,
-            _mod._chat_model,
-            _mod._chat_model_key,
-            _mod._EvoScientist_agent,
-        )
-
-        def _restore_globals() -> None:
-            """Roll back the four module globals to their pre-call values.
-
-            Keeps the two failure sites (``_load_agent`` and
-            ``set_chat_model``) in sync — adding a new snapshotted global
-            only requires updating ``snap`` and this helper.
-            """
-            (
-                _mod._config,
-                _mod._chat_model,
-                _mod._chat_model_key,
-                _mod._EvoScientist_agent,
-            ) = snap
-
         try:
+            new_chat_model = _build_chat_model(temp_cfg)
             new_agent = _load_agent(
                 workspace_dir=ctx.workspace_dir,
                 checkpointer=ctx.checkpointer,
                 config=temp_cfg,
+                chat_model=new_chat_model,
             )
         except Exception as e:
-            _restore_globals()
             ctx.ui.append_system(f"Failed to switch model: {e}", style="red")
             return
 
-        # Agent built successfully — now commit the change globally.
-        try:
-            set_chat_model(model_name, provider=provider)
-        except Exception as e:
-            # _load_agent already mutated the four globals; restore them so a
-            # failure here doesn't leave the session half-switched.
-            _restore_globals()
-            ctx.ui.append_system(f"Failed to switch model: {e}", style="red")
-            return
-
-        cfg.model = model_name
-        cfg.provider = provider
+        # Agent built with no global mutation — commit the switch atomically.
+        # These are pure assignments and cannot fail, so the session can never
+        # be left half-switched. ``temp_cfg`` (not the original ``cfg``) becomes
+        # the active config; nothing depends on the old config object identity.
+        set_active_config(temp_cfg)
+        set_chat_model_instance(new_chat_model, (model_name, provider))
         ctx.agent = new_agent
 
         # Persist to config file if --save was given

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -150,9 +150,9 @@ class TestModelCommandSwitch:
                 "EvoScientist.EvoScientist._ensure_config",
                 return_value=cfg,
             ),
-            patch(
-                "EvoScientist.EvoScientist.set_chat_model",
-            ),
+            patch("EvoScientist.EvoScientist._build_chat_model"),
+            patch("EvoScientist.EvoScientist.set_active_config") as set_cfg,
+            patch("EvoScientist.EvoScientist.set_chat_model_instance"),
             patch(
                 "EvoScientist.cli.agent._load_agent",
                 return_value=new_agent,
@@ -160,9 +160,12 @@ class TestModelCommandSwitch:
         ):
             _run(cmd.execute(ctx, ["claude-opus-4-8"]))
 
-        # Config should be updated
-        assert cfg.model == "claude-opus-4-8"
-        assert cfg.provider == "anthropic"
+        # The switch is committed via set_active_config(temp_cfg), not by
+        # mutating the original cfg object in place.
+        set_cfg.assert_called_once()
+        committed = set_cfg.call_args[0][0]
+        assert committed.model == "claude-opus-4-8"
+        assert committed.provider == "anthropic"
 
         # Agent should be replaced on context
         assert ctx.agent == new_agent
@@ -191,7 +194,9 @@ class TestModelCommandSwitch:
                 "EvoScientist.EvoScientist._ensure_config",
                 return_value=cfg,
             ),
-            patch("EvoScientist.EvoScientist.set_chat_model"),
+            patch("EvoScientist.EvoScientist._build_chat_model"),
+            patch("EvoScientist.EvoScientist.set_active_config"),
+            patch("EvoScientist.EvoScientist.set_chat_model_instance"),
             patch(
                 "EvoScientist.cli.agent._load_agent",
                 return_value=MagicMock(),
@@ -226,7 +231,9 @@ class TestModelCommandSwitch:
                 "EvoScientist.EvoScientist._ensure_config",
                 return_value=cfg,
             ),
-            patch("EvoScientist.EvoScientist.set_chat_model"),
+            patch("EvoScientist.EvoScientist._build_chat_model"),
+            patch("EvoScientist.EvoScientist.set_active_config"),
+            patch("EvoScientist.EvoScientist.set_chat_model_instance"),
             patch(
                 "EvoScientist.cli.agent._load_agent",
                 return_value=MagicMock(),
@@ -244,9 +251,9 @@ class TestModelCommandSwitch:
 
 
 class TestModelCommandFailure:
-    """Verify error handling when set_chat_model raises."""
+    """Verify error handling when chat-model construction raises."""
 
-    def test_set_chat_model_error(self):
+    def test_build_chat_model_error(self):
         from EvoScientist.commands.implementation.model import ModelCommand
 
         cmd = ModelCommand()
@@ -265,17 +272,13 @@ class TestModelCommandFailure:
                 return_value=cfg,
             ),
             patch(
-                "EvoScientist.cli.agent._load_agent",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "EvoScientist.EvoScientist.set_chat_model",
+                "EvoScientist.EvoScientist._build_chat_model",
                 side_effect=RuntimeError("API key missing"),
-            ) as mock_set,
+            ) as mock_build,
         ):
             _run(cmd.execute(ctx, ["claude-opus-4-8"]))
 
-        mock_set.assert_called_once()
+        mock_build.assert_called_once()
         ui.append_system.assert_called_once()
         call_args = ui.append_system.call_args
         assert "Failed to switch model" in call_args[0][0]
@@ -429,18 +432,18 @@ class TestEnsureChatModelCacheInvalidation:
 
 
 class TestApplyModelIntegration:
-    """End-to-end regression for #179: `_apply_model` must produce an agent
-    bound to the NEW model, not a stale cached one.
+    """End-to-end regression for #179 + #183: `_apply_model` must produce an
+    agent bound to the NEW model, threaded in via the pure ``create_cli_agent``
+    path.
 
     Exercises the real chain:
-        ``_apply_model → _load_agent → _ensure_config → _ensure_chat_model``
+        ``_apply_model → _build_chat_model → _load_agent(chat_model=...) →
+        set_active_config / set_chat_model_instance``
 
-    Only ``_load_agent`` is replaced by a minimal fake that mirrors the
-    exact two globals ``create_cli_agent`` mutates (``_ensure_config``
-    + ``_ensure_chat_model``) — so the bug path is fully exercised
-    without having to spin up deepagents, MCP tools, middleware, and
-    subagent YAML. ``get_chat_model`` returns a distinct sentinel per
-    ``(model, provider)`` pair so we can assert on identity.
+    Only ``_load_agent`` is faked (to avoid spinning up deepagents, MCP tools,
+    middleware, and subagent YAML); it binds the ``chat_model`` it receives.
+    ``get_chat_model`` returns a distinct sentinel per ``(model, provider)``
+    pair so we can assert on identity.
     """
 
     def test_new_agent_is_bound_to_newly_selected_model(self, evo_module_state):
@@ -460,14 +463,17 @@ class TestApplyModelIntegration:
             return sentinels[key]
 
         def _fake_load_agent(
-            workspace_dir=None, checkpointer=None, config=None, *, on_mcp_progress=None
+            workspace_dir=None,
+            checkpointer=None,
+            config=None,
+            chat_model=None,
+            *,
+            on_mcp_progress=None,
         ):
-            # Replicates the two create_cli_agent side effects that
-            # reveal the bug: ``_ensure_config`` writes the new cfg,
-            # then ``_ensure_chat_model`` must rebuild to match it.
-            mod._ensure_config(config)
+            # The pure path threads the freshly built chat model in; bind it
+            # directly instead of re-deriving via _ensure_chat_model.
             agent = MagicMock(name="fake-agent")
-            agent._bound_model = mod._ensure_chat_model()
+            agent._bound_model = chat_model
             return agent
 
         cfg = EvoScientistConfig(model="claude-sonnet-4-6", provider="anthropic")
@@ -499,16 +505,18 @@ class TestApplyModelIntegration:
             _run(cmd._apply_model(ctx, "minimax-m2.7", "openrouter"))
 
         # The agent produced by _apply_model must be bound to the
-        # NEWLY requested model, not the previously cached one.
+        # NEWLY requested model, threaded in via chat_model=.
         assert ctx.agent._bound_model is not old_model
         assert ctx.agent._bound_model._bound_model == "minimax-m2.7"
         assert ctx.agent._bound_model._bound_provider == "openrouter"
 
-        # Global state reflects the switch end-to-end.
+        # Global state reflects the switch end-to-end, committed via the setters.
         assert mod._chat_model_key == ("minimax-m2.7", "openrouter")
         assert mod._chat_model is sentinels[("minimax-m2.7", "openrouter")]
-        assert cfg.model == "minimax-m2.7"
-        assert cfg.provider == "openrouter"
+        # The committed temp_cfg became the active config; the original cfg
+        # object is no longer mutated in place.
+        assert mod._config.model == "minimax-m2.7"
+        assert mod._config.provider == "openrouter"
 
         # User-visible success message.
         msg = ctx.ui.append_system.call_args[0][0]
@@ -544,13 +552,17 @@ class TestModelCommandLoadAgentFailure:
                 "EvoScientist.EvoScientist._ensure_config",
                 return_value=cfg,
             ),
+            patch("EvoScientist.EvoScientist._build_chat_model"),
             patch(
                 "EvoScientist.cli.agent._load_agent",
                 side_effect=RuntimeError("agent build failed"),
             ) as mock_load,
             patch(
-                "EvoScientist.EvoScientist.set_chat_model",
-            ) as mock_set,
+                "EvoScientist.EvoScientist.set_active_config",
+            ) as mock_set_cfg,
+            patch(
+                "EvoScientist.EvoScientist.set_chat_model_instance",
+            ) as mock_set_model,
             patch(
                 "EvoScientist.config.settings.set_config_value",
             ) as mock_save,
@@ -562,8 +574,9 @@ class TestModelCommandLoadAgentFailure:
 
         # _load_agent was attempted (transactional first step).
         mock_load.assert_called_once()
-        # Downstream side-effects must NOT have happened.
-        mock_set.assert_not_called()
+        # Commit setters and downstream side-effects must NOT have happened.
+        mock_set_cfg.assert_not_called()
+        mock_set_model.assert_not_called()
         mock_save.assert_not_called()
         # Config must be untouched.
         assert cfg.model == "claude-sonnet-4-6"
@@ -576,46 +589,38 @@ class TestModelCommandLoadAgentFailure:
 
 
 class TestApplyModelLoadAgentFailureTransactional:
-    """Regression: if ``create_cli_agent`` raises AFTER partially mutating
-    module globals via ``_ensure_config`` + ``_ensure_chat_model``,
-    ``_apply_model`` must roll those back so the session stays on the
-    original model.
+    """Regression for #183: when agent construction fails, the session stays on
+    the original model with no snapshot/restore.
 
-    Complements :class:`TestModelCommandLoadAgentFailure`, which tests
-    the early-failure path where ``_load_agent`` never reaches
-    ``create_cli_agent`` and no globals get mutated.
+    Because ``create_cli_agent(config=..., chat_model=...)`` is now pure — it
+    writes none of the four config/model globals — and ``_apply_model`` commits
+    only after a successful build, a failing ``_load_agent`` leaves all four
+    globals untouched. This replaces the old snapshot/restore rollback test.
+
+    Complements :class:`TestModelCommandLoadAgentFailure`, which asserts the
+    downstream setters never run on failure.
     """
 
-    def test_globals_restored_after_create_cli_agent_partial_mutation(
-        self, evo_module_state
-    ):
+    def test_globals_unchanged_when_load_agent_raises(self, evo_module_state):
         from EvoScientist.commands.implementation.model import ModelCommand
         from EvoScientist.config.settings import EvoScientistConfig
 
         mod = evo_module_state
-        sentinels: dict[tuple[str, str | None], MagicMock] = {}
-
-        def _fake_get_chat_model(model, provider=None):
-            key = (model, provider)
-            sentinels.setdefault(key, MagicMock(name=f"chat_model[{model}|{provider}]"))
-            return sentinels[key]
 
         def _fake_load_agent(
             workspace_dir=None,
             checkpointer=None,
             config=None,
+            chat_model=None,
             *,
             on_mcp_progress=None,
         ):
-            # Mimic ``create_cli_agent``: mutate globals via
-            # ``_ensure_config`` + ``_ensure_chat_model``, then raise
-            # (as if middleware construction or deepagents wiring failed).
-            mod._ensure_config(config)
-            mod._ensure_chat_model()
+            # The pure path writes no globals; mimic a failure partway through
+            # agent wiring (middleware build, deepagents, MCP reconnect, ...).
             raise RuntimeError("middleware build failed")
 
         cfg = EvoScientistConfig(model="claude-sonnet-4-6", provider="anthropic")
-        old_model = _fake_get_chat_model("claude-sonnet-4-6", "anthropic")
+        old_model = MagicMock(name="old-model")
         old_agent = MagicMock(name="old-default-agent")
 
         mod._config = cfg
@@ -631,8 +636,8 @@ class TestApplyModelLoadAgentFailureTransactional:
 
         with (
             patch(
-                "EvoScientist.llm.get_chat_model",
-                side_effect=_fake_get_chat_model,
+                "EvoScientist.EvoScientist._build_chat_model",
+                return_value=MagicMock(name="new-model"),
             ),
             patch(
                 "EvoScientist.cli.agent._load_agent",
@@ -642,95 +647,12 @@ class TestApplyModelLoadAgentFailureTransactional:
             cmd = ModelCommand()
             _run(cmd._apply_model(ctx, "minimax-m2.7", "openrouter"))
 
-        # All four globals restored to their pre-call state.
+        # All four globals are unchanged — nothing was committed.
         assert mod._config is cfg
         assert mod._chat_model is old_model
         assert mod._chat_model_key == ("claude-sonnet-4-6", "anthropic")
         assert mod._EvoScientist_agent is old_agent
         # The ``cfg`` object itself was not mutated.
-        assert cfg.model == "claude-sonnet-4-6"
-        assert cfg.provider == "anthropic"
-        # User sees an error message.
-        msg = ctx.ui.append_system.call_args[0][0]
-        assert "Failed to switch model" in msg
-
-
-class TestApplyModelSetChatModelFailureTransactional:
-    """Regression (CodeRabbit review on PR #187): if ``set_chat_model``
-    raises *after* ``_load_agent`` has already mutated module globals,
-    those globals must be restored. Without the rollback the session
-    ends up half-switched — new ``_config`` / ``_chat_model`` committed,
-    but no successful agent to back them.
-
-    Complements :class:`TestApplyModelLoadAgentFailureTransactional`
-    which covers the earlier failure site.
-    """
-
-    def test_globals_restored_when_set_chat_model_raises(self, evo_module_state):
-        from EvoScientist.commands.implementation.model import ModelCommand
-        from EvoScientist.config.settings import EvoScientistConfig
-
-        mod = evo_module_state
-        sentinels: dict[tuple[str, str | None], MagicMock] = {}
-
-        def _fake_get_chat_model(model, provider=None):
-            key = (model, provider)
-            sentinels.setdefault(key, MagicMock(name=f"chat_model[{model}|{provider}]"))
-            return sentinels[key]
-
-        def _fake_load_agent(
-            workspace_dir=None,
-            checkpointer=None,
-            config=None,
-            *,
-            on_mcp_progress=None,
-        ):
-            # Mimic the real ``create_cli_agent``: mutate globals via
-            # ``_ensure_config`` + ``_ensure_chat_model``, then succeed.
-            mod._ensure_config(config)
-            mod._ensure_chat_model()
-            return MagicMock(name="new-agent")
-
-        cfg = EvoScientistConfig(model="claude-sonnet-4-6", provider="anthropic")
-        old_model = _fake_get_chat_model("claude-sonnet-4-6", "anthropic")
-        old_agent = MagicMock(name="old-default-agent")
-
-        mod._config = cfg
-        mod._chat_model = old_model
-        mod._chat_model_key = ("claude-sonnet-4-6", "anthropic")
-        mod._EvoScientist_agent = old_agent
-
-        ctx = MagicMock()
-        ctx.ui = MagicMock()
-        ctx.ui.supports_interactive = True
-        ctx.workspace_dir = "/tmp/test_rollback_set"
-        ctx.checkpointer = None
-
-        with (
-            patch(
-                "EvoScientist.llm.get_chat_model",
-                side_effect=_fake_get_chat_model,
-            ),
-            patch(
-                "EvoScientist.cli.agent._load_agent",
-                side_effect=_fake_load_agent,
-            ),
-            patch(
-                "EvoScientist.EvoScientist.set_chat_model",
-                side_effect=RuntimeError("API key missing at commit step"),
-            ),
-        ):
-            cmd = ModelCommand()
-            _run(cmd._apply_model(ctx, "minimax-m2.7", "openrouter"))
-
-        # All four globals restored — the new agent was built, but the
-        # commit step (set_chat_model) failed, so the session must remain
-        # on the original model.
-        assert mod._config is cfg
-        assert mod._chat_model is old_model
-        assert mod._chat_model_key == ("claude-sonnet-4-6", "anthropic")
-        assert mod._EvoScientist_agent is old_agent
-        # cfg itself must not have been mutated (happens after the commit).
         assert cfg.model == "claude-sonnet-4-6"
         assert cfg.provider == "anthropic"
         # User sees an error message.
@@ -922,7 +844,9 @@ class TestModelCommandOllamaPicker:
                 "EvoScientist.llm.ollama_discovery.discover_ollama_models",
                 side_effect=fake_discover,
             ),
-            patch("EvoScientist.EvoScientist.set_chat_model"),
+            patch("EvoScientist.EvoScientist._build_chat_model"),
+            patch("EvoScientist.EvoScientist.set_active_config") as set_cfg,
+            patch("EvoScientist.EvoScientist.set_chat_model_instance"),
             patch(
                 "EvoScientist.cli.agent._load_agent",
                 return_value=MagicMock(),
@@ -930,5 +854,8 @@ class TestModelCommandOllamaPicker:
         ):
             _run(ModelCommand().execute(ctx, []))
 
-        assert cfg.model == "llama3.3"
-        assert cfg.provider == "ollama"
+        # Committed via set_active_config(temp_cfg); original cfg untouched.
+        set_cfg.assert_called_once()
+        committed = set_cfg.call_args[0][0]
+        assert committed.model == "llama3.3"
+        assert committed.provider == "ollama"


### PR DESCRIPTION
## Description

Follow-up to #180 — implements the "option 2" [@din0s](https://github.com/din0s) proposed in the #180 review: make `create_cli_agent` a pure function of its inputs instead of patching the symptom with snapshot/restore.

**Problem.** `create_cli_agent(config=temp_cfg)` looks side-effect-free but silently writes 4 module globals (`_config`, `_chat_model`, `_chat_model_key`, `_EvoScientist_agent`) via `_ensure_config()` / `_ensure_chat_model()`. To stay correct, `/model`'s `_apply_model` carried a fragile snapshot/restore of those globals (added in #180); any new global write inside the factory would silently break that rollback.

**Fix.** When **both** `config` and `chat_model` are explicit, `create_cli_agent` now builds the agent purely from those locals and writes none of the 4 globals. `/model` builds + verifies the agent, then commits atomically on success via two new setters (`set_active_config` / `set_chat_model_instance`) — deleting the snapshot/restore entirely.

The pure path is gated on **both** args so CLI startup callers (serve, single-shot, TUI, rich) — which pass `config=` only — keep the existing global-writing behavior unchanged, as does the implicit langgraph-dev / notebook path.

### Changes
- **`EvoScientist.py`** — new `_build_chat_model`, `_apply_env_from_config`, `set_active_config`, `set_chat_model_instance`; thread optional `cfg`/`chat_model` through `_get_default_middleware`, `load_mcp_and_build_kwargs`, `_build_base_kwargs`, `_maybe_swap_async_subagents`, and `_inject_subagent_middleware`. The last is the subtle one: it builds subagent context-editing middleware with no `model=`, which falls back to the global-writing `_ensure_chat_model()` — so `chat_model` must be threaded there too, or the pure path isn't pure on a `/model` switch.
- **`cli/agent.py`** — `_load_agent` forwards `chat_model=`.
- **`commands/implementation/model.py`** — `_apply_model` builds via `_build_chat_model` + `_load_agent(chat_model=)` and commits only on success.
- **`tests/test_model_command.py`** — assert on the committed `temp_cfg` via the setters; drop the now-impossible `set_chat_model` commit-failure rollback test.

### Notes
- One observable semantic change: the success path used to mutate the *original* cfg object in place; now the active config becomes `temp_cfg` (object identity changes). Verified nothing depends on the old identity — `ChannelRuntime` holds only `agent`/`thread_id`, and `CommandContext.config` is never read.
- The pure path still writes the unrelated `_fallback_chain` global (deterministic from cfg, idempotent) — not one of the 4 target globals.

### Testing
- `tests/test_model_command.py`: **26 passed** (rewritten for the pure path).
- `uv run ruff check .` and `ruff format --check .`: clean.
- Full suite: 19 failures remain, but they are **pre-existing** (identical on clean `main`) — Python 3.14 mock behavior in `test_ollama_discovery` / `test_subagent_summarize` / `test_wechat_channel`. CI runs 3.11/3.12, where the suite is green.

## Type of change

- [ ] Bug fix
- [ ] New feature — link issue: #
- [ ] Documentation / examples
- [ ] Test improvement
- [x] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes — #183 tests green; the 19 remaining failures are pre-existing on Python 3.14 (also fail on clean `main`; CI uses 3.11/3.12)

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge cases in model switching to ensure reliable state consistency.

* **Refactor**
  * Internal improvements to agent initialization and configuration management for enhanced stability during model changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->