### PR TITLE
fix(cli): submit slash command on Enter when name prefixes another (#293)

### DIFF
--- a/EvoScientist/commands/_completion_engine.py
+++ b/EvoScientist/commands/_completion_engine.py
@@ -58,12 +58,20 @@ def compute_completions(text: str, cursor_pos: int) -> CompletionResult:
         commands = cmd_manager.list_commands()
         matches = [(c, d) for c, d in commands if c.startswith(prefix)]
 
+        # Whether the typed prefix is itself a complete command name. Checked
+        # via membership rather than ``len(matches) == 1`` so a command whose
+        # name is a strict prefix of another (e.g. ``/model`` vs
+        # ``/model-fallback``) still counts as an exact match — otherwise the
+        # popup never hides on the shorter command and Enter completes instead
+        # of submitting it.
+        exact = any(c == prefix for c, _ in matches)
+
         # Exact match with no trailing space → hide
-        if len(matches) == 1 and matches[0][0] == prefix and not has_trailing_space:
+        if exact and not has_trailing_space:
             return CompletionResult(CompletionKind.EMPTY, [])
 
         # Exact match + trailing space + has subcommands → show subcommands
-        if len(matches) == 1 and matches[0][0] == prefix and has_trailing_space:
+        if exact and has_trailing_space:
             if not cmd_manager.get_subcommands(prefix):
                 return CompletionResult(CompletionKind.EMPTY, [])
             sub_items = cmd_manager.list_subcommands(cmd_name)

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -29,6 +29,20 @@ class TestSlashCommandCompleter:
         completions = list(completer.get_completions(_doc("/help"), None))
         assert completions == []
 
+    def test_exact_command_hides_even_when_prefix_of_another(self):
+        """Regression for #293: ``/model`` must hide on exact match so Enter
+        submits it, even though ``/model-fallback`` shares the prefix. Before
+        the fix the popup stayed visible (two prefix matches) and the TUI's
+        Enter handler completed the text instead of executing the command.
+        """
+        completer = SlashCommandCompleter()
+        # Sanity: both commands share the prefix, so a partial prefix lists both.
+        partial = {c.text for c in completer.get_completions(_doc("/mode"), None)}
+        assert {"/model", "/model-fallback"} <= partial
+        # Exact ``/model`` with no trailing space → hide.
+        completions = list(completer.get_completions(_doc("/model"), None))
+        assert completions == []
+
     def test_non_slash_returns_empty(self):
         completer = SlashCommandCompleter()
         completions = list(completer.get_completions(_doc("hello"), None))


### PR DESCRIPTION
## Description

Fixes #293. In the TUI, typing `/model` and pressing Enter did nothing — the model picker only opened via `/model --save` or `/model <name>`.

### Root cause

The completion popup matches commands by prefix, so `/model` matched **both** `/model` and `/model-fallback`. The "exact match → hide popup" guard in `_completion_engine.py` required a *single* match (`len(matches) == 1`), so it never fired for `/model`. With the popup still visible, the TUI's Enter handler (`_handle_completion_enter`) applied the completion and suppressed submit, so the command never executed.

`/model --save` and `/model <name>` worked because those go through the argument/subcommand branch where the popup is hidden, letting Enter submit normally.

### Fix

Treat the typed prefix as an exact match whenever it equals **any** matched command name, not only when it is the sole match. This hides the popup on a complete command name so Enter submits it, even when a longer command shares the prefix (`/model` vs `/model-fallback`). This generalizes to any command whose name is a strict prefix of another.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Testing

- Added regression test `test_exact_command_hides_even_when_prefix_of_another` in `tests/test_cli_completion.py`.
- `uv run pytest tests/test_cli_completion.py` — 10 passed.
- `uv run ruff check .` and `uv run ruff format --check` pass.

### Demo

<img width="1242" height="962" alt="4aa6ede3-ec5f-4d02-837c-539108ce293e" src="https://github.com/user-attachments/assets/d55b86ad-cac5-4b0f-a1a7-d67b6ce87e9d" />

## Checklist

- [x] I have read the Contributing Guidelines
- [x] This targets core functionality used by the majority of users
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command completion logic to correctly handle cases where a typed command is also a prefix of another command (e.g., `/model` vs `/model-fallback`). Exact command matches now properly hide suggestions when appropriate and display subcommands with trailing space.

* **Tests**
  * Added regression test for command completion edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->