### PR TITLE
fix: session lost after evoscientist restart

### DIFF
--- a/EvoScientist/langgraph_dev/langgraph.json
+++ b/EvoScientist/langgraph_dev/langgraph.json
@@ -7,6 +7,10 @@
         "evomemory-subagent-worker": "EvoScientist.langgraph_dev.graphs:evomemory_subagent_worker",
         "evomemory-turn-worker": "EvoScientist.langgraph_dev.graphs:evomemory_turn_worker"
     },
+    "checkpointer": {
+        "backend": "custom",
+        "path": "EvoScientist.sessions.create_checkpointer_for_langgraph_api"
+    },
     "config": {
         "recursion_limit": 1000000
     }

--- a/EvoScientist/sessions.py
+++ b/EvoScientist/sessions.py
@@ -13,6 +13,56 @@ Per-step pruning:
     ``get_checkpointer()`` yields a ``PruningCheckpointer`` that prunes
     older rows for the same ``(thread_id, checkpoint_ns)`` after every
     ``aput()``. The first-run migration sweep cleans up legacy bloat.
+
+WebUI / langgraph-dev checkpointer:
+    When EvoScientist runs in ``EvoSci deploy`` or WebUI mode, the agent
+    graph is served by a ``langgraph dev`` subprocess.  By default that
+    subprocess uses ``langgraph_runtime_inmem``'s ``InMemorySaver``, which
+    serialises state to ``<workspace>/.langgraph_api/*.pckl`` files via a
+    background flush loop.  Two failure modes cause history loss on restart:
+
+    1. **Flush-window data loss** — the background thread flushes every
+       10 seconds.  A SIGKILL (or abrupt container stop) between flushes
+       discards the unflushed checkpoints, making sessions disappear.
+
+    2. **Pickle incompatibility** — a deepagents / langgraph upgrade can
+       change class definitions.  On reload ``PersistentDict.load()``
+       raises ``ModuleNotFoundError``; the error handler calls
+       ``os.remove(self.filename)`` with the *prefix* string rather than
+       the concrete ``*.pckl`` path, so the file is not cleaned up.  The
+       process then starts with an empty in-memory dict while the API
+       thread list still reports the thread id (from memory), producing
+       sessions with a title but empty content.
+
+    Fix: ``create_checkpointer_for_langgraph_api()`` is an async context
+    manager that yields a ``PruningCheckpointer`` backed by the same
+    ``~/.evoscientist/sessions.db`` SQLite file used by the CLI/TUI.
+    Configured via ``langgraph.json`` ``checkpointer.path`` so the
+    ``langgraph dev`` subprocess uses it instead of ``InMemorySaver``.
+    SQLite WAL mode gives transaction-level durability — no flush window,
+    no pickle compatibility issues.
+
+WebUI thread-list restoration:
+    ``langgraph_runtime_inmem``'s ``GlobalStore`` keeps the authoritative
+    thread registry in ``conn.store["threads"]`` (an in-memory list that is
+    optionally pickled to ``.langgraph_api/.langgraph_ops.pckl``).  On every
+    restart ``GlobalStore.__init__`` calls ``clear()`` which resets
+    ``store["threads"] = []``.  If the pickle file is absent or
+    undeserializable (e.g. after a package upgrade), the thread list stays
+    empty even though all checkpoint data is safely stored in SQLite.
+
+    ``create_checkpointer_for_langgraph_api()`` therefore also calls
+    ``_restore_webui_threads_to_global_store()`` before yielding.  This
+    function reads all UUID-format thread IDs from the SQLite ``checkpoints``
+    table (rows written by ``langgraph dev`` runs use standard UUID thread
+    IDs, vs. the 8-char hex IDs used by the CLI/TUI) and re-populates
+    ``conn.store["threads"]`` with minimal stub dicts that satisfy
+    ``POST /threads/search``.  The stub contains ``thread_id``, ``metadata``,
+    ``created_at``, ``updated_at``, ``state_updated_at``, ``status``, and
+    ``values`` — the exact fields expected by the WebUI front-end.
+
+    The restore is best-effort: any error is logged and silently skipped so
+    a broken restore never prevents the checkpointer from starting.
 """
 
 import asyncio
@@ -1369,3 +1419,223 @@ async def db_stats(top_n: int = 5) -> dict[str, Any]:
         # Read-only — corrupt/locked DB → return zeroed stats rather than crash.
         return out
     return out
+
+
+# ---------------------------------------------------------------------------
+# langgraph-api / WebUI checkpointer factory
+# ---------------------------------------------------------------------------
+
+
+async def _restore_webui_threads_to_global_store() -> None:
+    """Re-populate ``GlobalStore["threads"]`` from SQLite on server startup.
+
+    ``langgraph_runtime_inmem``'s ``GlobalStore`` resets ``store["threads"] = []``
+    on every process start (``GlobalStore.__init__`` calls ``clear()``).  If the
+    ``.pckl`` file is absent or corrupt — which happens after every package
+    upgrade — the WebUI sidebar shows an empty thread list even though all
+    checkpoint data is safely persisted in SQLite.
+
+    This function reads every UUID-format thread ID from the SQLite
+    ``checkpoints`` table and re-inserts minimal stub dicts into
+    ``GLOBAL_STORE["threads"]`` so the ``POST /threads/search`` endpoint
+    can return them.  Existing entries (e.g. restored from a valid ``.pckl``)
+    are not duplicated.
+
+    UUID-format IDs (``xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``) are used by
+    ``langgraph dev`` / WebUI runs; the CLI/TUI uses 8-char hex IDs which
+    are intentionally excluded — those are managed by ``list_threads()`` and
+    the CLI commands, not the WebUI.
+
+    The restore is best-effort: any exception is logged and swallowed so a
+    broken restore never prevents the checkpointer (and therefore the whole
+    ``langgraph dev`` server) from starting.
+    """
+    try:
+        from langgraph_runtime_inmem.database import (  # type: ignore[import-untyped]
+            GLOBAL_STORE,
+        )
+    except ImportError:
+        # langgraph_runtime_inmem not available (unit tests, plain CLI mode).
+        return
+
+    try:
+        db_path = str(get_db_path())
+        async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+            if not await _table_exists(conn, "checkpoints"):
+                return
+
+            # Fetch all distinct UUID-format thread IDs with their latest
+            # checkpoint timestamp and the assistant_id / graph_id stored in
+            # the checkpoint metadata.  These are written by the langgraph-api
+            # adapter (_enrich_metadata) and are required by the WebUI's
+            # POST /threads/search filter (e.g. metadata.assistant_id).
+            # UUID regex: 8-4-4-4-12 hex groups.
+            query = """
+                SELECT thread_id,
+                       MAX(json_extract(metadata, '$.updated_at')) as updated_at,
+                       json_extract(metadata, '$.assistant_id') as assistant_id,
+                       json_extract(metadata, '$.graph_id') as graph_id
+                FROM checkpoints
+                WHERE thread_id LIKE '________-____-____-____-____________'
+                GROUP BY thread_id
+                ORDER BY updated_at DESC
+            """
+            async with conn.execute(query) as cur:
+                rows = await cur.fetchall()
+
+        if not rows:
+            return
+
+        def _to_uuid_safe(v: Any) -> uuid.UUID | None:
+            try:
+                return uuid.UUID(str(v))
+            except (ValueError, AttributeError):
+                return None
+
+        # Build a lookup of SQLite data keyed by UUID object.
+        sqlite_data: dict[uuid.UUID, tuple[str | None, str | None, str | None]] = {}
+        for row in rows:
+            thread_id_str, updated_at, assistant_id, graph_id = row
+            thread_uuid = _to_uuid_safe(thread_id_str)
+            if thread_uuid is not None:
+                sqlite_data[thread_uuid] = (updated_at, assistant_id, graph_id)
+
+        def _parse_dt(s: str | None) -> datetime:
+            """Parse an ISO timestamp string to datetime, falling back to now."""
+            if s:
+                try:
+                    return datetime.fromisoformat(s)
+                except (ValueError, TypeError):
+                    pass
+            return datetime.now(UTC)
+
+        # Pass 1 — fix issues in-place on threads already present in GlobalStore.
+        # Threads loaded from .pckl may have:
+        #   1. thread_id as plain string → needs uuid.UUID for == comparison.
+        #   2. metadata={} missing assistant_id/graph_id → search filters fail.
+        #   3. "config" key absent → State.get() KeyError.
+        #   4. created_at/updated_at as ISO string → Threads.search() sorts with
+        #      sorted(), raising TypeError when mixing datetime and str.
+        fixed = 0
+        existing_uuids: set[uuid.UUID] = set()
+        store_threads: list[dict[str, Any]] = GLOBAL_STORE.get("threads", [])
+        for entry in store_threads:
+            tid_uuid = _to_uuid_safe(entry.get("thread_id"))
+            if tid_uuid is None:
+                continue
+            existing_uuids.add(tid_uuid)
+            changed = False
+            # Fix 1: string thread_id → UUID object.
+            if not isinstance(entry.get("thread_id"), uuid.UUID):
+                entry["thread_id"] = tid_uuid
+                changed = True
+            # Fix 2: backfill metadata from SQLite.
+            if tid_uuid in sqlite_data:
+                _updated_at, asst_id_str, gid = sqlite_data[tid_uuid]
+                meta: dict[str, Any] = entry.setdefault("metadata", {})
+                if asst_id_str and "assistant_id" not in meta:
+                    meta["assistant_id"] = _to_uuid_safe(asst_id_str) or asst_id_str
+                    changed = True
+                if gid and "graph_id" not in meta:
+                    meta["graph_id"] = gid
+                    changed = True
+            # Fix 3: ensure config key exists.
+            if "config" not in entry:
+                entry["config"] = {}
+                changed = True
+            # Fix 4: convert ISO string timestamps to datetime objects so that
+            # Threads.search() sorted() doesn't raise TypeError.
+            for ts_key in ("created_at", "updated_at", "state_updated_at"):
+                if isinstance(entry.get(ts_key), str):
+                    entry[ts_key] = _parse_dt(entry[ts_key])
+                    changed = True
+            if changed:
+                fixed += 1
+
+        # Pass 2 — append threads that exist in SQLite but are absent entirely.
+        restored = 0
+        for thread_uuid, (updated_at, assistant_id, graph_id) in sqlite_data.items():
+            if thread_uuid in existing_uuids:
+                continue
+            stub_metadata: dict[str, Any] = {}
+            if assistant_id:
+                stub_metadata["assistant_id"] = (
+                    _to_uuid_safe(assistant_id) or assistant_id
+                )
+            if graph_id:
+                stub_metadata["graph_id"] = graph_id
+            ts = _parse_dt(updated_at)
+            stub: dict[str, Any] = {
+                "thread_id": thread_uuid,
+                "created_at": ts,
+                "updated_at": ts,
+                "state_updated_at": ts,
+                "metadata": stub_metadata,
+                "status": "idle",
+                "config": {},
+                "values": None,
+            }
+            GLOBAL_STORE["threads"].append(stub)
+            existing_uuids.add(thread_uuid)
+            restored += 1
+
+        if fixed or restored:
+            _logger.info(
+                "WebUI thread restore: fixed %d existing + appended %d new thread(s) "
+                "in GlobalStore (langgraph_runtime_inmem).",
+                fixed,
+                restored,
+            )
+    except Exception:
+        _logger.warning(
+            "WebUI thread restore failed (non-fatal); WebUI session list may be "
+            "empty until new threads are created.",
+            exc_info=True,
+        )
+
+
+@asynccontextmanager
+async def create_checkpointer_for_langgraph_api() -> AsyncIterator[PruningCheckpointer]:
+    """Async context manager yielding a SQLite-backed ``PruningCheckpointer``.
+
+    Intended as the ``checkpointer.path`` target in
+    ``EvoScientist/langgraph_dev/langgraph.json`` so that the ``langgraph dev``
+    subprocess (used by ``EvoSci deploy`` and WebUI mode) persists session
+    history to ``~/.evoscientist/sessions.db`` rather than the default
+    ``langgraph_runtime_inmem`` ``InMemorySaver``.
+
+    **Why this matters — two failure modes of the default InMemorySaver:**
+
+    1. *Flush-window data loss.*  ``InMemorySaver`` (aka ``langgraph_runtime_inmem``)
+       serialises checkpoints to ``<workspace>/.langgraph_api/*.pckl`` via a
+       background thread that flushes every 10 seconds.  A SIGKILL or abrupt
+       container stop between flushes silently discards all unflushed
+       checkpoints.  SQLite WAL mode commits every ``aput()`` as a proper
+       transaction — no flush window.
+
+    2. *Pickle incompatibility.*  A deepagents / langgraph upgrade can change
+       class definitions stored inside the pickle files.  On reload the error
+       handler calls ``os.remove(self.filename)`` with the *prefix* string
+       (``".langgraph_api/.langgraph_checkpoint."``) rather than the concrete
+       ``*.pckl`` path, so files are not cleaned up.  The process then starts
+       with an empty in-memory store while the API thread-list still reports
+       the old thread ids — producing sessions whose title exists but whose
+       content is empty.  SQLite stores serialised blobs; any deserialization
+       failure is isolated to the specific checkpoint row, not the entire store.
+
+    The ``langgraph-api`` adapter (``_checkpointer._adapter._yield_checkpointer``)
+    detects async context managers and calls ``__aenter__`` / ``__aexit__``
+    automatically, so yielding here is the correct integration pattern.
+
+    ``PruningCheckpointer`` inherits all of ``AsyncSqliteSaver``'s extended
+    methods (``adelete_thread``, ``adelete_for_runs``, ``acopy_thread``,
+    ``aprune``) so the adapter reports full capability and every langgraph-api
+    feature (thread deletion, rollback pruning, thread copy) works correctly.
+    """
+    keep = _resolve_keep_per_ns()
+    async with PruningCheckpointer.from_conn_string_with_keep(
+        str(get_db_path()), keep_per_ns=keep
+    ) as saver:
+        await saver.setup()
+        await _restore_webui_threads_to_global_store()
+        yield saver

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2004,5 +2004,397 @@ class TestReduceMessagesDeltaUpstreamParity:
         assert _signature(out) == [("HumanMessage", "d1", "x")]
 
 
+class TestCreateCheckpointerForLanggraphApi(unittest.TestCase):
+    """Tests for ``create_checkpointer_for_langgraph_api`` — the WebUI/deploy
+    SQLite checkpointer factory that replaces the default ``InMemorySaver``."""
+
+    def test_yields_pruning_checkpointer(self):
+        """Factory yields a ``PruningCheckpointer`` instance."""
+        from EvoScientist.sessions import (
+            PruningCheckpointer,
+            create_checkpointer_for_langgraph_api,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with patch(
+                "EvoScientist.sessions.get_db_path",
+                return_value=_mock_path(db),
+            ):
+
+                async def _run_inner():
+                    async with create_checkpointer_for_langgraph_api() as cp:
+                        assert isinstance(cp, PruningCheckpointer)
+
+                _run(_run_inner())
+
+    def test_checkpointer_is_set_up(self):
+        """Factory calls ``setup()`` so tables exist before yielding."""
+        import aiosqlite
+
+        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with patch(
+                "EvoScientist.sessions.get_db_path",
+                return_value=_mock_path(db),
+            ):
+
+                async def _run_inner():
+                    async with create_checkpointer_for_langgraph_api():
+                        async with aiosqlite.connect(db) as conn:
+                            async with conn.execute(
+                                "SELECT name FROM sqlite_master WHERE type='table' AND name='checkpoints'"
+                            ) as cur:
+                                row = await cur.fetchone()
+                            assert row is not None, (
+                                "checkpoints table must exist after setup()"
+                            )
+
+                _run(_run_inner())
+
+    def test_checkpointer_persists_across_contexts(self):
+        """Data written in one context manager is readable in a new one.
+
+        This is the core regression test: verifies that session data
+        survives process restarts (simulated as two separate ``async with``
+        blocks sharing the same DB file).
+        """
+        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+
+        thread_id = "testthread1"
+
+        async def _run_inner():
+            with tempfile.TemporaryDirectory() as td:
+                db = os.path.join(td, "sessions.db")
+
+                def _patch():
+                    return patch(
+                        "EvoScientist.sessions.get_db_path",
+                        return_value=_mock_path(db),
+                    )
+
+                # --- First "process": write a checkpoint ---
+                with _patch():
+                    async with create_checkpointer_for_langgraph_api() as cp:
+                        config = {
+                            "configurable": {
+                                "thread_id": thread_id,
+                                "checkpoint_ns": "",
+                            }
+                        }
+                        checkpoint = {
+                            "v": 1,
+                            "id": "ckpt-001",
+                            "ts": "2024-01-01T00:00:00+00:00",
+                            "channel_values": {"messages": []},
+                            "channel_versions": {},
+                            "versions_seen": {},
+                            "pending_sends": [],
+                        }
+                        metadata = {
+                            "source": "input",
+                            "step": 0,
+                            "writes": {},
+                            "parents": {},
+                            "agent_name": "EvoScientist",
+                        }
+                        await cp.aput(config, checkpoint, metadata, {})
+
+                # --- Second "process": read back the checkpoint ---
+                with _patch():
+                    async with create_checkpointer_for_langgraph_api() as cp2:
+                        result = await cp2.aget_tuple(
+                            {
+                                "configurable": {
+                                    "thread_id": thread_id,
+                                    "checkpoint_ns": "",
+                                }
+                            }
+                        )
+                        assert result is not None, (
+                            "Checkpoint written in first context must be readable in second context "
+                            "(simulates data survival across process restarts)"
+                        )
+                        assert result.config["configurable"]["thread_id"] == thread_id
+
+        _run(_run_inner())
+
+    def test_has_required_extended_methods(self):
+        """Yielded checkpointer exposes the full capability set expected by
+        ``langgraph-api``'s ``_CustomCheckpointerAdapter``."""
+        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with patch(
+                "EvoScientist.sessions.get_db_path",
+                return_value=_mock_path(db),
+            ):
+
+                async def _run_inner():
+                    async with create_checkpointer_for_langgraph_api() as cp:
+                        for method in (
+                            "adelete_thread",
+                            "adelete_for_runs",
+                            "acopy_thread",
+                            "aprune",
+                            "aget_tuple",
+                            "aput",
+                            "aput_writes",
+                            "alist",
+                        ):
+                            assert callable(getattr(cp, method, None)), (
+                                f"PruningCheckpointer must expose '{method}' for "
+                                "langgraph-api full-capability compliance"
+                            )
+
+                _run(_run_inner())
+
+
+class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
+    """Tests for ``_restore_webui_threads_to_global_store``.
+
+    Verifies that UUID-format threads written to SQLite by ``langgraph dev``
+    runs are re-populated into ``GlobalStore["threads"]`` on server restart,
+    so the WebUI sidebar is not empty after a package upgrade or clean restart.
+    """
+
+    def _make_db_with_threads(
+        self,
+        db_path: str,
+        thread_ids: list[str],
+        assistant_id: str = "aaaa-bbbb",
+        graph_id: str = "EvoScientist",
+    ) -> None:
+        """Insert minimal checkpoint rows for the given thread_ids into a fresh DB."""
+        import json
+        import sqlite3
+
+        con = sqlite3.connect(db_path)
+        con.execute(
+            "CREATE TABLE checkpoints "
+            "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT PRIMARY KEY, "
+            " parent_checkpoint_id TEXT, type TEXT, checkpoint BLOB, metadata TEXT)"
+        )
+        for tid in thread_ids:
+            meta = json.dumps(
+                {
+                    "updated_at": "2025-01-01T00:00:00+00:00",
+                    "agent_name": "EvoScientist",
+                    "assistant_id": assistant_id,
+                    "graph_id": graph_id,
+                }
+            )
+            con.execute(
+                "INSERT INTO checkpoints VALUES (?,?,?,?,?,?,?)",
+                (tid, "", f"ckpt-{tid[:8]}", None, "empty", b"", meta),
+            )
+        con.commit()
+        con.close()
+
+    def test_restores_uuid_threads_into_global_store(self):
+        """UUID-format thread IDs from SQLite are injected into GlobalStore."""
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        uuid_id = "12345678-1234-1234-1234-123456789abc"
+        asst_uuid_id = "a2b49500-c49b-5560-b664-d42ee8b66d3c"
+        short_id = "abcd1234"  # CLI-style, must be excluded
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            self._make_db_with_threads(
+                db, [uuid_id, short_id], assistant_id=asst_uuid_id
+            )
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        # Only the UUID thread should have been added; the short-hex CLI thread
+        # should not appear because it doesn't match the UUID LIKE pattern.
+        added = mock_store["threads"]
+        assert len(added) == 1, f"Expected 1 restored thread, got {len(added)}: {added}"
+        import uuid as _uuid_mod
+
+        # thread_id MUST be stored as a uuid.UUID object, not a plain string.
+        # langgraph_runtime_inmem._get_with_filters compares with == against
+        # _ensure_uuid(thread_id), which returns a UUID object.  A string never
+        # equals a UUID object, causing every Threads.get() call to 404.
+        assert isinstance(added[0]["thread_id"], _uuid_mod.UUID), (
+            f"thread_id must be uuid.UUID, got {type(added[0]['thread_id'])}"
+        )
+        assert added[0]["thread_id"] == _uuid_mod.UUID(uuid_id)
+        assert added[0]["status"] == "idle"
+        # metadata must carry assistant_id (as UUID) and graph_id so
+        # POST /threads/search filters work correctly in the WebUI.
+        assert isinstance(added[0]["metadata"].get("assistant_id"), _uuid_mod.UUID)
+        assert added[0]["metadata"].get("assistant_id") == _uuid_mod.UUID(asst_uuid_id)
+        assert added[0]["metadata"].get("graph_id") == "EvoScientist"
+        # created_at / updated_at must be datetime objects, not ISO strings.
+        # Threads.search() sorts by these fields using sorted(); mixing
+        # datetime and str raises TypeError: '<' not supported.
+        from datetime import datetime as _dt
+
+        assert isinstance(added[0]["created_at"], _dt), (
+            f"created_at must be datetime, got {type(added[0]['created_at'])}"
+        )
+        assert isinstance(added[0]["updated_at"], _dt)
+
+    def test_fixes_existing_string_thread_ids_in_place(self):
+        """Threads already in GlobalStore with string thread_id get fixed in-place.
+
+        When .pckl loads successfully, threads are already in the store but
+        thread_id is a plain string (as pickled).  The restore must:
+          1. Convert thread_id to uuid.UUID so Threads.get() comparison works.
+          2. Backfill missing metadata.assistant_id / graph_id from SQLite.
+          3. Not create duplicate entries.
+        """
+        import sys
+        import uuid as _uuid_mod
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        uuid_id = "aaaabbbb-aaaa-bbbb-cccc-ddddeeeeffff"
+        asst_uuid_id = "a2b49500-c49b-5560-b664-d42ee8b66d3c"
+
+        # Simulate .pckl-restored thread: thread_id is a string, metadata empty.
+        existing_stub: dict = {"thread_id": uuid_id, "status": "idle", "metadata": {}}
+        mock_store: dict = {"threads": [existing_stub]}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            self._make_db_with_threads(db, [uuid_id], assistant_id=asst_uuid_id)
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        # No duplicate: still exactly one entry.
+        assert len(mock_store["threads"]) == 1, (
+            f"Expected 1 thread, got {len(mock_store['threads'])}"
+        )
+        t = mock_store["threads"][0]
+        # thread_id must now be a UUID object, not a string.
+        assert isinstance(t["thread_id"], _uuid_mod.UUID), (
+            f"thread_id must be uuid.UUID after fix, got {type(t['thread_id'])}"
+        )
+        assert t["thread_id"] == _uuid_mod.UUID(uuid_id)
+        # metadata must be backfilled.
+        assert isinstance(t["metadata"].get("assistant_id"), _uuid_mod.UUID)
+        assert t["metadata"].get("graph_id") == "EvoScientist"
+
+    def test_no_op_when_langgraph_runtime_inmem_absent(self):
+        """ImportError for langgraph_runtime_inmem is silently swallowed."""
+        import sys
+        from unittest.mock import patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        with patch.dict(sys.modules, {"langgraph_runtime_inmem.database": None}):
+            # Must not raise.
+            _run(_restore_webui_threads_to_global_store())
+
+    def test_no_op_when_db_has_no_checkpoints_table(self):
+        """Missing checkpoints table is handled gracefully."""
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "empty.db")
+            # Create a valid but empty SQLite DB (no checkpoints table).
+            import sqlite3
+
+            sqlite3.connect(db).close()
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        # threads list untouched.
+        assert mock_store["threads"] == []
+
+    def test_create_checkpointer_calls_restore(self):
+        """create_checkpointer_for_langgraph_api calls _restore_webui_threads_to_global_store."""
+        from unittest.mock import patch
+
+        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+
+        restore_called = []
+
+        async def fake_restore():
+            restore_called.append(True)
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch(
+                    "EvoScientist.sessions._restore_webui_threads_to_global_store",
+                    side_effect=fake_restore,
+                ),
+            ):
+
+                async def _run_inner():
+                    async with create_checkpointer_for_langgraph_api():
+                        pass
+
+                _run(_run_inner())
+
+        assert restore_called, "_restore_webui_threads_to_global_store must be called"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

fix session lost after evoscientist restart， close #277

## Type of change

<!-- Check the one that applies. -->

- [X] Bug fix
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [* ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [* ] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [* ] I have added/updated tests where applicable
- [* ] `uv run ruff check .` passes
- [* ] `uv run pytest` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented persistent SQLite-backed checkpointing to prevent data loss on application restarts.
  * Automatic WebUI thread history restoration on startup.

* **Bug Fixes**
  * Resolved data loss issues with default in-memory checkpoint storage and pickle compatibility problems.

* **Tests**
  * Added comprehensive test coverage for persistent checkpointing and WebUI thread restoration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->