### PR TITLE
feat(llm): make OpenRouter Anthropic prompt cache opt-out

### DIFF
--- a/EvoScientist/config/settings.py
+++ b/EvoScientist/config/settings.py
@@ -223,8 +223,9 @@ class EvoScientistConfig:
     ui_backend: Literal["cli", "tui", "webui"] = "tui"
     log_level: str = "warning"
     reasoning_effort: str = "high"
-    # Opt into Anthropic prompt caching for OpenRouter anthropic/* models.
-    openrouter_anthropic_prompt_cache: bool = False
+    # Anthropic prompt caching for OpenRouter anthropic/* models. Opt out if
+    # cache-write costs outweigh the benefit for a workflow.
+    openrouter_anthropic_prompt_cache: bool = True
 
     # Channel Settings
     channel_enabled: str = ""  # "imessage" | "telegram" | "discord" | "slack" | "wechat" | "dingtalk" | "feishu" | "email" | "qq" | "signal" | "" (comma-separated for multiple)
@@ -773,10 +774,10 @@ def apply_config_to_env(config: EvoScientistConfig) -> None:
         os.environ["TAVILY_API_KEY"] = config.tavily_api_key
     if config.reasoning_effort and not os.environ.get("EVOSCIENTIST_REASONING_EFFORT"):
         os.environ["EVOSCIENTIST_REASONING_EFFORT"] = config.reasoning_effort
-    if config.openrouter_anthropic_prompt_cache and not os.environ.get(
+    if not config.openrouter_anthropic_prompt_cache and not os.environ.get(
         "EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE"
     ):
-        os.environ["EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE"] = "true"
+        os.environ["EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE"] = "false"
     # Round-trip dangerous_mode to env so it survives a fresh get_effective_config()
     # (warning banner, run_in_background) and is inherited by the langgraph dev
     # subprocess — otherwise a --dangerous CLI flag (not persisted to file/env)

--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -65,7 +65,7 @@ _ANTHROPIC_ROUTED_PROVIDERS: dict[str, tuple[str | None, str]] = {
 # Anthropic-routed providers that support extended thinking.
 _THINKING_CAPABLE_PROVIDERS: set[str] = {"minimax"}
 
-_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+_FALSEY_ENV_VALUES = {"0", "false", "no", "off"}
 
 # Model registry: list of (short_name, model_id, provider)
 # Allows same short_name across different providers.
@@ -240,8 +240,9 @@ def get_models_for_provider(provider: str) -> list[tuple[str, str]]:
     return [(name, model_id) for name, model_id, p in _MODEL_ENTRIES if p == provider]
 
 
-def _env_flag_enabled(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+def _env_flag_disabled(name: str) -> bool:
+    value = os.environ.get(name)
+    return value is not None and value.strip().lower() in _FALSEY_ENV_VALUES
 
 
 def _supports_openrouter_anthropic_prompt_cache(provider: str, model_id: str) -> bool:
@@ -275,12 +276,12 @@ def _apply_openrouter_anthropic_prompt_cache(
     model_id: str,
     kwargs: dict[str, Any],
 ) -> None:
-    """Opt into OpenRouter Claude prompt caching when explicitly requested.
+    """Declare OpenRouter Claude prompt caching unless explicitly disabled.
 
     OpenRouter already handles implicit caching for most providers, but Claude
     prompt caching needs Anthropic-style cache-control declaration.
     """
-    if not _env_flag_enabled("EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE"):
+    if _env_flag_disabled("EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE"):
         return
     if not _supports_openrouter_anthropic_prompt_cache(provider, model_id):
         return

--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -65,6 +65,7 @@ _ANTHROPIC_ROUTED_PROVIDERS: dict[str, tuple[str | None, str]] = {
 # Anthropic-routed providers that support extended thinking.
 _THINKING_CAPABLE_PROVIDERS: set[str] = {"minimax"}
 
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 _FALSEY_ENV_VALUES = {"0", "false", "no", "off"}
 
 # Model registry: list of (short_name, model_id, provider)
@@ -238,6 +239,10 @@ def get_models_for_provider(provider: str) -> list[tuple[str, str]]:
         List of (short_name, model_id) tuples for the provider.
     """
     return [(name, model_id) for name, model_id, p in _MODEL_ENTRIES if p == provider]
+
+
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
 
 
 def _env_flag_disabled(name: str) -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,7 +120,7 @@ class TestEvoScientistConfig:
         assert config.ui_backend == "tui"
         assert config.log_level == "warning"
         assert config.reasoning_effort == "high"
-        assert config.openrouter_anthropic_prompt_cache is False
+        assert config.openrouter_anthropic_prompt_cache is True
         assert config.memory_profile_enabled is True
         assert config.memory_observations_enabled is True
         assert config.memory_observation_writer == MemoryObservationWriter.ALL
@@ -579,22 +579,22 @@ class TestPriorityChain:
         config = get_effective_config()
         assert config.openai_auth_mode == "oauth"
 
-    def test_env_openrouter_anthropic_prompt_cache_override(
+    def test_env_openrouter_anthropic_prompt_cache_opt_out(
         self, temp_config_dir, monkeypatch
     ):
-        """Test OpenRouter Anthropic prompt cache flag from env overrides file."""
-        save_config(EvoScientistConfig(openrouter_anthropic_prompt_cache=False))
-        monkeypatch.setenv("EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE", "true")
+        """Test OpenRouter Anthropic prompt cache opt-out env overrides file."""
+        save_config(EvoScientistConfig(openrouter_anthropic_prompt_cache=True))
+        monkeypatch.setenv("EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE", "false")
 
         config = get_effective_config()
-        assert config.openrouter_anthropic_prompt_cache is True
+        assert config.openrouter_anthropic_prompt_cache is False
 
     def test_set_openrouter_anthropic_prompt_cache(self, temp_config_dir, clean_env):
         """Test OpenRouter Anthropic prompt cache can be set through config."""
         save_config(EvoScientistConfig())
 
-        assert set_config_value("openrouter_anthropic_prompt_cache", "true") is True
-        assert get_config_value("openrouter_anthropic_prompt_cache") is True
+        assert set_config_value("openrouter_anthropic_prompt_cache", "false") is True
+        assert get_config_value("openrouter_anthropic_prompt_cache") is False
 
 
 # =============================================================================
@@ -635,16 +635,18 @@ class TestApplyConfigToEnv:
         assert os.environ.get("OPENAI_API_KEY") is None
         assert os.environ.get("EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE") is None
 
-    def test_openrouter_anthropic_prompt_cache_applied(self, clean_env, monkeypatch):
-        """Test OpenRouter Anthropic prompt cache config is applied to env."""
+    def test_openrouter_anthropic_prompt_cache_opt_out_applied(
+        self, clean_env, monkeypatch
+    ):
+        """Test OpenRouter Anthropic prompt cache opt-out config is applied to env."""
         monkeypatch.delenv(
             "EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE", raising=False
         )
-        config = EvoScientistConfig(openrouter_anthropic_prompt_cache=True)
+        config = EvoScientistConfig(openrouter_anthropic_prompt_cache=False)
         apply_config_to_env(config)
 
         assert os.environ.get("EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE") == (
-            "true"
+            "false"
         )
 
     def test_dangerous_mode_round_trips_to_env(self, clean_env, monkeypatch):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -440,10 +440,10 @@ class TestThirdPartyRouting:
         assert call_kwargs["reasoning"] == {"effort": "medium", "summary": "auto"}
 
     @patch("EvoScientist.llm.models.init_chat_model")
-    def test_openrouter_anthropic_prompt_cache_disabled_by_default(
+    def test_openrouter_anthropic_prompt_cache_enabled_by_default(
         self, mock_init, monkeypatch
     ):
-        """OpenRouter Anthropic prompt caching should be opt-in."""
+        """OpenRouter Anthropic prompt caching should be opt-out."""
         mock_init.return_value = "mock_model"
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         monkeypatch.delenv(
@@ -453,25 +453,25 @@ class TestThirdPartyRouting:
         get_chat_model("claude-sonnet-4.6", provider="openrouter")
 
         call_kwargs = mock_init.call_args[1]
-        assert "cache_control" not in call_kwargs
-        assert "cache_control" not in call_kwargs.get("model_kwargs", {})
-
-    @patch("EvoScientist.llm.models.init_chat_model")
-    def test_openrouter_anthropic_prompt_cache_opt_in(self, mock_init, monkeypatch):
-        """The opt-in flag should declare caching for OpenRouter Claude models."""
-        mock_init.return_value = "mock_model"
-        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
-        monkeypatch.setenv("EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE", "true")
-
-        get_chat_model("claude-sonnet-4.6", provider="openrouter")
-
-        call_kwargs = mock_init.call_args[1]
         assert call_kwargs["model_provider"] == "openrouter"
         assert call_kwargs["model"] == "anthropic/claude-sonnet-4.6"
         assert call_kwargs["model_kwargs"]["cache_control"] == {"type": "ephemeral"}
 
     @patch("EvoScientist.llm.models.init_chat_model")
-    def test_prompt_cache_opt_in_skips_non_anthropic_openrouter(
+    def test_openrouter_anthropic_prompt_cache_opt_out(self, mock_init, monkeypatch):
+        """The opt-out flag should skip caching for OpenRouter Claude models."""
+        mock_init.return_value = "mock_model"
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        monkeypatch.setenv("EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE", "false")
+
+        get_chat_model("claude-sonnet-4.6", provider="openrouter")
+
+        call_kwargs = mock_init.call_args[1]
+        assert "cache_control" not in call_kwargs
+        assert "cache_control" not in call_kwargs.get("model_kwargs", {})
+
+    @patch("EvoScientist.llm.models.init_chat_model")
+    def test_prompt_cache_default_skips_non_anthropic_openrouter(
         self, mock_init, monkeypatch
     ):
         """OpenRouter models with implicit caching should be left alone."""


### PR DESCRIPTION
See https://github.com/EvoScientist/EvoScientist/issues/294#issuecomment-4730537220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * OpenRouter Claude prompt caching is now enabled by default to optimize performance.
  * You can opt out by setting `EVOSCIENTIST_OPENROUTER_ANTHROPIC_PROMPT_CACHE=false`, which will disable caching for supported Anthropic models.
* **Testing**
  * Updated configuration and LLM behavior tests to reflect the new default and opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->