### PR TITLE
fix(config): set config.yaml permissions to 0x600

### DIFF
--- a/EvoScientist/config/settings.py
+++ b/EvoScientist/config/settings.py
@@ -548,6 +548,10 @@ def save_config(config: EvoScientistConfig) -> None:
     """
     config_path = get_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        config_path.parent.chmod(0o700)
+    except OSError:
+        pass
 
     data = _config_to_dict(config)
 
@@ -560,6 +564,10 @@ def save_config(config: EvoScientistConfig) -> None:
             sort_keys=False,
             allow_unicode=True,
         )
+    try:
+        config_path.chmod(0o600)
+    except OSError:
+        pass
 
 
 def reset_config() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -242,6 +242,18 @@ class TestLoadSaveReset:
         assert data["provider"] == "openai"
         assert data["model"] == "gpt-4o"
 
+    def test_save_restricts_config_permissions(self, temp_config_dir, clean_env):
+        """Config file permissions should not depend on the process umask."""
+        original_umask = os.umask(0)
+        try:
+            save_config(EvoScientistConfig(anthropic_api_key="test-key"))
+        finally:
+            os.umask(original_umask)
+
+        config_path = get_config_path()
+        assert config_path.parent.stat().st_mode & 0o777 == 0o700
+        assert config_path.stat().st_mode & 0o777 == 0o600
+
     def test_load_reads_saved_config(self, temp_config_dir, clean_env):
         """Test that load reads previously saved config."""
         original = EvoScientistConfig(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -251,6 +251,11 @@ class TestLoadSaveReset:
             os.umask(original_umask)
 
         config_path = get_config_path()
+        if os.name == "nt":
+            assert config_path.exists()
+            # Windows reports pseudo-permission bits, so we don't test them here.
+            return
+
         assert config_path.parent.stat().st_mode & 0o777 == 0o700
         assert config_path.stat().st_mode & 0o777 == 0o600
 


### PR DESCRIPTION
## Description

`save_config` serializes the config, including API keys and tokens, to plaintext YAML at `~/.config/evoscientist/config.yaml` using the process' default umask without restricting the file mode. On a shared host these secrets are readable by other users. The WeChat credential writer does `path.chmod(0o600)` right after writing, so we now apply the same hardening to the main config file.

## Type of change

<!-- Check the one that applies. -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files are now persisted with more restrictive permissions by default, helping keep settings private.
  * The app also attempts to lock down both the settings directory and the config file while gracefully continuing if permission changes aren’t supported.

* **Tests**
  * Added coverage to verify restrictive permission bits are applied even when the process umask is different.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->