### PR TITLE
chore: bump ruff in pre-commit 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ bridge/package-lock.json
 .langgraph_api/
 workspace/
 skills/
+!EvoScientist/skills/
 memory/
 !EvoScientist/memory/
 media/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.9
+    rev: v0.15.17
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format

--- a/EvoScientist/skills/skill-creator/scripts/run_eval.py
+++ b/EvoScientist/skills/skill-creator/scripts/run_eval.py
@@ -240,7 +240,7 @@ def main():
         print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
         sys.exit(1)
 
-    name, original_description, content = parse_skill_md(skill_path)
+    name, original_description, _content = parse_skill_md(skill_path)
     description = args.description or original_description
 
     if args.verbose:


### PR DESCRIPTION
* Bumps ruff version in pre-commit to match uv version
* Misc: Adds exception to gitignore to check built-in skills
  * Applies a ruff fix for `skill-creator` skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to properly track the skills directory.
  * Updated development tooling to the latest version for enhanced code quality checks.

* **Refactor**
  * Refined internal variable naming for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->