### PR TITLE
fix: session lost after evoscientist restart (supersedes #278)

### DIFF
--- a/EvoScientist/cli/interactive.py
+++ b/EvoScientist/cli/interactive.py
@@ -39,6 +39,7 @@ from ..sessions import (
     get_thread_messages,
     get_thread_metadata,
     resolve_thread_id_prefix,
+    short_thread_id,
     thread_exists,
 )
 from ..stream.console import console
@@ -1423,7 +1424,7 @@ def cmd_run(
     console.print(sep)
     console.print(Text(f"> {prompt}"))
     console.print(sep)
-    console.print(f"[dim]Thread: {thread_id}[/dim]")
+    console.print(f"[dim]Thread: {short_thread_id(thread_id)}[/dim]")
     if workspace_dir:
         console.print(f"[dim]Workspace: {_shorten_path(workspace_dir)}[/dim]")
     console.print()

--- a/EvoScientist/cli/resume_hint.py
+++ b/EvoScientist/cli/resume_hint.py
@@ -14,6 +14,8 @@ def print_resume_hint(
     out = console or Console()
     out.print("[dim]Goodbye![/dim]")
     if thread_id:
+        from ..sessions import short_thread_id
+
         out.print()
         out.print("[dim]Resume this session with:[/dim]")
-        out.print(f"[cyan]EvoSci --resume {escape(thread_id)}[/cyan]")
+        out.print(f"[cyan]EvoSci --resume {escape(short_thread_id(thread_id))}[/cyan]")

--- a/EvoScientist/cli/widgets/thread_selector.py
+++ b/EvoScientist/cli/widgets/thread_selector.py
@@ -202,9 +202,9 @@ def build_row_text(
     indented: bool = False,
 ) -> Text:
     """Thread row.  *indented* adds extra leading space for L2-grouped rows."""
-    from ...sessions import _format_relative_time
+    from ...sessions import _format_relative_time, short_thread_id
 
-    tid = thread["thread_id"]
+    tid = short_thread_id(thread["thread_id"])
     preview = thread.get("preview", "") or ""
     msgs = thread.get("message_count", 0)
     model = thread.get("model", "") or ""

--- a/EvoScientist/commands/implementation/session.py
+++ b/EvoScientist/commands/implementation/session.py
@@ -98,12 +98,14 @@ class ThreadsCommand(Command):
             table.add_column("Model", style="dim")
         table.add_column("Last Used", style="dim")
 
+        from ...sessions import short_thread_id
+
         for thread in threads:
             thread_id_value = thread["thread_id"]
             marker = " *" if thread_id_value == ctx.thread_id else ""
 
             row = [
-                f"{thread_id_value}{marker}",
+                f"{short_thread_id(thread_id_value)}{marker}",
                 thread.get("preview", "") or "",
                 str(thread.get("message_count", 0)),
             ]

--- a/EvoScientist/langgraph_dev/langgraph.json
+++ b/EvoScientist/langgraph_dev/langgraph.json
@@ -7,6 +7,10 @@
         "evomemory-subagent-worker": "EvoScientist.langgraph_dev.graphs:evomemory_subagent_worker",
         "evomemory-turn-worker": "EvoScientist.langgraph_dev.graphs:evomemory_turn_worker"
     },
+    "checkpointer": {
+        "backend": "custom",
+        "path": "EvoScientist.sessions.create_checkpointer_for_langgraph_api"
+    },
     "config": {
         "recursion_limit": 1000000
     }

--- a/EvoScientist/middleware/memory_lifecycle.py
+++ b/EvoScientist/middleware/memory_lifecycle.py
@@ -958,6 +958,32 @@ def _status_from_run_response(run: object) -> str:
     return str(value or "").strip().lower()
 
 
+def _delete_memory_worker_thread(client: Any, thread_id: str) -> None:
+    """Best-effort delete of a finished worker thread.
+
+    Worker conversations have no value after the run: the durable artifact
+    is the memory files they write, and worker threads are never resumed.
+    Deleting the thread drops its checkpoints from the shared sessions.db
+    so short-lived workers leave no per-turn residue behind.
+    """
+    try:
+        client.threads.delete(thread_id)
+    except Exception:
+        logger.debug(
+            "Failed to delete EvoMemory worker thread %s", thread_id, exc_info=True
+        )
+
+
+async def _adelete_memory_worker_thread(client: Any, thread_id: str) -> None:
+    """Async variant of :func:`_delete_memory_worker_thread`."""
+    try:
+        await client.threads.delete(thread_id)
+    except Exception:
+        logger.debug(
+            "Failed to delete EvoMemory worker thread %s", thread_id, exc_info=True
+        )
+
+
 def _spawn_memory_worker_status_thread(
     *,
     url: str,
@@ -984,6 +1010,7 @@ def _watch_memory_worker_run_sync(
 
     failures = 0
     worker_confirmed_finished = False
+    client = None
     try:
         client = get_sync_client(url=url, headers={"x-auth-scheme": "langsmith"})
         while True:
@@ -1010,6 +1037,11 @@ def _watch_memory_worker_run_sync(
             time.sleep(_MEMORY_WORKER_POLL_INTERVAL_SECONDS)
     finally:
         if worker_confirmed_finished:
+            # Only delete once the run is terminal — deleting a thread with a
+            # live run would break it. Crash residue is handled by the
+            # restore whitelist + startup purge in sessions.py.
+            if client is not None:
+                _delete_memory_worker_thread(client, thread_id)
             mark_memory_worker_finished(thread_id, run_id)
         else:
             forget_memory_worker(thread_id, run_id)
@@ -1064,6 +1096,7 @@ async def _watch_memory_worker_run_async(
             await asyncio.sleep(_MEMORY_WORKER_POLL_INTERVAL_SECONDS)
     finally:
         if worker_confirmed_finished:
+            await _adelete_memory_worker_thread(client, thread_id)
             await asyncio.to_thread(mark_memory_worker_finished, thread_id, run_id)
         else:
             forget_memory_worker(thread_id, run_id)

--- a/EvoScientist/middleware/memory_lifecycle.py
+++ b/EvoScientist/middleware/memory_lifecycle.py
@@ -1037,12 +1037,14 @@ def _watch_memory_worker_run_sync(
             time.sleep(_MEMORY_WORKER_POLL_INTERVAL_SECONDS)
     finally:
         if worker_confirmed_finished:
-            # Only delete once the run is terminal — deleting a thread with a
-            # live run would break it. Crash residue is handled by the
+            # Accounting first, then best-effort deletion (mirrors the
+            # async watcher's cancellation-safe ordering). Only delete
+            # once the run is terminal — deleting a thread with a live
+            # run would break it. Crash residue is handled by the
             # restore whitelist + startup purge in sessions.py.
+            mark_memory_worker_finished(thread_id, run_id)
             if client is not None:
                 _delete_memory_worker_thread(client, thread_id)
-            mark_memory_worker_finished(thread_id, run_id)
         else:
             forget_memory_worker(thread_id, run_id)
 
@@ -1096,8 +1098,13 @@ async def _watch_memory_worker_run_async(
             await asyncio.sleep(_MEMORY_WORKER_POLL_INTERVAL_SECONDS)
     finally:
         if worker_confirmed_finished:
-            await _adelete_memory_worker_thread(client, thread_id)
+            # Accounting BEFORE the best-effort deletion: if this task is
+            # cancelled mid-finally, only the deletion await is lost
+            # (startup purge covers the residue). The to_thread side
+            # effect completes even if its await is cancelled, so the
+            # worker is never stuck "running".
             await asyncio.to_thread(mark_memory_worker_finished, thread_id, run_id)
+            await _adelete_memory_worker_thread(client, thread_id)
         else:
             forget_memory_worker(thread_id, run_id)
 

--- a/EvoScientist/sessions.py
+++ b/EvoScientist/sessions.py
@@ -111,9 +111,25 @@ def get_db_path() -> Path:
     return Path(_to_short_path(str(db_dir))) / "sessions.db"
 
 
+def short_thread_id(thread_id: str) -> str:
+    """First 8 chars for display (git-style); legacy 8-hex ids pass through.
+
+    All lookup commands (``/resume``, ``/delete``) accept prefixes, so the
+    shortened form is always a usable handle.
+    """
+    return thread_id[:8]
+
+
 def generate_thread_id() -> str:
-    """Generate an 8-char hex thread ID."""
-    return uuid.uuid4().hex[:8]
+    """Generate a full-UUID thread ID.
+
+    UUID format (not the legacy 8-char hex) so CLI threads are addressable
+    by langgraph-api — its thread endpoints reject non-UUID ids — which is
+    what lets the WebUI list and resume CLI sessions. UIs display the
+    first 8 chars; ``/resume`` prefix matching is unaffected. Pre-existing
+    8-char hex threads keep working in the CLI but stay CLI-only.
+    """
+    return str(uuid.uuid4())
 
 
 # ---------------------------------------------------------------------------
@@ -1503,39 +1519,14 @@ async def _restore_webui_threads_to_global_store() -> None:
         # langgraph_runtime_inmem not available (unit tests, plain CLI mode).
         return
 
+    def _to_uuid_safe(v: Any) -> uuid.UUID | None:
+        try:
+            return uuid.UUID(str(v))
+        except (ValueError, AttributeError):
+            return None
+
     try:
         rows: list[Any] = []
-        db_path = str(get_db_path())
-        async with aiosqlite.connect(db_path, timeout=30.0) as conn:
-            # No checkpoints table (fresh DB) → rows stays empty, but the
-            # ghost-removal pass below must still run: every UUID entry the
-            # .pckl registry loaded is then stale by definition.
-            if await _table_exists(conn, "checkpoints"):
-                # Fetch all distinct UUID-format thread IDs with their latest
-                # checkpoint timestamp and the assistant_id / graph_id stored
-                # in the checkpoint metadata.  Required by the WebUI's
-                # POST /threads/search filter (e.g. metadata.assistant_id).
-                # UUID regex: 8-4-4-4-12 hex groups.
-                query = """
-                    SELECT thread_id,
-                           MAX(json_extract(metadata, '$.updated_at')) as updated_at,
-                           json_extract(metadata, '$.assistant_id') as assistant_id,
-                           json_extract(metadata, '$.graph_id') as graph_id,
-                           MAX(json_extract(metadata, '$.workspace_dir')) as workspace_dir
-                    FROM checkpoints
-                    WHERE thread_id LIKE '________-____-____-____-____________'
-                    GROUP BY thread_id
-                    ORDER BY updated_at DESC
-                """
-                async with conn.execute(query) as cur:
-                    rows = await cur.fetchall()
-
-        def _to_uuid_safe(v: Any) -> uuid.UUID | None:
-            try:
-                return uuid.UUID(str(v))
-            except (ValueError, AttributeError):
-                return None
-
         # All UUID threads that have ANY checkpoint rows — the existence
         # check for ghost removal (deliberately unscoped: a thread whose
         # checkpoints exist but fall outside the restore scope is not a
@@ -1545,23 +1536,78 @@ async def _restore_webui_threads_to_global_store() -> None:
         # workspace. sessions.db is machine-global, so an unscoped restore
         # would resurrect every workspace's history (and internal
         # worker/subagent threads) into this server's thread registry — and
-        # expose it over the unauthenticated API / --tunnel.
-        # workspace_dir/agent_name are stamped at write time by
-        # _ApiPruningCheckpointer; rows that predate stamping have no
+        # expose it over the unauthenticated API / --tunnel. Main-graph =
+        # metadata.graph_id == AGENT_NAME (langgraph-api rows, stamped by
+        # _ApiPruningCheckpointer) OR no graph_id but agent_name ==
+        # AGENT_NAME (CLI rows via build_metadata). Worker residue carries
+        # graph_id='evomemory-*' and is excluded by the first clause even
+        # though it also stamps agent_name. Rows predating stamping have no
         # workspace_dir and are deliberately excluded.
         current_workspace = _api_workspace_dir()
-        sqlite_data: dict[uuid.UUID, tuple[str | None, str | None, str | None]] = {}
-        for row in rows:
-            thread_id_str, updated_at, assistant_id, graph_id, workspace_dir = row
-            thread_uuid = _to_uuid_safe(thread_id_str)
-            if thread_uuid is None:
-                continue
-            uuid_threads_in_db.add(thread_uuid)
-            if graph_id != AGENT_NAME:
-                continue
-            if not workspace_dir or workspace_dir != current_workspace:
-                continue
-            sqlite_data[thread_uuid] = (updated_at, assistant_id, graph_id)
+        sqlite_data: dict[uuid.UUID, tuple[str | None, str | None, str]] = {}
+        titles: dict[uuid.UUID, str] = {}
+        db_path = str(get_db_path())
+        async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+            # No checkpoints table (fresh DB) → rows stays empty, but the
+            # ghost-removal pass below must still run: every UUID entry the
+            # .pckl registry loaded is then stale by definition.
+            if await _table_exists(conn, "checkpoints"):
+                # UUID regex: 8-4-4-4-12 hex groups. assistant_id/graph_id
+                # are needed by the WebUI's POST /threads/search filters.
+                # Every metadata field is MAX-aggregated: an interop thread
+                # mixes CLI rows (no assistant_id/graph_id) with WebUI rows,
+                # and a bare column under GROUP BY would let SQLite pick an
+                # arbitrary row's NULL.
+                query = """
+                    SELECT thread_id,
+                           MAX(json_extract(metadata, '$.updated_at')) as updated_at,
+                           MAX(json_extract(metadata, '$.assistant_id')) as assistant_id,
+                           MAX(json_extract(metadata, '$.graph_id')) as graph_id,
+                           MAX(json_extract(metadata, '$.workspace_dir')) as workspace_dir,
+                           MAX(json_extract(metadata, '$.agent_name')) as agent_name
+                    FROM checkpoints
+                    WHERE thread_id LIKE '________-____-____-____-____________'
+                    GROUP BY thread_id
+                    ORDER BY updated_at DESC
+                """
+                async with conn.execute(query) as cur:
+                    rows = await cur.fetchall()
+
+            for row in rows:
+                (
+                    thread_id_str,
+                    updated_at,
+                    assistant_id,
+                    graph_id,
+                    workspace_dir,
+                    agent_name,
+                ) = row
+                thread_uuid = _to_uuid_safe(thread_id_str)
+                if thread_uuid is None:
+                    continue
+                uuid_threads_in_db.add(thread_uuid)
+                is_main_graph = graph_id == AGENT_NAME or (
+                    graph_id is None and agent_name == AGENT_NAME
+                )
+                if not is_main_graph:
+                    continue
+                if not workspace_dir or workspace_dir != current_workspace:
+                    continue
+                sqlite_data[thread_uuid] = (updated_at, assistant_id, AGENT_NAME)
+
+            # Derive a sidebar title from each scoped thread's first human
+            # message (stubs carry values=None, so the WebUI would otherwise
+            # render every restored thread as "Untitled Thread").
+            if sqlite_data:
+                saver = AsyncSqliteSaver(conn, serde=JsonPlusSerializer())
+                for thread_uuid in sqlite_data:
+                    try:
+                        msgs = await _load_checkpoint_messages(saver, str(thread_uuid))
+                        preview = _extract_preview(msgs)
+                        if preview:
+                            titles[thread_uuid] = preview
+                    except Exception:
+                        continue
 
         def _parse_dt(s: str | None) -> datetime:
             """Parse an ISO timestamp string to datetime, falling back to now."""
@@ -1609,6 +1655,9 @@ async def _restore_webui_threads_to_global_store() -> None:
                 if gid and "graph_id" not in meta:
                     meta["graph_id"] = gid
                     changed = True
+                if "title" not in meta and tid_uuid in titles:
+                    meta["title"] = titles[tid_uuid]
+                    changed = True
             # State.get() KeyErrors without "config".
             if "config" not in entry:
                 entry["config"] = {}
@@ -1626,12 +1675,12 @@ async def _restore_webui_threads_to_global_store() -> None:
         for thread_uuid, (updated_at, assistant_id, graph_id) in sqlite_data.items():
             if thread_uuid in existing_uuids:
                 continue
-            stub_metadata: dict[str, Any] = {}
+            stub_metadata: dict[str, Any] = {"graph_id": graph_id}
             if assistant_id:
                 # str, not uuid.UUID — same convention as above.
                 stub_metadata["assistant_id"] = str(assistant_id)
-            if graph_id:
-                stub_metadata["graph_id"] = graph_id
+            if thread_uuid in titles:
+                stub_metadata["title"] = titles[thread_uuid]
             ts = _parse_dt(updated_at)
             stub: dict[str, Any] = {
                 "thread_id": thread_uuid,

--- a/EvoScientist/sessions.py
+++ b/EvoScientist/sessions.py
@@ -13,6 +13,56 @@ Per-step pruning:
     ``get_checkpointer()`` yields a ``PruningCheckpointer`` that prunes
     older rows for the same ``(thread_id, checkpoint_ns)`` after every
     ``aput()``. The first-run migration sweep cleans up legacy bloat.
+
+WebUI / langgraph-dev checkpointer:
+    When EvoScientist runs in ``EvoSci deploy`` or WebUI mode, the agent
+    graph is served by a ``langgraph dev`` subprocess.  By default that
+    subprocess uses ``langgraph_runtime_inmem``'s ``InMemorySaver``, which
+    serialises state to ``<workspace>/.langgraph_api/*.pckl`` files via a
+    background flush loop.  Two failure modes cause history loss on restart:
+
+    1. **Flush-window data loss** — the background thread flushes every
+       10 seconds.  A SIGKILL (or abrupt container stop) between flushes
+       discards the unflushed checkpoints, making sessions disappear.
+
+    2. **Pickle incompatibility** — a deepagents / langgraph upgrade can
+       change class definitions.  On reload ``PersistentDict.load()``
+       raises ``ModuleNotFoundError``; the error handler calls
+       ``os.remove(self.filename)`` with the *prefix* string rather than
+       the concrete ``*.pckl`` path, so the file is not cleaned up.  The
+       process then starts with an empty in-memory dict while the API
+       thread list still reports the thread id (from memory), producing
+       sessions with a title but empty content.
+
+    Fix: ``create_checkpointer_for_langgraph_api()`` is an async context
+    manager that yields a ``PruningCheckpointer`` backed by the same
+    ``~/.evoscientist/sessions.db`` SQLite file used by the CLI/TUI.
+    Configured via ``langgraph.json`` ``checkpointer.path`` so the
+    ``langgraph dev`` subprocess uses it instead of ``InMemorySaver``.
+    SQLite WAL mode gives transaction-level durability — no flush window,
+    no pickle compatibility issues.
+
+WebUI thread-list restoration:
+    ``langgraph_runtime_inmem``'s ``GlobalStore`` keeps the authoritative
+    thread registry in ``conn.store["threads"]`` (an in-memory list that is
+    optionally pickled to ``.langgraph_api/.langgraph_ops.pckl``).  On every
+    restart ``GlobalStore.__init__`` calls ``clear()`` which resets
+    ``store["threads"] = []``.  If the pickle file is absent or
+    undeserializable (e.g. after a package upgrade), the thread list stays
+    empty even though all checkpoint data is safely stored in SQLite.
+
+    ``create_checkpointer_for_langgraph_api()`` therefore also calls
+    ``_restore_webui_threads_to_global_store()`` before yielding.  This
+    function reads all UUID-format thread IDs from the SQLite ``checkpoints``
+    table (rows written by ``langgraph dev`` runs use standard UUID thread
+    IDs, vs. the 8-char hex IDs used by the CLI/TUI) and re-populates
+    ``conn.store["threads"]`` with minimal stub dicts that satisfy
+    ``POST /threads/search``.  The stub contains ``thread_id``, ``metadata``,
+    ``created_at``, ``updated_at``, ``state_updated_at``, ``status``, and
+    ``values`` — the exact fields expected by the WebUI front-end.
+
+    The restore is best-effort: any error is logged and silently skipped so
+    a broken restore never prevents the checkpointer from starting.
 """
 
 import asyncio
@@ -1369,3 +1419,223 @@ async def db_stats(top_n: int = 5) -> dict[str, Any]:
         # Read-only — corrupt/locked DB → return zeroed stats rather than crash.
         return out
     return out
+
+
+# ---------------------------------------------------------------------------
+# langgraph-api / WebUI checkpointer factory
+# ---------------------------------------------------------------------------
+
+
+async def _restore_webui_threads_to_global_store() -> None:
+    """Re-populate ``GlobalStore["threads"]`` from SQLite on server startup.
+
+    ``langgraph_runtime_inmem``'s ``GlobalStore`` resets ``store["threads"] = []``
+    on every process start (``GlobalStore.__init__`` calls ``clear()``).  If the
+    ``.pckl`` file is absent or corrupt — which happens after every package
+    upgrade — the WebUI sidebar shows an empty thread list even though all
+    checkpoint data is safely persisted in SQLite.
+
+    This function reads every UUID-format thread ID from the SQLite
+    ``checkpoints`` table and re-inserts minimal stub dicts into
+    ``GLOBAL_STORE["threads"]`` so the ``POST /threads/search`` endpoint
+    can return them.  Existing entries (e.g. restored from a valid ``.pckl``)
+    are not duplicated.
+
+    UUID-format IDs (``xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``) are used by
+    ``langgraph dev`` / WebUI runs; the CLI/TUI uses 8-char hex IDs which
+    are intentionally excluded — those are managed by ``list_threads()`` and
+    the CLI commands, not the WebUI.
+
+    The restore is best-effort: any exception is logged and swallowed so a
+    broken restore never prevents the checkpointer (and therefore the whole
+    ``langgraph dev`` server) from starting.
+    """
+    try:
+        from langgraph_runtime_inmem.database import (  # type: ignore[import-untyped]
+            GLOBAL_STORE,
+        )
+    except ImportError:
+        # langgraph_runtime_inmem not available (unit tests, plain CLI mode).
+        return
+
+    try:
+        db_path = str(get_db_path())
+        async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+            if not await _table_exists(conn, "checkpoints"):
+                return
+
+            # Fetch all distinct UUID-format thread IDs with their latest
+            # checkpoint timestamp and the assistant_id / graph_id stored in
+            # the checkpoint metadata.  These are written by the langgraph-api
+            # adapter (_enrich_metadata) and are required by the WebUI's
+            # POST /threads/search filter (e.g. metadata.assistant_id).
+            # UUID regex: 8-4-4-4-12 hex groups.
+            query = """
+                SELECT thread_id,
+                       MAX(json_extract(metadata, '$.updated_at')) as updated_at,
+                       json_extract(metadata, '$.assistant_id') as assistant_id,
+                       json_extract(metadata, '$.graph_id') as graph_id
+                FROM checkpoints
+                WHERE thread_id LIKE '________-____-____-____-____________'
+                GROUP BY thread_id
+                ORDER BY updated_at DESC
+            """
+            async with conn.execute(query) as cur:
+                rows = await cur.fetchall()
+
+        if not rows:
+            return
+
+        def _to_uuid_safe(v: Any) -> uuid.UUID | None:
+            try:
+                return uuid.UUID(str(v))
+            except (ValueError, AttributeError):
+                return None
+
+        # Build a lookup of SQLite data keyed by UUID object.
+        sqlite_data: dict[uuid.UUID, tuple[str | None, str | None, str | None]] = {}
+        for row in rows:
+            thread_id_str, updated_at, assistant_id, graph_id = row
+            thread_uuid = _to_uuid_safe(thread_id_str)
+            if thread_uuid is not None:
+                sqlite_data[thread_uuid] = (updated_at, assistant_id, graph_id)
+
+        def _parse_dt(s: str | None) -> datetime:
+            """Parse an ISO timestamp string to datetime, falling back to now."""
+            if s:
+                try:
+                    return datetime.fromisoformat(s)
+                except (ValueError, TypeError):
+                    pass
+            return datetime.now(UTC)
+
+        # Pass 1 — fix issues in-place on threads already present in GlobalStore.
+        # Threads loaded from .pckl may have:
+        #   1. thread_id as plain string → needs uuid.UUID for == comparison.
+        #   2. metadata={} missing assistant_id/graph_id → search filters fail.
+        #   3. "config" key absent → State.get() KeyError.
+        #   4. created_at/updated_at as ISO string → Threads.search() sorts with
+        #      sorted(), raising TypeError when mixing datetime and str.
+        fixed = 0
+        existing_uuids: set[uuid.UUID] = set()
+        store_threads: list[dict[str, Any]] = GLOBAL_STORE.get("threads", [])
+        for entry in store_threads:
+            tid_uuid = _to_uuid_safe(entry.get("thread_id"))
+            if tid_uuid is None:
+                continue
+            existing_uuids.add(tid_uuid)
+            changed = False
+            # Fix 1: string thread_id → UUID object.
+            if not isinstance(entry.get("thread_id"), uuid.UUID):
+                entry["thread_id"] = tid_uuid
+                changed = True
+            # Fix 2: backfill metadata from SQLite.
+            if tid_uuid in sqlite_data:
+                _updated_at, asst_id_str, gid = sqlite_data[tid_uuid]
+                meta: dict[str, Any] = entry.setdefault("metadata", {})
+                if asst_id_str and "assistant_id" not in meta:
+                    meta["assistant_id"] = _to_uuid_safe(asst_id_str) or asst_id_str
+                    changed = True
+                if gid and "graph_id" not in meta:
+                    meta["graph_id"] = gid
+                    changed = True
+            # Fix 3: ensure config key exists.
+            if "config" not in entry:
+                entry["config"] = {}
+                changed = True
+            # Fix 4: convert ISO string timestamps to datetime objects so that
+            # Threads.search() sorted() doesn't raise TypeError.
+            for ts_key in ("created_at", "updated_at", "state_updated_at"):
+                if isinstance(entry.get(ts_key), str):
+                    entry[ts_key] = _parse_dt(entry[ts_key])
+                    changed = True
+            if changed:
+                fixed += 1
+
+        # Pass 2 — append threads that exist in SQLite but are absent entirely.
+        restored = 0
+        for thread_uuid, (updated_at, assistant_id, graph_id) in sqlite_data.items():
+            if thread_uuid in existing_uuids:
+                continue
+            stub_metadata: dict[str, Any] = {}
+            if assistant_id:
+                stub_metadata["assistant_id"] = (
+                    _to_uuid_safe(assistant_id) or assistant_id
+                )
+            if graph_id:
+                stub_metadata["graph_id"] = graph_id
+            ts = _parse_dt(updated_at)
+            stub: dict[str, Any] = {
+                "thread_id": thread_uuid,
+                "created_at": ts,
+                "updated_at": ts,
+                "state_updated_at": ts,
+                "metadata": stub_metadata,
+                "status": "idle",
+                "config": {},
+                "values": None,
+            }
+            GLOBAL_STORE["threads"].append(stub)
+            existing_uuids.add(thread_uuid)
+            restored += 1
+
+        if fixed or restored:
+            _logger.info(
+                "WebUI thread restore: fixed %d existing + appended %d new thread(s) "
+                "in GlobalStore (langgraph_runtime_inmem).",
+                fixed,
+                restored,
+            )
+    except Exception:
+        _logger.warning(
+            "WebUI thread restore failed (non-fatal); WebUI session list may be "
+            "empty until new threads are created.",
+            exc_info=True,
+        )
+
+
+@asynccontextmanager
+async def create_checkpointer_for_langgraph_api() -> AsyncIterator[PruningCheckpointer]:
+    """Async context manager yielding a SQLite-backed ``PruningCheckpointer``.
+
+    Intended as the ``checkpointer.path`` target in
+    ``EvoScientist/langgraph_dev/langgraph.json`` so that the ``langgraph dev``
+    subprocess (used by ``EvoSci deploy`` and WebUI mode) persists session
+    history to ``~/.evoscientist/sessions.db`` rather than the default
+    ``langgraph_runtime_inmem`` ``InMemorySaver``.
+
+    **Why this matters — two failure modes of the default InMemorySaver:**
+
+    1. *Flush-window data loss.*  ``InMemorySaver`` (aka ``langgraph_runtime_inmem``)
+       serialises checkpoints to ``<workspace>/.langgraph_api/*.pckl`` via a
+       background thread that flushes every 10 seconds.  A SIGKILL or abrupt
+       container stop between flushes silently discards all unflushed
+       checkpoints.  SQLite WAL mode commits every ``aput()`` as a proper
+       transaction — no flush window.
+
+    2. *Pickle incompatibility.*  A deepagents / langgraph upgrade can change
+       class definitions stored inside the pickle files.  On reload the error
+       handler calls ``os.remove(self.filename)`` with the *prefix* string
+       (``".langgraph_api/.langgraph_checkpoint."``) rather than the concrete
+       ``*.pckl`` path, so files are not cleaned up.  The process then starts
+       with an empty in-memory store while the API thread-list still reports
+       the old thread ids — producing sessions whose title exists but whose
+       content is empty.  SQLite stores serialised blobs; any deserialization
+       failure is isolated to the specific checkpoint row, not the entire store.
+
+    The ``langgraph-api`` adapter (``_checkpointer._adapter._yield_checkpointer``)
+    detects async context managers and calls ``__aenter__`` / ``__aexit__``
+    automatically, so yielding here is the correct integration pattern.
+
+    ``PruningCheckpointer`` inherits all of ``AsyncSqliteSaver``'s extended
+    methods (``adelete_thread``, ``adelete_for_runs``, ``acopy_thread``,
+    ``aprune``) so the adapter reports full capability and every langgraph-api
+    feature (thread deletion, rollback pruning, thread copy) works correctly.
+    """
+    keep = _resolve_keep_per_ns()
+    async with PruningCheckpointer.from_conn_string_with_keep(
+        str(get_db_path()), keep_per_ns=keep
+    ) as saver:
+        await saver.setup()
+        await _restore_webui_threads_to_global_store()
+        yield saver

--- a/EvoScientist/sessions.py
+++ b/EvoScientist/sessions.py
@@ -15,54 +15,16 @@ Per-step pruning:
     ``aput()``. The first-run migration sweep cleans up legacy bloat.
 
 WebUI / langgraph-dev checkpointer:
-    When EvoScientist runs in ``EvoSci deploy`` or WebUI mode, the agent
-    graph is served by a ``langgraph dev`` subprocess.  By default that
-    subprocess uses ``langgraph_runtime_inmem``'s ``InMemorySaver``, which
-    serialises state to ``<workspace>/.langgraph_api/*.pckl`` files via a
-    background flush loop.  Two failure modes cause history loss on restart:
-
-    1. **Flush-window data loss** — the background thread flushes every
-       10 seconds.  A SIGKILL (or abrupt container stop) between flushes
-       discards the unflushed checkpoints, making sessions disappear.
-
-    2. **Pickle incompatibility** — a deepagents / langgraph upgrade can
-       change class definitions.  On reload ``PersistentDict.load()``
-       raises ``ModuleNotFoundError``; the error handler calls
-       ``os.remove(self.filename)`` with the *prefix* string rather than
-       the concrete ``*.pckl`` path, so the file is not cleaned up.  The
-       process then starts with an empty in-memory dict while the API
-       thread list still reports the thread id (from memory), producing
-       sessions with a title but empty content.
-
-    Fix: ``create_checkpointer_for_langgraph_api()`` is an async context
-    manager that yields a ``PruningCheckpointer`` backed by the same
-    ``~/.evoscientist/sessions.db`` SQLite file used by the CLI/TUI.
-    Configured via ``langgraph.json`` ``checkpointer.path`` so the
-    ``langgraph dev`` subprocess uses it instead of ``InMemorySaver``.
-    SQLite WAL mode gives transaction-level durability — no flush window,
-    no pickle compatibility issues.
-
-WebUI thread-list restoration:
-    ``langgraph_runtime_inmem``'s ``GlobalStore`` keeps the authoritative
-    thread registry in ``conn.store["threads"]`` (an in-memory list that is
-    optionally pickled to ``.langgraph_api/.langgraph_ops.pckl``).  On every
-    restart ``GlobalStore.__init__`` calls ``clear()`` which resets
-    ``store["threads"] = []``.  If the pickle file is absent or
-    undeserializable (e.g. after a package upgrade), the thread list stays
-    empty even though all checkpoint data is safely stored in SQLite.
-
-    ``create_checkpointer_for_langgraph_api()`` therefore also calls
-    ``_restore_webui_threads_to_global_store()`` before yielding.  This
-    function reads all UUID-format thread IDs from the SQLite ``checkpoints``
-    table (rows written by ``langgraph dev`` runs use standard UUID thread
-    IDs, vs. the 8-char hex IDs used by the CLI/TUI) and re-populates
-    ``conn.store["threads"]`` with minimal stub dicts that satisfy
-    ``POST /threads/search``.  The stub contains ``thread_id``, ``metadata``,
-    ``created_at``, ``updated_at``, ``state_updated_at``, ``status``, and
-    ``values`` — the exact fields expected by the WebUI front-end.
-
-    The restore is best-effort: any error is logged and silently skipped so
-    a broken restore never prevents the checkpointer from starting.
+    ``create_checkpointer_for_langgraph_api()`` — the ``checkpointer.path``
+    target in ``langgraph_dev/langgraph.json`` — backs every ``langgraph
+    dev`` subprocess (deploy / WebUI / CLI-spawned) with this same SQLite
+    file instead of the default pickle-based ``InMemorySaver``, whose flush
+    window and pickle-compatibility failures lose session history on
+    restart (issue #277). On startup it purges leftover evomemory-worker
+    rows and rebuilds the in-memory thread registry from SQLite. See
+    ``_restore_webui_threads_to_global_store`` for the restore scope and
+    ``_ApiPruningCheckpointer`` for the metadata stamping that makes WebUI
+    threads first-class CLI sessions.
 """
 
 import asyncio
@@ -1426,29 +1388,112 @@ async def db_stats(top_n: int = 5) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _api_workspace_dir() -> str:
+    """Resolve the langgraph dev subprocess's workspace directory.
+
+    ``start_langgraph_dev`` injects ``EVOSCIENTIST_WORKSPACE_DIR`` and sets
+    the subprocess cwd to the workspace, so either source identifies the
+    workspace this server instance is serving.
+    """
+    import os
+
+    ws = os.environ.get("EVOSCIENTIST_WORKSPACE_DIR", "").strip()
+    if ws:
+        return str(Path(ws).expanduser().resolve())
+    return str(Path.cwd().resolve())
+
+
+class _ApiPruningCheckpointer(PruningCheckpointer):
+    """``PruningCheckpointer`` that stamps CLI-compatible ownership metadata.
+
+    langgraph-api run metadata carries ``graph_id``/``assistant_id`` but not
+    the ``agent_name`` / ``workspace_dir`` / ``updated_at`` keys that the CLI
+    session surface (``list_threads``, ``/resume``, ``/delete``,
+    ``_prune_after_put``) filters and sorts on. Stamping them at write time
+    — for main-graph runs only — makes WebUI threads first-class CLI
+    sessions in the same workspace, and brings them under the existing
+    pruning/retention machinery. Worker and async-subagent graphs are left
+    unstamped on purpose: they must not surface in CLI listings.
+    """
+
+    async def aput(
+        self,
+        config: Any,
+        checkpoint: Any,
+        metadata: Any,
+        new_versions: Any,
+    ) -> Any:
+        if isinstance(metadata, dict) and metadata.get("graph_id") == AGENT_NAME:
+            metadata = dict(metadata)
+            metadata.setdefault("agent_name", AGENT_NAME)
+            metadata.setdefault("workspace_dir", _api_workspace_dir())
+            metadata["updated_at"] = datetime.now(UTC).isoformat()
+        return await super().aput(config, checkpoint, metadata, new_versions)
+
+
+async def _purge_internal_worker_threads() -> None:
+    """Best-effort removal of evomemory-worker checkpoint residue.
+
+    Finished workers delete their own thread (see
+    ``middleware/memory_lifecycle.py``), but a crash between run completion
+    and deletion leaves rows behind — and rows written before that cleanup
+    existed are still in the DB. Idempotent, runs on every server start,
+    and never blocks startup on failure.
+    """
+    try:
+        db_path = str(get_db_path())
+        async with aiosqlite.connect(db_path, timeout=30.0) as conn:
+            if not await _table_exists(conn, "checkpoints"):
+                return
+            if await _table_exists(conn, "writes"):
+                await conn.execute(
+                    """
+                    DELETE FROM writes WHERE thread_id IN (
+                        SELECT DISTINCT thread_id FROM checkpoints
+                        WHERE json_extract(metadata, '$.graph_id') LIKE 'evomemory-%'
+                    )
+                    """
+                )
+            cur = await conn.execute(
+                """
+                DELETE FROM checkpoints
+                WHERE json_extract(metadata, '$.graph_id') LIKE 'evomemory-%'
+                """
+            )
+            await conn.commit()
+            if cur.rowcount:
+                _logger.info(
+                    "Purged %d leftover evomemory-worker checkpoint row(s).",
+                    cur.rowcount,
+                )
+    except Exception:
+        _logger.warning(
+            "evomemory-worker residue purge failed (non-fatal).", exc_info=True
+        )
+
+
 async def _restore_webui_threads_to_global_store() -> None:
     """Re-populate ``GlobalStore["threads"]`` from SQLite on server startup.
 
-    ``langgraph_runtime_inmem``'s ``GlobalStore`` resets ``store["threads"] = []``
-    on every process start (``GlobalStore.__init__`` calls ``clear()``).  If the
-    ``.pckl`` file is absent or corrupt — which happens after every package
-    upgrade — the WebUI sidebar shows an empty thread list even though all
-    checkpoint data is safely persisted in SQLite.
+    The inmem runtime's thread registry lives in memory (pickled to
+    ``.langgraph_ops.pckl``) and is cleared on every start — if the pickle
+    is absent or corrupt, the WebUI sidebar is empty even though all
+    checkpoint data sits safely in SQLite. This rebuilds it: ghost entries
+    whose threads have no checkpoint rows are dropped, surviving entries
+    are normalized in place, and missing threads are appended as stub
+    dicts that satisfy ``POST /threads/search``.
 
-    This function reads every UUID-format thread ID from the SQLite
-    ``checkpoints`` table and re-inserts minimal stub dicts into
-    ``GLOBAL_STORE["threads"]`` so the ``POST /threads/search`` endpoint
-    can return them.  Existing entries (e.g. restored from a valid ``.pckl``)
-    are not duplicated.
+    Restore scope — only threads that are BOTH main-graph
+    (``metadata.graph_id == AGENT_NAME``) and owned by this server's
+    workspace (``metadata.workspace_dir`` matches): sessions.db is
+    machine-global, and an unscoped restore would expose every workspace's
+    history (and internal worker threads) on the unauthenticated API —
+    worst case ``--tunnel``. CLI/TUI threads (8-char hex IDs, managed by
+    ``list_threads()``) and pre-stamping rows without ``workspace_dir``
+    are excluded.
 
-    UUID-format IDs (``xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``) are used by
-    ``langgraph dev`` / WebUI runs; the CLI/TUI uses 8-char hex IDs which
-    are intentionally excluded — those are managed by ``list_threads()`` and
-    the CLI commands, not the WebUI.
-
-    The restore is best-effort: any exception is logged and swallowed so a
-    broken restore never prevents the checkpointer (and therefore the whole
-    ``langgraph dev`` server) from starting.
+    Best-effort: any exception is logged and swallowed so a broken restore
+    never prevents the ``langgraph dev`` server from starting.
     """
     try:
         from langgraph_runtime_inmem.database import (  # type: ignore[import-untyped]
@@ -1459,32 +1504,31 @@ async def _restore_webui_threads_to_global_store() -> None:
         return
 
     try:
+        rows: list[Any] = []
         db_path = str(get_db_path())
         async with aiosqlite.connect(db_path, timeout=30.0) as conn:
-            if not await _table_exists(conn, "checkpoints"):
-                return
-
-            # Fetch all distinct UUID-format thread IDs with their latest
-            # checkpoint timestamp and the assistant_id / graph_id stored in
-            # the checkpoint metadata.  These are written by the langgraph-api
-            # adapter (_enrich_metadata) and are required by the WebUI's
-            # POST /threads/search filter (e.g. metadata.assistant_id).
-            # UUID regex: 8-4-4-4-12 hex groups.
-            query = """
-                SELECT thread_id,
-                       MAX(json_extract(metadata, '$.updated_at')) as updated_at,
-                       json_extract(metadata, '$.assistant_id') as assistant_id,
-                       json_extract(metadata, '$.graph_id') as graph_id
-                FROM checkpoints
-                WHERE thread_id LIKE '________-____-____-____-____________'
-                GROUP BY thread_id
-                ORDER BY updated_at DESC
-            """
-            async with conn.execute(query) as cur:
-                rows = await cur.fetchall()
-
-        if not rows:
-            return
+            # No checkpoints table (fresh DB) → rows stays empty, but the
+            # ghost-removal pass below must still run: every UUID entry the
+            # .pckl registry loaded is then stale by definition.
+            if await _table_exists(conn, "checkpoints"):
+                # Fetch all distinct UUID-format thread IDs with their latest
+                # checkpoint timestamp and the assistant_id / graph_id stored
+                # in the checkpoint metadata.  Required by the WebUI's
+                # POST /threads/search filter (e.g. metadata.assistant_id).
+                # UUID regex: 8-4-4-4-12 hex groups.
+                query = """
+                    SELECT thread_id,
+                           MAX(json_extract(metadata, '$.updated_at')) as updated_at,
+                           json_extract(metadata, '$.assistant_id') as assistant_id,
+                           json_extract(metadata, '$.graph_id') as graph_id,
+                           MAX(json_extract(metadata, '$.workspace_dir')) as workspace_dir
+                    FROM checkpoints
+                    WHERE thread_id LIKE '________-____-____-____-____________'
+                    GROUP BY thread_id
+                    ORDER BY updated_at DESC
+                """
+                async with conn.execute(query) as cur:
+                    rows = await cur.fetchall()
 
         def _to_uuid_safe(v: Any) -> uuid.UUID | None:
             try:
@@ -1492,13 +1536,32 @@ async def _restore_webui_threads_to_global_store() -> None:
             except (ValueError, AttributeError):
                 return None
 
-        # Build a lookup of SQLite data keyed by UUID object.
+        # All UUID threads that have ANY checkpoint rows — the existence
+        # check for ghost removal (deliberately unscoped: a thread whose
+        # checkpoints exist but fall outside the restore scope is not a
+        # ghost, its state still loads when opened).
+        uuid_threads_in_db: set[uuid.UUID] = set()
+        # Restore scope: ONLY main-graph threads belonging to THIS server's
+        # workspace. sessions.db is machine-global, so an unscoped restore
+        # would resurrect every workspace's history (and internal
+        # worker/subagent threads) into this server's thread registry — and
+        # expose it over the unauthenticated API / --tunnel.
+        # workspace_dir/agent_name are stamped at write time by
+        # _ApiPruningCheckpointer; rows that predate stamping have no
+        # workspace_dir and are deliberately excluded.
+        current_workspace = _api_workspace_dir()
         sqlite_data: dict[uuid.UUID, tuple[str | None, str | None, str | None]] = {}
         for row in rows:
-            thread_id_str, updated_at, assistant_id, graph_id = row
+            thread_id_str, updated_at, assistant_id, graph_id, workspace_dir = row
             thread_uuid = _to_uuid_safe(thread_id_str)
-            if thread_uuid is not None:
-                sqlite_data[thread_uuid] = (updated_at, assistant_id, graph_id)
+            if thread_uuid is None:
+                continue
+            uuid_threads_in_db.add(thread_uuid)
+            if graph_id != AGENT_NAME:
+                continue
+            if not workspace_dir or workspace_dir != current_workspace:
+                continue
+            sqlite_data[thread_uuid] = (updated_at, assistant_id, graph_id)
 
         def _parse_dt(s: str | None) -> datetime:
             """Parse an ISO timestamp string to datetime, falling back to now."""
@@ -1509,42 +1572,48 @@ async def _restore_webui_threads_to_global_store() -> None:
                     pass
             return datetime.now(UTC)
 
-        # Pass 1 — fix issues in-place on threads already present in GlobalStore.
-        # Threads loaded from .pckl may have:
-        #   1. thread_id as plain string → needs uuid.UUID for == comparison.
-        #   2. metadata={} missing assistant_id/graph_id → search filters fail.
-        #   3. "config" key absent → State.get() KeyError.
-        #   4. created_at/updated_at as ISO string → Threads.search() sorts with
-        #      sorted(), raising TypeError when mixing datetime and str.
+        # Drop ghost entries: a .pckl-loaded UUID entry with no checkpoint
+        # rows opens as an empty session (the #277 symptom). Slice
+        # assignment mutates the live registry list.
+        store_threads: list[dict[str, Any]] = GLOBAL_STORE.get("threads", [])
+        before = len(store_threads)
+        store_threads[:] = [
+            entry
+            for entry in store_threads
+            if (tid := _to_uuid_safe(entry.get("thread_id"))) is None
+            or tid in uuid_threads_in_db
+        ]
+        removed = before - len(store_threads)
+
+        # Normalize surviving .pckl-loaded entries in place.
         fixed = 0
         existing_uuids: set[uuid.UUID] = set()
-        store_threads: list[dict[str, Any]] = GLOBAL_STORE.get("threads", [])
         for entry in store_threads:
             tid_uuid = _to_uuid_safe(entry.get("thread_id"))
             if tid_uuid is None:
                 continue
             existing_uuids.add(tid_uuid)
             changed = False
-            # Fix 1: string thread_id → UUID object.
+            # Threads.get() compares against _ensure_uuid() — str never matches.
             if not isinstance(entry.get("thread_id"), uuid.UUID):
                 entry["thread_id"] = tid_uuid
                 changed = True
-            # Fix 2: backfill metadata from SQLite.
             if tid_uuid in sqlite_data:
                 _updated_at, asst_id_str, gid = sqlite_data[tid_uuid]
                 meta: dict[str, Any] = entry.setdefault("metadata", {})
                 if asst_id_str and "assistant_id" not in meta:
-                    meta["assistant_id"] = _to_uuid_safe(asst_id_str) or asst_id_str
+                    # str, not uuid.UUID: the runtime stores str and search
+                    # filters compare with raw == against JSON strings.
+                    meta["assistant_id"] = str(asst_id_str)
                     changed = True
                 if gid and "graph_id" not in meta:
                     meta["graph_id"] = gid
                     changed = True
-            # Fix 3: ensure config key exists.
+            # State.get() KeyErrors without "config".
             if "config" not in entry:
                 entry["config"] = {}
                 changed = True
-            # Fix 4: convert ISO string timestamps to datetime objects so that
-            # Threads.search() sorted() doesn't raise TypeError.
+            # Threads.search() sorted() raises on datetime-vs-str mixes.
             for ts_key in ("created_at", "updated_at", "state_updated_at"):
                 if isinstance(entry.get(ts_key), str):
                     entry[ts_key] = _parse_dt(entry[ts_key])
@@ -1552,16 +1621,15 @@ async def _restore_webui_threads_to_global_store() -> None:
             if changed:
                 fixed += 1
 
-        # Pass 2 — append threads that exist in SQLite but are absent entirely.
+        # Append threads present in SQLite but absent from the registry.
         restored = 0
         for thread_uuid, (updated_at, assistant_id, graph_id) in sqlite_data.items():
             if thread_uuid in existing_uuids:
                 continue
             stub_metadata: dict[str, Any] = {}
             if assistant_id:
-                stub_metadata["assistant_id"] = (
-                    _to_uuid_safe(assistant_id) or assistant_id
-                )
+                # str, not uuid.UUID — same convention as above.
+                stub_metadata["assistant_id"] = str(assistant_id)
             if graph_id:
                 stub_metadata["graph_id"] = graph_id
             ts = _parse_dt(updated_at)
@@ -1579,12 +1647,14 @@ async def _restore_webui_threads_to_global_store() -> None:
             existing_uuids.add(thread_uuid)
             restored += 1
 
-        if fixed or restored:
+        if fixed or restored or removed:
             _logger.info(
-                "WebUI thread restore: fixed %d existing + appended %d new thread(s) "
-                "in GlobalStore (langgraph_runtime_inmem).",
+                "WebUI thread restore: fixed %d existing + appended %d new + "
+                "removed %d ghost thread(s) in GlobalStore "
+                "(langgraph_runtime_inmem).",
                 fixed,
                 restored,
+                removed,
             )
     except Exception:
         _logger.warning(
@@ -1596,46 +1666,33 @@ async def _restore_webui_threads_to_global_store() -> None:
 
 @asynccontextmanager
 async def create_checkpointer_for_langgraph_api() -> AsyncIterator[PruningCheckpointer]:
-    """Async context manager yielding a SQLite-backed ``PruningCheckpointer``.
+    """SQLite-backed checkpointer for the ``langgraph dev`` subprocess.
 
-    Intended as the ``checkpointer.path`` target in
-    ``EvoScientist/langgraph_dev/langgraph.json`` so that the ``langgraph dev``
-    subprocess (used by ``EvoSci deploy`` and WebUI mode) persists session
-    history to ``~/.evoscientist/sessions.db`` rather than the default
-    ``langgraph_runtime_inmem`` ``InMemorySaver``.
+    ``checkpointer.path`` target in ``langgraph_dev/langgraph.json``
+    (applies to every ``langgraph dev`` launch: deploy, WebUI, and the
+    CLI-spawned subprocess). Replaces the default pickle-based
+    ``InMemorySaver``, whose 10s flush window drops recent checkpoints on
+    SIGKILL and whose pickle-incompatible upgrades wipe the whole store
+    (issue #277); here every ``aput()`` commits a WAL transaction and a
+    bad row only loses that row. The langgraph-api adapter detects async
+    context managers and enters them automatically.
 
-    **Why this matters — two failure modes of the default InMemorySaver:**
+    The yielded ``_ApiPruningCheckpointer`` stamps main-graph rows with
+    ``agent_name`` / ``workspace_dir`` / ``updated_at`` so WebUI threads
+    surface in the CLI session commands and participate in
+    ``_prune_after_put`` retention.
 
-    1. *Flush-window data loss.*  ``InMemorySaver`` (aka ``langgraph_runtime_inmem``)
-       serialises checkpoints to ``<workspace>/.langgraph_api/*.pckl`` via a
-       background thread that flushes every 10 seconds.  A SIGKILL or abrupt
-       container stop between flushes silently discards all unflushed
-       checkpoints.  SQLite WAL mode commits every ``aput()`` as a proper
-       transaction — no flush window.
-
-    2. *Pickle incompatibility.*  A deepagents / langgraph upgrade can change
-       class definitions stored inside the pickle files.  On reload the error
-       handler calls ``os.remove(self.filename)`` with the *prefix* string
-       (``".langgraph_api/.langgraph_checkpoint."``) rather than the concrete
-       ``*.pckl`` path, so files are not cleaned up.  The process then starts
-       with an empty in-memory store while the API thread-list still reports
-       the old thread ids — producing sessions whose title exists but whose
-       content is empty.  SQLite stores serialised blobs; any deserialization
-       failure is isolated to the specific checkpoint row, not the entire store.
-
-    The ``langgraph-api`` adapter (``_checkpointer._adapter._yield_checkpointer``)
-    detects async context managers and calls ``__aenter__`` / ``__aexit__``
-    automatically, so yielding here is the correct integration pattern.
-
-    ``PruningCheckpointer`` inherits all of ``AsyncSqliteSaver``'s extended
-    methods (``adelete_thread``, ``adelete_for_runs``, ``acopy_thread``,
-    ``aprune``) so the adapter reports full capability and every langgraph-api
-    feature (thread deletion, rollback pruning, thread copy) works correctly.
+    Capability note: ``adelete_thread`` is real, but ``aprune`` /
+    ``adelete_for_runs`` / ``acopy_thread`` remain ``BaseCheckpointSaver``
+    raising stubs — langgraph-api's probe reports them missing and
+    degrades (``multitask_strategy='rollback'`` cleanup raises; thread
+    copy uses the slow generic fallback).
     """
     keep = _resolve_keep_per_ns()
-    async with PruningCheckpointer.from_conn_string_with_keep(
+    async with _ApiPruningCheckpointer.from_conn_string_with_keep(
         str(get_db_path()), keep_per_ns=keep
     ) as saver:
         await saver.setup()
+        await _purge_internal_worker_threads()
         await _restore_webui_threads_to_global_store()
         yield saver

--- a/tests/test_observation_memory.py
+++ b/tests/test_observation_memory.py
@@ -877,6 +877,10 @@ def test_async_watcher_deletes_worker_thread_on_terminal_status(
 
     class _Threads:
         async def delete(self, thread_id):
+            # Accounting must complete BEFORE the best-effort deletion —
+            # cancellation mid-deletion must never leave the worker
+            # stuck as "running" (CodeRabbit on #279).
+            assert worker_activity.memory_worker_status().is_running is False
             deleted.append(thread_id)
 
     monkeypatch.setattr(memory_lifecycle, "_MEMORY_WORKER_POLL_INTERVAL_SECONDS", 0)

--- a/tests/test_observation_memory.py
+++ b/tests/test_observation_memory.py
@@ -754,6 +754,147 @@ def test_memory_worker_watcher_finishes_on_terminal_status(tmp_path, monkeypatch
         worker_activity.reset_memory_worker_status_for_tests()
 
 
+def test_sync_watcher_deletes_worker_thread_on_terminal_status(tmp_path, monkeypatch):
+    """Finished workers leave no checkpoint residue: thread is deleted."""
+    worker_activity.reset_memory_worker_status_for_tests()
+    worker_activity.mark_memory_worker_started(
+        thread_id="worker-thread",
+        run_id="run-1",
+        memory_dir=tmp_path / "memories",
+    )
+    deleted: list[str] = []
+
+    class _Runs:
+        def get(self, **_kwargs):
+            return {"status": "success"}
+
+    class _Threads:
+        def delete(self, thread_id):
+            deleted.append(thread_id)
+
+    monkeypatch.setattr(
+        "langgraph_sdk.get_sync_client",
+        lambda **_kwargs: SimpleNamespace(runs=_Runs(), threads=_Threads()),
+    )
+    monkeypatch.setattr(memory_lifecycle, "_MEMORY_WORKER_POLL_INTERVAL_SECONDS", 0)
+
+    try:
+        memory_lifecycle._watch_memory_worker_run_sync(
+            url="http://x",
+            thread_id="worker-thread",
+            run_id="run-1",
+        )
+        assert deleted == ["worker-thread"]
+        assert worker_activity.memory_worker_status().is_running is False
+    finally:
+        worker_activity.reset_memory_worker_status_for_tests()
+
+
+def test_sync_watcher_delete_failure_still_marks_finished(tmp_path, monkeypatch):
+    """Thread deletion is best-effort: a failure must not break accounting."""
+    worker_activity.reset_memory_worker_status_for_tests()
+    worker_activity.mark_memory_worker_started(
+        thread_id="worker-thread",
+        run_id="run-1",
+        memory_dir=tmp_path / "memories",
+    )
+
+    class _Runs:
+        def get(self, **_kwargs):
+            return {"status": "success"}
+
+    class _Threads:
+        def delete(self, thread_id):
+            raise RuntimeError("delete failed")
+
+    monkeypatch.setattr(
+        "langgraph_sdk.get_sync_client",
+        lambda **_kwargs: SimpleNamespace(runs=_Runs(), threads=_Threads()),
+    )
+    monkeypatch.setattr(memory_lifecycle, "_MEMORY_WORKER_POLL_INTERVAL_SECONDS", 0)
+
+    try:
+        memory_lifecycle._watch_memory_worker_run_sync(
+            url="http://x",
+            thread_id="worker-thread",
+            run_id="run-1",
+        )
+        assert worker_activity.memory_worker_status().is_running is False
+    finally:
+        worker_activity.reset_memory_worker_status_for_tests()
+
+
+def test_sync_watcher_does_not_delete_thread_on_poll_abort(tmp_path, monkeypatch):
+    """A run we lost track of may still be live — never delete its thread."""
+    worker_activity.reset_memory_worker_status_for_tests()
+    worker_activity.mark_memory_worker_started(
+        thread_id="worker-thread",
+        run_id="run-1",
+        memory_dir=tmp_path / "memories",
+    )
+    deleted: list[str] = []
+
+    class _Runs:
+        def get(self, **_kwargs):
+            raise RuntimeError("poll failed")
+
+    class _Threads:
+        def delete(self, thread_id):
+            deleted.append(thread_id)
+
+    monkeypatch.setattr(
+        "langgraph_sdk.get_sync_client",
+        lambda **_kwargs: SimpleNamespace(runs=_Runs(), threads=_Threads()),
+    )
+    monkeypatch.setattr(memory_lifecycle, "_MEMORY_WORKER_POLL_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(memory_lifecycle, "_MEMORY_WORKER_MAX_POLL_FAILURES", 1)
+
+    try:
+        memory_lifecycle._watch_memory_worker_run_sync(
+            url="http://x",
+            thread_id="worker-thread",
+            run_id="run-1",
+        )
+        assert deleted == []
+    finally:
+        worker_activity.reset_memory_worker_status_for_tests()
+
+
+def test_async_watcher_deletes_worker_thread_on_terminal_status(
+    tmp_path, monkeypatch, run_async
+):
+    worker_activity.reset_memory_worker_status_for_tests()
+    worker_activity.mark_memory_worker_started(
+        thread_id="worker-thread",
+        run_id="run-1",
+        memory_dir=tmp_path / "memories",
+    )
+    deleted: list[str] = []
+
+    class _Runs:
+        async def get(self, **_kwargs):
+            return {"status": "success"}
+
+    class _Threads:
+        async def delete(self, thread_id):
+            deleted.append(thread_id)
+
+    monkeypatch.setattr(memory_lifecycle, "_MEMORY_WORKER_POLL_INTERVAL_SECONDS", 0)
+
+    try:
+        run_async(
+            memory_lifecycle._watch_memory_worker_run_async(
+                SimpleNamespace(runs=_Runs(), threads=_Threads()),
+                thread_id="worker-thread",
+                run_id="run-1",
+            )
+        )
+        assert deleted == ["worker-thread"]
+        assert worker_activity.memory_worker_status().is_running is False
+    finally:
+        worker_activity.reset_memory_worker_status_for_tests()
+
+
 def test_memory_worker_skips_when_langgraph_dev_unavailable(tmp_path, monkeypatch):
     monkeypatch.setattr(memory_lifecycle, "_memory_worker_url", lambda: "http://x")
     monkeypatch.setattr(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2121,36 +2121,118 @@ class TestCreateCheckpointerForLanggraphApi(unittest.TestCase):
 
         _run(_run_inner())
 
-    def test_has_required_extended_methods(self):
-        """Yielded checkpointer exposes the full capability set expected by
-        ``langgraph-api``'s ``_CustomCheckpointerAdapter``."""
-        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+    def test_capability_surface_matches_langgraph_api_probe(self):
+        """Document the REAL capability surface langgraph-api will detect.
+
+        The adapter's ``_is_overridden`` probe compares each method against
+        ``BaseCheckpointSaver``: inherited raising stubs do NOT count as
+        capability. ``callable()`` checks would pass on the stubs and give
+        false confidence (the original PR test did exactly that).
+        """
+        from langgraph.checkpoint.base import BaseCheckpointSaver
+
+        from EvoScientist.sessions import _ApiPruningCheckpointer
+
+        def overridden(name: str) -> bool:
+            base = getattr(BaseCheckpointSaver, name, None)
+            sub = getattr(_ApiPruningCheckpointer, name, None)
+            return base is not None and sub is not None and sub is not base
+
+        # Real implementations the adapter will detect and use.
+        for method in ("adelete_thread", "aget_tuple", "aput", "aput_writes"):
+            assert overridden(method), f"'{method}' must be a real implementation"
+        # Known degradations: still BaseCheckpointSaver raising stubs.
+        # rollback cleanup raises at runtime; thread copy uses the adapter's
+        # slow generic fallback. If these start passing, the docstring in
+        # create_checkpointer_for_langgraph_api should be updated.
+        for method in ("aprune", "adelete_for_runs", "acopy_thread"):
+            assert not overridden(method), (
+                f"'{method}' is now overridden — update the capability "
+                "docstring in create_checkpointer_for_langgraph_api"
+            )
+
+    def test_aput_stamps_cli_metadata_for_main_graph_rows(self):
+        """Main-graph (graph_id == AGENT_NAME) rows get agent_name /
+        workspace_dir / updated_at so they surface in CLI listings and
+        participate in pruning."""
+        import json
+
+        import aiosqlite
+
+        from EvoScientist.sessions import (
+            AGENT_NAME,
+            create_checkpointer_for_langgraph_api,
+        )
+
+        def _checkpoint(cid: str) -> dict:
+            return {
+                "v": 1,
+                "id": cid,
+                "ts": "2024-01-01T00:00:00+00:00",
+                "channel_values": {"messages": []},
+                "channel_versions": {},
+                "versions_seen": {},
+                "pending_sends": [],
+            }
+
+        async def _run_inner(db: str):
+            async with create_checkpointer_for_langgraph_api() as cp:
+                # Simulates a WebUI main-graph run (langgraph-api metadata).
+                await cp.aput(
+                    {
+                        "configurable": {
+                            "thread_id": "11111111-1111-1111-1111-111111111111",
+                            "checkpoint_ns": "",
+                        }
+                    },
+                    _checkpoint("ckpt-main"),
+                    {"source": "loop", "step": 1, "graph_id": AGENT_NAME},
+                    {},
+                )
+                # Simulates a memory-worker run: must stay unstamped.
+                await cp.aput(
+                    {
+                        "configurable": {
+                            "thread_id": "22222222-2222-2222-2222-222222222222",
+                            "checkpoint_ns": "",
+                        }
+                    },
+                    _checkpoint("ckpt-worker"),
+                    {"source": "loop", "step": 1, "graph_id": "evomemory-turn-worker"},
+                    {},
+                )
+            async with aiosqlite.connect(db) as conn:
+                rows = {}
+                async with conn.execute(
+                    "SELECT thread_id, metadata FROM checkpoints"
+                ) as cur:
+                    async for tid, meta in cur:
+                        rows[tid] = json.loads(meta)
+            main = rows["11111111-1111-1111-1111-111111111111"]
+            worker = rows["22222222-2222-2222-2222-222222222222"]
+            assert main.get("agent_name") == AGENT_NAME
+            assert main.get("workspace_dir") == "/tmp/test-workspace"
+            assert main.get("updated_at"), "updated_at drives /threads ordering"
+            assert "agent_name" not in worker
+            assert "workspace_dir" not in worker
 
         with tempfile.TemporaryDirectory() as td:
             db = os.path.join(td, "sessions.db")
-            with patch(
-                "EvoScientist.sessions.get_db_path",
-                return_value=_mock_path(db),
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    os.environ,
+                    {"EVOSCIENTIST_WORKSPACE_DIR": "/tmp/test-workspace"},
+                ),
+                patch(
+                    "EvoScientist.sessions._api_workspace_dir",
+                    return_value="/tmp/test-workspace",
+                ),
             ):
-
-                async def _run_inner():
-                    async with create_checkpointer_for_langgraph_api() as cp:
-                        for method in (
-                            "adelete_thread",
-                            "adelete_for_runs",
-                            "acopy_thread",
-                            "aprune",
-                            "aget_tuple",
-                            "aput",
-                            "aput_writes",
-                            "alist",
-                        ):
-                            assert callable(getattr(cp, method, None)), (
-                                f"PruningCheckpointer must expose '{method}' for "
-                                "langgraph-api full-capability compliance"
-                            )
-
-                _run(_run_inner())
+                _run(_run_inner(db))
 
 
 class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
@@ -2161,12 +2243,15 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
     so the WebUI sidebar is not empty after a package upgrade or clean restart.
     """
 
+    _WS = "/tmp/restore-test-workspace"
+
     def _make_db_with_threads(
         self,
         db_path: str,
         thread_ids: list[str],
         assistant_id: str = "aaaa-bbbb",
         graph_id: str = "EvoScientist",
+        workspace_dir: str | None = _WS,
     ) -> None:
         """Insert minimal checkpoint rows for the given thread_ids into a fresh DB."""
         import json
@@ -2174,25 +2259,31 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
 
         con = sqlite3.connect(db_path)
         con.execute(
-            "CREATE TABLE checkpoints "
+            "CREATE TABLE IF NOT EXISTS checkpoints "
             "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT PRIMARY KEY, "
             " parent_checkpoint_id TEXT, type TEXT, checkpoint BLOB, metadata TEXT)"
         )
         for tid in thread_ids:
-            meta = json.dumps(
-                {
-                    "updated_at": "2025-01-01T00:00:00+00:00",
-                    "agent_name": "EvoScientist",
-                    "assistant_id": assistant_id,
-                    "graph_id": graph_id,
-                }
-            )
+            meta_dict = {
+                "updated_at": "2025-01-01T00:00:00+00:00",
+                "agent_name": "EvoScientist",
+                "assistant_id": assistant_id,
+                "graph_id": graph_id,
+            }
+            if workspace_dir is not None:
+                meta_dict["workspace_dir"] = workspace_dir
+            meta = json.dumps(meta_dict)
             con.execute(
                 "INSERT INTO checkpoints VALUES (?,?,?,?,?,?,?)",
                 (tid, "", f"ckpt-{tid[:8]}", None, "empty", b"", meta),
             )
         con.commit()
         con.close()
+
+    def _patch_workspace(self):
+        from unittest.mock import patch
+
+        return patch("EvoScientist.sessions._api_workspace_dir", return_value=self._WS)
 
     def test_restores_uuid_threads_into_global_store(self):
         """UUID-format thread IDs from SQLite are injected into GlobalStore."""
@@ -2227,6 +2318,7 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
                 patch.dict(
                     sys.modules, {"langgraph_runtime_inmem.database": fake_module}
                 ),
+                self._patch_workspace(),
             ):
                 _run(_restore_webui_threads_to_global_store())
 
@@ -2245,10 +2337,12 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
         )
         assert added[0]["thread_id"] == _uuid_mod.UUID(uuid_id)
         assert added[0]["status"] == "idle"
-        # metadata must carry assistant_id (as UUID) and graph_id so
-        # POST /threads/search filters work correctly in the WebUI.
-        assert isinstance(added[0]["metadata"].get("assistant_id"), _uuid_mod.UUID)
-        assert added[0]["metadata"].get("assistant_id") == _uuid_mod.UUID(asst_uuid_id)
+        # metadata.assistant_id must stay a STRING: the runtime stores
+        # str(assistant_id) (ops.py Threads.create) and search filters compare
+        # with raw == against JSON strings — a uuid.UUID here would silently
+        # exclude restored threads from assistant_id-filtered searches.
+        assert added[0]["metadata"].get("assistant_id") == asst_uuid_id
+        assert isinstance(added[0]["metadata"].get("assistant_id"), str)
         assert added[0]["metadata"].get("graph_id") == "EvoScientist"
         # created_at / updated_at must be datetime objects, not ISO strings.
         # Threads.search() sorts by these fields using sorted(); mixing
@@ -2300,6 +2394,7 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
                 patch.dict(
                     sys.modules, {"langgraph_runtime_inmem.database": fake_module}
                 ),
+                self._patch_workspace(),
             ):
                 _run(_restore_webui_threads_to_global_store())
 
@@ -2313,9 +2408,158 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
             f"thread_id must be uuid.UUID after fix, got {type(t['thread_id'])}"
         )
         assert t["thread_id"] == _uuid_mod.UUID(uuid_id)
-        # metadata must be backfilled.
-        assert isinstance(t["metadata"].get("assistant_id"), _uuid_mod.UUID)
+        # metadata must be backfilled — assistant_id as str (runtime convention).
+        assert t["metadata"].get("assistant_id") == asst_uuid_id
+        assert isinstance(t["metadata"].get("assistant_id"), str)
         assert t["metadata"].get("graph_id") == "EvoScientist"
+
+    def test_restore_excludes_other_workspaces_and_internal_graphs(self):
+        """The restore scope is graph_id==AGENT_NAME AND current workspace.
+
+        Threads from other workspaces, internal worker/subagent graphs, and
+        pre-stamping rows without workspace_dir must NOT be resurrected —
+        sessions.db is machine-global and an unscoped restore would expose
+        them on the unauthenticated API (worst case --tunnel).
+        """
+        import sys
+        import uuid as _uuid_mod
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        mine = "11111111-1111-1111-1111-111111111111"
+        other_ws = "22222222-2222-2222-2222-222222222222"
+        worker = "33333333-3333-3333-3333-333333333333"
+        subagent = "44444444-4444-4444-4444-444444444444"
+        legacy_no_ws = "55555555-5555-5555-5555-555555555555"
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            self._make_db_with_threads(db, [mine])
+            self._make_db_with_threads(db, [other_ws], workspace_dir="/elsewhere")
+            self._make_db_with_threads(db, [worker], graph_id="evomemory-turn-worker")
+            self._make_db_with_threads(db, [subagent], graph_id="writing-agent")
+            self._make_db_with_threads(db, [legacy_no_ws], workspace_dir=None)
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+                self._patch_workspace(),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        added = mock_store["threads"]
+        assert len(added) == 1, (
+            f"Only the current-workspace main-graph thread may be restored, "
+            f"got {len(added)}: {[t['thread_id'] for t in added]}"
+        )
+        assert added[0]["thread_id"] == _uuid_mod.UUID(mine)
+
+    def test_purge_removes_only_evomemory_rows(self):
+        """Startup purge drops evomemory-* residue, leaves everything else."""
+        import sqlite3
+        from unittest.mock import patch
+
+        from EvoScientist.sessions import _purge_internal_worker_threads
+
+        keep_main = "11111111-1111-1111-1111-111111111111"
+        keep_cli = "abcd1234"
+        drop_worker = "33333333-3333-3333-3333-333333333333"
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            self._make_db_with_threads(db, [keep_main, keep_cli])
+            self._make_db_with_threads(
+                db, [drop_worker], graph_id="evomemory-turn-worker"
+            )
+            with patch(
+                "EvoScientist.sessions.get_db_path",
+                return_value=_mock_path(db),
+            ):
+                _run(_purge_internal_worker_threads())
+                # Idempotent: second run is a no-op, not an error.
+                _run(_purge_internal_worker_threads())
+
+            con = sqlite3.connect(db)
+            remaining = {
+                r[0] for r in con.execute("SELECT DISTINCT thread_id FROM checkpoints")
+            }
+            con.close()
+        assert remaining == {keep_main, keep_cli}
+
+    def test_removes_ghost_entries_absent_from_sqlite(self):
+        """Stale .pckl UUID entries with no checkpoint rows are dropped.
+
+        Ghost entries point at deleted/lost state and render as empty
+        sessions (the #277 symptom). Existence is checked against ALL UUID
+        threads in the DB, not the scoped restore set: a thread whose
+        checkpoints exist but fall outside the restore scope still opens
+        fine, so it must NOT be treated as a ghost. CLI-style non-UUID
+        entries are never touched.
+        """
+        import sys
+        import uuid as _uuid_mod
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        in_scope = "11111111-1111-1111-1111-111111111111"
+        out_of_scope = "22222222-2222-2222-2222-222222222222"
+        ghost = "99999999-9999-9999-9999-999999999999"
+
+        ghost_entry: dict = {"thread_id": ghost, "status": "idle", "metadata": {}}
+        out_of_scope_entry: dict = {
+            "thread_id": out_of_scope,
+            "status": "idle",
+            "metadata": {},
+        }
+        cli_entry: dict = {"thread_id": "notauuid", "status": "idle"}
+        mock_store: dict = {"threads": [ghost_entry, out_of_scope_entry, cli_entry]}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            self._make_db_with_threads(db, [in_scope])
+            self._make_db_with_threads(db, [out_of_scope], workspace_dir="/elsewhere")
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+                self._patch_workspace(),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        ids = [t["thread_id"] for t in mock_store["threads"]]
+        assert _uuid_mod.UUID(ghost) not in ids, f"ghost must be removed, got {ids}"
+        assert ghost not in ids, f"ghost must be removed (str form), got {ids}"
+        assert "notauuid" in ids, "CLI-style entries must never be touched"
+        # Out-of-scope but existing in DB: kept (state still loads when opened).
+        assert _uuid_mod.UUID(out_of_scope) in ids
+        # In-scope thread restored as usual.
+        assert _uuid_mod.UUID(in_scope) in ids
 
     def test_no_op_when_langgraph_runtime_inmem_absent(self):
         """ImportError for langgraph_runtime_inmem is silently swallowed."""

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -5,6 +5,7 @@ import json
 import os
 import tempfile
 import unittest
+import uuid
 from datetime import UTC
 from unittest.mock import patch
 
@@ -50,13 +51,10 @@ def _mock_path(db_path: str):
 
 
 class TestGenerateThreadId(unittest.TestCase):
-    def test_length(self):
+    def test_uuid_format(self):
+        # Full UUID so langgraph-api can address CLI threads (WebUI interop).
         tid = generate_thread_id()
-        assert len(tid) == 8
-
-    def test_hex(self):
-        tid = generate_thread_id()
-        int(tid, 16)  # Should not raise
+        assert tid == str(uuid.UUID(tid))
 
     def test_uniqueness(self):
         ids = {generate_thread_id() for _ in range(100)}
@@ -2249,9 +2247,11 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
         self,
         db_path: str,
         thread_ids: list[str],
-        assistant_id: str = "aaaa-bbbb",
-        graph_id: str = "EvoScientist",
+        assistant_id: str | None = "aaaa-bbbb",
+        graph_id: str | None = "EvoScientist",
         workspace_dir: str | None = _WS,
+        agent_name: str | None = "EvoScientist",
+        ckpt_prefix: str = "ckpt",
     ) -> None:
         """Insert minimal checkpoint rows for the given thread_ids into a fresh DB."""
         import json
@@ -2264,18 +2264,19 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
             " parent_checkpoint_id TEXT, type TEXT, checkpoint BLOB, metadata TEXT)"
         )
         for tid in thread_ids:
-            meta_dict = {
-                "updated_at": "2025-01-01T00:00:00+00:00",
-                "agent_name": "EvoScientist",
-                "assistant_id": assistant_id,
-                "graph_id": graph_id,
-            }
+            meta_dict: dict = {"updated_at": "2025-01-01T00:00:00+00:00"}
+            if agent_name is not None:
+                meta_dict["agent_name"] = agent_name
+            if assistant_id is not None:
+                meta_dict["assistant_id"] = assistant_id
+            if graph_id is not None:
+                meta_dict["graph_id"] = graph_id
             if workspace_dir is not None:
                 meta_dict["workspace_dir"] = workspace_dir
             meta = json.dumps(meta_dict)
             con.execute(
                 "INSERT INTO checkpoints VALUES (?,?,?,?,?,?,?)",
-                (tid, "", f"ckpt-{tid[:8]}", None, "empty", b"", meta),
+                (tid, "", f"{ckpt_prefix}-{tid[:8]}", None, "empty", b"", meta),
             )
         con.commit()
         con.close()
@@ -2499,6 +2500,173 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
             }
             con.close()
         assert remaining == {keep_main, keep_cli}
+
+    def test_restores_cli_rows_and_excludes_worker_residue(self):
+        """CLI rows (agent_name, no graph_id) are restored with graph_id
+        backfilled; crashed-worker residue (agent_name AND graph_id=
+        evomemory-*) stays excluded — graph_id wins over agent_name."""
+        import sys
+        import uuid as _uuid_mod
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        cli_thread = "11111111-1111-1111-1111-111111111111"
+        worker_residue = "22222222-2222-2222-2222-222222222222"
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            # CLI row: build_metadata stamps agent_name/workspace_dir but
+            # never graph_id or assistant_id.
+            self._make_db_with_threads(
+                db, [cli_thread], assistant_id=None, graph_id=None
+            )
+            # Crashed memory-worker residue: stamps BOTH.
+            self._make_db_with_threads(
+                db, [worker_residue], graph_id="evomemory-turn-worker"
+            )
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+                self._patch_workspace(),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        added = mock_store["threads"]
+        assert len(added) == 1, f"expected only the CLI thread, got {added}"
+        assert added[0]["thread_id"] == _uuid_mod.UUID(cli_thread)
+        # graph_id backfilled so Threads.State.get works on the stub.
+        assert added[0]["metadata"].get("graph_id") == "EvoScientist"
+
+    def test_mixed_cli_webui_rows_keep_assistant_and_graph_id(self):
+        """Interop thread (CLI rows + WebUI rows under one UUID): bare
+        columns under GROUP BY let SQLite pick an arbitrary row's NULL —
+        all metadata fields must be MAX-aggregated (Codex F2)."""
+        import sys
+        import uuid as _uuid_mod
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        tid = "11111111-1111-1111-1111-111111111111"
+        asst = "a2b49500-c49b-5560-b664-d42ee8b66d3c"
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            # Older CLI row: no assistant_id / graph_id. "a-..." checkpoint
+            # id sorts BEFORE the WebUI row's so a bare-column GROUP BY
+            # would tend to surface this row's NULLs.
+            self._make_db_with_threads(
+                db, [tid], assistant_id=None, graph_id=None, ckpt_prefix="a"
+            )
+            # Newer WebUI row on the SAME thread: carries both.
+            self._make_db_with_threads(db, [tid], assistant_id=asst, ckpt_prefix="b")
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+                self._patch_workspace(),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        added = mock_store["threads"]
+        assert len(added) == 1, f"expected 1 thread, got {added}"
+        assert added[0]["thread_id"] == _uuid_mod.UUID(tid)
+        assert added[0]["metadata"].get("assistant_id") == asst
+        assert added[0]["metadata"].get("graph_id") == "EvoScientist"
+
+    def test_restored_stub_gets_title_from_first_human_message(self):
+        """Stubs carry metadata.title derived from the thread's first human
+        message, so the WebUI sidebar doesn't show "Untitled Thread"."""
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        from langchain_core.messages import HumanMessage
+
+        from EvoScientist.sessions import (
+            AGENT_NAME,
+            _restore_webui_threads_to_global_store,
+            create_checkpointer_for_langgraph_api,
+        )
+
+        thread_id = "33333333-3333-3333-3333-333333333333"
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        async def _write_then_restore():
+            async with create_checkpointer_for_langgraph_api() as cp:
+                await cp.aput(
+                    {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}},
+                    {
+                        "v": 1,
+                        "id": "ckpt-title",
+                        "ts": "2024-01-01T00:00:00+00:00",
+                        "channel_values": {
+                            "messages": [HumanMessage(content="hello title test")]
+                        },
+                        "channel_versions": {},
+                        "versions_seen": {},
+                        "pending_sends": [],
+                    },
+                    {"source": "loop", "step": 1, "graph_id": AGENT_NAME},
+                    {},
+                )
+            await _restore_webui_threads_to_global_store()
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+                patch(
+                    "EvoScientist.sessions._api_workspace_dir",
+                    return_value=self._WS,
+                ),
+            ):
+                _run(_write_then_restore())
+
+        added = mock_store["threads"]
+        assert len(added) == 1, f"expected 1 restored thread, got {added}"
+        assert added[0]["metadata"].get("title") == "hello title test"
 
     def test_removes_ghost_entries_absent_from_sqlite(self):
         """Stale .pckl UUID entries with no checkpoint rows are dropped.

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2004,5 +2004,397 @@ class TestReduceMessagesDeltaUpstreamParity:
         assert _signature(out) == [("HumanMessage", "d1", "x")]
 
 
+class TestCreateCheckpointerForLanggraphApi(unittest.TestCase):
+    """Tests for ``create_checkpointer_for_langgraph_api`` — the WebUI/deploy
+    SQLite checkpointer factory that replaces the default ``InMemorySaver``."""
+
+    def test_yields_pruning_checkpointer(self):
+        """Factory yields a ``PruningCheckpointer`` instance."""
+        from EvoScientist.sessions import (
+            PruningCheckpointer,
+            create_checkpointer_for_langgraph_api,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with patch(
+                "EvoScientist.sessions.get_db_path",
+                return_value=_mock_path(db),
+            ):
+
+                async def _run_inner():
+                    async with create_checkpointer_for_langgraph_api() as cp:
+                        assert isinstance(cp, PruningCheckpointer)
+
+                _run(_run_inner())
+
+    def test_checkpointer_is_set_up(self):
+        """Factory calls ``setup()`` so tables exist before yielding."""
+        import aiosqlite
+
+        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with patch(
+                "EvoScientist.sessions.get_db_path",
+                return_value=_mock_path(db),
+            ):
+
+                async def _run_inner():
+                    async with create_checkpointer_for_langgraph_api():
+                        async with aiosqlite.connect(db) as conn:
+                            async with conn.execute(
+                                "SELECT name FROM sqlite_master WHERE type='table' AND name='checkpoints'"
+                            ) as cur:
+                                row = await cur.fetchone()
+                            assert row is not None, (
+                                "checkpoints table must exist after setup()"
+                            )
+
+                _run(_run_inner())
+
+    def test_checkpointer_persists_across_contexts(self):
+        """Data written in one context manager is readable in a new one.
+
+        This is the core regression test: verifies that session data
+        survives process restarts (simulated as two separate ``async with``
+        blocks sharing the same DB file).
+        """
+        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+
+        thread_id = "testthread1"
+
+        async def _run_inner():
+            with tempfile.TemporaryDirectory() as td:
+                db = os.path.join(td, "sessions.db")
+
+                def _patch():
+                    return patch(
+                        "EvoScientist.sessions.get_db_path",
+                        return_value=_mock_path(db),
+                    )
+
+                # --- First "process": write a checkpoint ---
+                with _patch():
+                    async with create_checkpointer_for_langgraph_api() as cp:
+                        config = {
+                            "configurable": {
+                                "thread_id": thread_id,
+                                "checkpoint_ns": "",
+                            }
+                        }
+                        checkpoint = {
+                            "v": 1,
+                            "id": "ckpt-001",
+                            "ts": "2024-01-01T00:00:00+00:00",
+                            "channel_values": {"messages": []},
+                            "channel_versions": {},
+                            "versions_seen": {},
+                            "pending_sends": [],
+                        }
+                        metadata = {
+                            "source": "input",
+                            "step": 0,
+                            "writes": {},
+                            "parents": {},
+                            "agent_name": "EvoScientist",
+                        }
+                        await cp.aput(config, checkpoint, metadata, {})
+
+                # --- Second "process": read back the checkpoint ---
+                with _patch():
+                    async with create_checkpointer_for_langgraph_api() as cp2:
+                        result = await cp2.aget_tuple(
+                            {
+                                "configurable": {
+                                    "thread_id": thread_id,
+                                    "checkpoint_ns": "",
+                                }
+                            }
+                        )
+                        assert result is not None, (
+                            "Checkpoint written in first context must be readable in second context "
+                            "(simulates data survival across process restarts)"
+                        )
+                        assert result.config["configurable"]["thread_id"] == thread_id
+
+        _run(_run_inner())
+
+    def test_has_required_extended_methods(self):
+        """Yielded checkpointer exposes the full capability set expected by
+        ``langgraph-api``'s ``_CustomCheckpointerAdapter``."""
+        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with patch(
+                "EvoScientist.sessions.get_db_path",
+                return_value=_mock_path(db),
+            ):
+
+                async def _run_inner():
+                    async with create_checkpointer_for_langgraph_api() as cp:
+                        for method in (
+                            "adelete_thread",
+                            "adelete_for_runs",
+                            "acopy_thread",
+                            "aprune",
+                            "aget_tuple",
+                            "aput",
+                            "aput_writes",
+                            "alist",
+                        ):
+                            assert callable(getattr(cp, method, None)), (
+                                f"PruningCheckpointer must expose '{method}' for "
+                                "langgraph-api full-capability compliance"
+                            )
+
+                _run(_run_inner())
+
+
+class TestRestoreWebuiThreadsToGlobalStore(unittest.TestCase):
+    """Tests for ``_restore_webui_threads_to_global_store``.
+
+    Verifies that UUID-format threads written to SQLite by ``langgraph dev``
+    runs are re-populated into ``GlobalStore["threads"]`` on server restart,
+    so the WebUI sidebar is not empty after a package upgrade or clean restart.
+    """
+
+    def _make_db_with_threads(
+        self,
+        db_path: str,
+        thread_ids: list[str],
+        assistant_id: str = "aaaa-bbbb",
+        graph_id: str = "EvoScientist",
+    ) -> None:
+        """Insert minimal checkpoint rows for the given thread_ids into a fresh DB."""
+        import json
+        import sqlite3
+
+        con = sqlite3.connect(db_path)
+        con.execute(
+            "CREATE TABLE checkpoints "
+            "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT PRIMARY KEY, "
+            " parent_checkpoint_id TEXT, type TEXT, checkpoint BLOB, metadata TEXT)"
+        )
+        for tid in thread_ids:
+            meta = json.dumps(
+                {
+                    "updated_at": "2025-01-01T00:00:00+00:00",
+                    "agent_name": "EvoScientist",
+                    "assistant_id": assistant_id,
+                    "graph_id": graph_id,
+                }
+            )
+            con.execute(
+                "INSERT INTO checkpoints VALUES (?,?,?,?,?,?,?)",
+                (tid, "", f"ckpt-{tid[:8]}", None, "empty", b"", meta),
+            )
+        con.commit()
+        con.close()
+
+    def test_restores_uuid_threads_into_global_store(self):
+        """UUID-format thread IDs from SQLite are injected into GlobalStore."""
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        uuid_id = "12345678-1234-1234-1234-123456789abc"
+        asst_uuid_id = "a2b49500-c49b-5560-b664-d42ee8b66d3c"
+        short_id = "abcd1234"  # CLI-style, must be excluded
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            self._make_db_with_threads(
+                db, [uuid_id, short_id], assistant_id=asst_uuid_id
+            )
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        # Only the UUID thread should have been added; the short-hex CLI thread
+        # should not appear because it doesn't match the UUID LIKE pattern.
+        added = mock_store["threads"]
+        assert len(added) == 1, f"Expected 1 restored thread, got {len(added)}: {added}"
+        import uuid as _uuid_mod
+
+        # thread_id MUST be stored as a uuid.UUID object, not a plain string.
+        # langgraph_runtime_inmem._get_with_filters compares with == against
+        # _ensure_uuid(thread_id), which returns a UUID object.  A string never
+        # equals a UUID object, causing every Threads.get() call to 404.
+        assert isinstance(added[0]["thread_id"], _uuid_mod.UUID), (
+            f"thread_id must be uuid.UUID, got {type(added[0]['thread_id'])}"
+        )
+        assert added[0]["thread_id"] == _uuid_mod.UUID(uuid_id)
+        assert added[0]["status"] == "idle"
+        # metadata must carry assistant_id (as UUID) and graph_id so
+        # POST /threads/search filters work correctly in the WebUI.
+        assert isinstance(added[0]["metadata"].get("assistant_id"), _uuid_mod.UUID)
+        assert added[0]["metadata"].get("assistant_id") == _uuid_mod.UUID(asst_uuid_id)
+        assert added[0]["metadata"].get("graph_id") == "EvoScientist"
+        # created_at / updated_at must be datetime objects, not ISO strings.
+        # Threads.search() sorts by these fields using sorted(); mixing
+        # datetime and str raises TypeError: '<' not supported.
+        from datetime import datetime as _dt
+
+        assert isinstance(added[0]["created_at"], _dt), (
+            f"created_at must be datetime, got {type(added[0]['created_at'])}"
+        )
+        assert isinstance(added[0]["updated_at"], _dt)
+
+    def test_fixes_existing_string_thread_ids_in_place(self):
+        """Threads already in GlobalStore with string thread_id get fixed in-place.
+
+        When .pckl loads successfully, threads are already in the store but
+        thread_id is a plain string (as pickled).  The restore must:
+          1. Convert thread_id to uuid.UUID so Threads.get() comparison works.
+          2. Backfill missing metadata.assistant_id / graph_id from SQLite.
+          3. Not create duplicate entries.
+        """
+        import sys
+        import uuid as _uuid_mod
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        uuid_id = "aaaabbbb-aaaa-bbbb-cccc-ddddeeeeffff"
+        asst_uuid_id = "a2b49500-c49b-5560-b664-d42ee8b66d3c"
+
+        # Simulate .pckl-restored thread: thread_id is a string, metadata empty.
+        existing_stub: dict = {"thread_id": uuid_id, "status": "idle", "metadata": {}}
+        mock_store: dict = {"threads": [existing_stub]}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            self._make_db_with_threads(db, [uuid_id], assistant_id=asst_uuid_id)
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        # No duplicate: still exactly one entry.
+        assert len(mock_store["threads"]) == 1, (
+            f"Expected 1 thread, got {len(mock_store['threads'])}"
+        )
+        t = mock_store["threads"][0]
+        # thread_id must now be a UUID object, not a string.
+        assert isinstance(t["thread_id"], _uuid_mod.UUID), (
+            f"thread_id must be uuid.UUID after fix, got {type(t['thread_id'])}"
+        )
+        assert t["thread_id"] == _uuid_mod.UUID(uuid_id)
+        # metadata must be backfilled.
+        assert isinstance(t["metadata"].get("assistant_id"), _uuid_mod.UUID)
+        assert t["metadata"].get("graph_id") == "EvoScientist"
+
+    def test_no_op_when_langgraph_runtime_inmem_absent(self):
+        """ImportError for langgraph_runtime_inmem is silently swallowed."""
+        import sys
+        from unittest.mock import patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        with patch.dict(sys.modules, {"langgraph_runtime_inmem.database": None}):
+            # Must not raise.
+            _run(_restore_webui_threads_to_global_store())
+
+    def test_no_op_when_db_has_no_checkpoints_table(self):
+        """Missing checkpoints table is handled gracefully."""
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "empty.db")
+            # Create a valid but empty SQLite DB (no checkpoints table).
+            import sqlite3
+
+            sqlite3.connect(db).close()
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+            ):
+                _run(_restore_webui_threads_to_global_store())
+
+        # threads list untouched.
+        assert mock_store["threads"] == []
+
+    def test_create_checkpointer_calls_restore(self):
+        """create_checkpointer_for_langgraph_api calls _restore_webui_threads_to_global_store."""
+        from unittest.mock import patch
+
+        from EvoScientist.sessions import create_checkpointer_for_langgraph_api
+
+        restore_called = []
+
+        async def fake_restore():
+            restore_called.append(True)
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch(
+                    "EvoScientist.sessions._restore_webui_threads_to_global_store",
+                    side_effect=fake_restore,
+                ),
+            ):
+
+                async def _run_inner():
+                    async with create_checkpointer_for_langgraph_api():
+                        pass
+
+                _run(_run_inner())
+
+        assert restore_called, "_restore_webui_threads_to_global_store must be called"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #277. Supersedes #278 — includes the original commit from @IAllenzhou (thanks for the diagnosis and the SQLite checkpointer approach!) plus review fixes and a follow-up interop feature.

## Commit 1 — review fixes on top of #278 (`a2a9b62`)

- **Scope the startup restore**: only main-graph threads belonging to the current workspace are resurrected. sessions.db is machine-global, so the unscoped restore exposed every workspace's history (incl. memory-worker conversations) over the unauthenticated API / `--tunnel`.
- **CLI/WebUI session interop (write side)**: langgraph-dev main-graph rows are stamped with `agent_name`/`workspace_dir`/`updated_at`, so WebUI threads surface in CLI `/threads`/`/resume`/`/delete` and participate in pruning.
- **No worker residue**: memory-worker threads are deleted on run completion; leftover rows are purged at startup.
- **Ghost reconciliation** (CodeRabbit on #278): stale registry entries whose checkpoints no longer exist are dropped.
- `metadata.assistant_id` stays `str` (runtime convention — `uuid.UUID` silently broke assistant_id-filtered searches).
- Replaced the `callable()` capability test with a real override probe; trimmed duplicated docstrings.

## Commit 2 — full-UUID thread ids: bidirectional CLI ⇄ WebUI sharing (`915a44a`)

- `generate_thread_id()` now returns a full UUID so langgraph-api can address CLI threads; new CLI/TUI sessions appear in the WebUI sidebar of the same workspace and vice versa. Legacy 8-char hex threads keep working in the CLI (CLI-only).
- Restored sidebar entries carry `metadata.title` derived from the first human message — no more "Untitled Thread".
- Thread ids display as 8-char prefixes (git-style) across `/threads`, the TUI selector, resume hints and banners; prefix matching unchanged.
- All restore metadata columns are MAX-aggregated: interop threads mix CLI rows (no `assistant_id`/`graph_id`) with WebUI rows, and bare columns under `GROUP BY` let SQLite pick an arbitrary row's NULL (caught by Codex review).

## Upgrade notes

- **Pre-existing WebUI sessions** (legacy `.langgraph_api/*.pckl` pickle storage) are **not carried over** — the sidebar entries are reconciled away; the pickle files remain on disk untouched. A one-time pckl→SQLite migration is planned as a follow-up PR.
- Pre-existing CLI/TUI sessions are unaffected.
- Driving the same thread from CLI and WebUI **simultaneously** is not corrupting (WAL serializes writes) but interleaves turns — use one surface at a time per thread.

## Review trail

Multi-agent review + manual reproduction (restore scoping, filter conventions, capability probe verified against installed langgraph-api 0.9.0), CodeRabbit findings from #278 all addressed, Codex cross-review: F2 (GROUP BY bare-column NULL) fixed with regression test; F1 = the documented pckl migration deferral; F3 = documented capability degradation (`rollback` cleanup); F4 rejected (8-char prefix collision ~1e-7 per pair, ambiguity falls back to candidate list).

## Type of change

- [x] Bug fix
- [x] New feature (CLI ⇄ WebUI session interop)

## Checklist

- [x] I have read the Contributing Guidelines
- [x] This targets **core functionality** used by the majority of users
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes (2391 passed / 10 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Thread identifiers now display in a shortened, user-friendly format throughout the CLI and session management interface
  * Enhanced session persistence and checkpointing for development environment workflows

* **Bug Fixes**
  * Automatic cleanup of finished memory worker threads prevents orphaned sessions
  * Improved recovery and restoration of sessions from storage after restart
<!-- end of auto-generated comment: release notes by coderabbit.ai -->