### PR TITLE
feat: agent-teams - expert-skill mechanism, TUI panel, delegation routing

### DIFF
--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -778,7 +778,7 @@ def _get_default_middleware(
         ConfigurableModelMiddleware(),
         # Team-binding cue for the main agent only. Reads
         # `configurable.active_teams: list[str]` and appends a cue biasing
-        # the main agent to consult the summoned expert(s). Skipped for
+        # the main agent to consult the invited expert(s). Skipped for
         # async subagents (a running expert graph shouldn't inject a
         # "prefer expert X" hint into its own system prompt — the persona
         # is already baked in). See agent-teams-design.md.

--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -702,6 +702,7 @@ def _get_default_middleware(
         ErrorNormalizationMiddleware,
         ModelFallbackMiddleware,
         ToolErrorHandlerMiddleware,
+        create_active_team_middleware,
         create_code_interpreter_middleware,
         create_context_editing_middleware,
         create_memory_lifecycle_middleware,
@@ -775,6 +776,13 @@ def _get_default_middleware(
         # envelope wrapper before anything downstream sees them.
         ErrorNormalizationMiddleware(),
         ConfigurableModelMiddleware(),
+        # Team-binding cue for the main agent only. Reads
+        # `configurable.active_teams: list[str]` and appends a cue biasing
+        # the main agent to consult the summoned expert(s). Skipped for
+        # async subagents (a running expert graph shouldn't inject a
+        # "prefer expert X" hint into its own system prompt — the persona
+        # is already baked in). See agent-teams-design.md.
+        *([] if for_async_subagent else [create_active_team_middleware()]),
         create_context_editing_middleware(model),
         ModelFallbackMiddleware(events=events),
         ContextOverflowMapperMiddleware(),

--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -503,6 +503,15 @@ def _build_base_kwargs(
         SUBAGENTS_CONFIG,
         tool_registry=tool_registry,
     )
+    # Fold in expert-skill sub-agents (agent-teams v1). Each installed expert
+    # skill becomes an in-process sub-agent entry so the main agent's `task`
+    # tool (and the QuickJS `task()` global for panel mode) can dispatch to
+    # it by name. Async-graph deploy of experts is v2 territory — for now
+    # they live purely in the sync in-process registry. See
+    # notes/teams-and-workflows/agent-teams-design.md.
+    from .subagents.expert_container import build_expert_subagent_specs
+
+    subs.extend(build_expert_subagent_specs(tool_registry=tool_registry))
     _ensure_general_purpose_subagent(subs)
     _inject_subagent_middleware(
         subs, workspace_dir=workspace_dir, cfg=cfg, chat_model=chat_model
@@ -573,6 +582,12 @@ def load_mcp_and_build_kwargs(
         SUBAGENTS_CONFIG,
         tool_registry=registry,
     )
+    # Fold in expert-skill sub-agents (agent-teams v1). See the same block
+    # in `_build_base_kwargs` above for rationale — this MCP path mirrors it
+    # so both construction routes surface installed experts identically.
+    from .subagents.expert_container import build_expert_subagent_specs
+
+    subs.extend(build_expert_subagent_specs(tool_registry=registry))
 
     _ensure_general_purpose_subagent(subs)
     _inject_subagent_middleware(

--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -507,8 +507,7 @@ def _build_base_kwargs(
     # skill becomes an in-process sub-agent entry so the main agent's `task`
     # tool (and the QuickJS `task()` global for panel mode) can dispatch to
     # it by name. Async-graph deploy of experts is v2 territory — for now
-    # they live purely in the sync in-process registry. See
-    # notes/teams-and-workflows/agent-teams-design.md.
+    # they live purely in the sync in-process registry.
     from .subagents.expert_container import build_expert_subagent_specs
 
     subs.extend(build_expert_subagent_specs(tool_registry=tool_registry))

--- a/EvoScientist/cli/tui_interactive.py
+++ b/EvoScientist/cli/tui_interactive.py
@@ -1782,6 +1782,10 @@ def run_textual_interactive(
                     summarization_w = None
                 try:
                     _anchor_engaged = False
+                    _active_teams = list(self._channel_runtime.active_teams)
+                    _configurable_extra = (
+                        {"active_teams": _active_teams} if _active_teams else None
+                    )
                     async for event in graph_gateway.stream_events(
                         RunRequest(
                             message=_stream_input,
@@ -1791,6 +1795,7 @@ def run_textual_interactive(
                                 local_graph=agent,
                                 workspace_dir=self._workspace_dir,
                             ),
+                            configurable_extra=_configurable_extra,
                         )
                     ):
                         if is_stream_cancel_requested(cancel_scope):

--- a/EvoScientist/cli/tui_interactive.py
+++ b/EvoScientist/cli/tui_interactive.py
@@ -515,6 +515,7 @@ def run_textual_interactive(
             CompactingWidget,
             LoadingWidget,
             MCPLoaderWidget,
+            PanelWidget,
             SubAgentWidget,
             SummarizationWidget,
             SystemMessage,
@@ -1579,6 +1580,7 @@ def run_textual_interactive(
             todo_w: TodoWidget | None = None
             tool_widgets: dict[str, ToolCallWidget] = {}
             subagent_widgets: dict[str, SubAgentWidget] = {}
+            panel_widgets: dict[str, PanelWidget] = {}
 
             @dataclass
             class _ResponseDisplayState:
@@ -2083,6 +2085,37 @@ def run_textual_interactive(
                             sa_w = _get_sa_widget(instance_id, event.get("name", ""))
                             if sa_w is not None:
                                 sa_w.finalize()
+
+                        elif event_type == "panel_dispatch_start":
+                            eval_id = event.get("eval_id", "") or "_unbatched"
+                            panel_w = panel_widgets.get(eval_id)
+                            if panel_w is None:
+                                panel_w = PanelWidget(eval_id)
+                                await container.mount(panel_w)
+                                panel_widgets[eval_id] = panel_w
+                            await panel_w.start_dispatch(
+                                event["id"],
+                                event.get("subagent_type", ""),
+                                event.get("label", "") or event.get("description", ""),
+                            )
+
+                        elif event_type == "panel_dispatch_complete":
+                            eval_id = event.get("eval_id", "") or "_unbatched"
+                            panel_w = panel_widgets.get(eval_id)
+                            if panel_w is not None:
+                                panel_w.complete_dispatch(
+                                    event["id"], int(event.get("duration_ms", 0))
+                                )
+
+                        elif event_type == "panel_dispatch_error":
+                            eval_id = event.get("eval_id", "") or "_unbatched"
+                            panel_w = panel_widgets.get(eval_id)
+                            if panel_w is not None:
+                                panel_w.fail_dispatch(
+                                    event["id"],
+                                    int(event.get("duration_ms", 0)),
+                                    event.get("error", ""),
+                                )
 
                         elif event_type == "ask_user":
                             questions = event.get("questions", [])

--- a/EvoScientist/cli/widgets/__init__.py
+++ b/EvoScientist/cli/widgets/__init__.py
@@ -7,6 +7,7 @@ from .compact_summary_widget import CompactSummaryWidget
 from .compacting_widget import CompactingWidget
 from .loading_widget import LoadingWidget
 from .mcp_loader_widget import MCPLoaderWidget
+from .panel_widget import PanelWidget
 from .subagent_widget import SubAgentWidget
 from .summarization_widget import SummarizationWidget
 from .system_message import SystemMessage
@@ -25,6 +26,7 @@ __all__ = [
     "CompactingWidget",
     "LoadingWidget",
     "MCPLoaderWidget",
+    "PanelWidget",
     "SubAgentWidget",
     "SummarizationWidget",
     "SystemMessage",

--- a/EvoScientist/cli/widgets/panel_widget.py
+++ b/EvoScientist/cli/widgets/panel_widget.py
@@ -1,0 +1,224 @@
+"""Panel widget — in-eval ``task()`` fan-out live view.
+
+Groups all sub-agent dispatches from a single ``code_interpreter`` eval into
+one bordered container, one row per dispatch. Each row shows the expert /
+subagent type, the label, a running elapsed timer, and a status dot that
+flips to ``ok``/``err`` on completion.
+
+Sourced from the ``custom`` stream events emitted by ``langchain_quickjs``
+(see ``.stream.emitter.panel_dispatch_start`` etc.). Keyed by ``eval_id``
+so parallel dispatches from the same eval appear stacked; distinct evals
+get distinct panels.
+"""
+
+from __future__ import annotations
+
+import time
+
+from rich.text import Text
+from textual.containers import Vertical
+from textual.widget import Widget
+from textual.widgets import Static
+
+_SPINNER_FRAMES = "\u280b\u2819\u2839\u2838\u283c\u2834\u2826\u2827\u2807\u280f"
+_ROW_LABEL_MAX_CHARS = 48
+
+
+class _DispatchRow(Widget):
+    """One row inside a PanelWidget — a single ``task()`` dispatch.
+
+    Subclasses ``Widget`` directly and overrides ``render()`` to build the
+    row's ``Text`` on demand. Earlier revisions subclassed ``Static`` (visual
+    stayed ``None`` past the first paint) and ``Vertical`` with an inner
+    ``Static`` (container-layout race); rendering from ``render()`` is the
+    standard pattern for single-line widgets and dodges both issues by
+    letting Textual manage the visual lifecycle itself.
+    """
+
+    DEFAULT_CSS = """
+    _DispatchRow {
+        height: 1;
+        width: 100%;
+    }
+    """
+
+    def __init__(self, subagent_type: str, label: str) -> None:
+        super().__init__()
+        self._subagent_type = subagent_type
+        self._label = label
+        self._started_at = time.monotonic()
+        self._status: str = "running"  # "running" | "ok" | "err"
+        self._duration_ms: int | None = None
+        self._error: str = ""
+        self._frame = 0
+
+    def render(self) -> Text:
+        line = Text()
+        if self._status == "running":
+            line.append(f"  {_SPINNER_FRAMES[self._frame]} ", style="cyan")
+        elif self._status == "ok":
+            line.append("  \u2713 ", style="green")
+        else:
+            line.append("  \u2717 ", style="red")
+        line.append(f"{self._subagent_type} ", style="bold")
+        if self._label:
+            trimmed = self._label
+            if len(trimmed) > _ROW_LABEL_MAX_CHARS:
+                trimmed = trimmed[: _ROW_LABEL_MAX_CHARS - 1] + "\u2026"
+            line.append(f"\u2014 {trimmed} ", style="dim")
+        line.append(self._elapsed_display(), style="dim")
+        if self._status == "err" and self._error:
+            err = self._error.split("\n", 1)[0]
+            if len(err) > 60:
+                err = err[:59] + "\u2026"
+            line.append(f"  {err}", style="red")
+        return line
+
+    def tick(self) -> None:
+        if self._status == "running":
+            self._frame = (self._frame + 1) % len(_SPINNER_FRAMES)
+        self.refresh()
+
+    def complete(self, duration_ms: int) -> None:
+        self._status = "ok"
+        self._duration_ms = duration_ms
+        self.refresh()
+
+    def fail(self, duration_ms: int, error: str) -> None:
+        self._status = "err"
+        self._duration_ms = duration_ms
+        self._error = error
+        self.refresh()
+
+    def _elapsed_display(self) -> str:
+        if self._duration_ms is not None:
+            secs = self._duration_ms / 1000.0
+        else:
+            secs = time.monotonic() - self._started_at
+        return f"{secs:5.1f}s"
+
+
+class PanelWidget(Vertical):
+    """Container for one eval's fan-out — bordered box, one row per dispatch."""
+
+    DEFAULT_CSS = """
+    PanelWidget {
+        height: auto;
+        margin: 0 0;
+    }
+    PanelWidget .panel-header {
+        height: auto;
+        color: #22d3ee;
+    }
+    PanelWidget .panel-rows {
+        height: auto;
+        padding: 0 0 0 2;
+    }
+    PanelWidget .panel-footer {
+        height: auto;
+        color: #22d3ee;
+    }
+    PanelWidget.--completed .panel-header {
+        color: #4ade80;
+    }
+    PanelWidget.--completed .panel-footer {
+        color: #4ade80;
+    }
+    """
+
+    def __init__(self, eval_id: str) -> None:
+        super().__init__()
+        self._eval_id = eval_id
+        self._rows: dict[str, _DispatchRow] = {}
+        self._timer_handle = None
+        self._is_active = True
+
+    @property
+    def eval_id(self) -> str:
+        return self._eval_id
+
+    @property
+    def dispatch_count(self) -> int:
+        return len(self._rows)
+
+    def compose(self):
+        yield Static("", classes="panel-header")
+        yield Vertical(classes="panel-rows")
+        yield Static("", classes="panel-footer")
+
+    def on_mount(self) -> None:
+        self._timer_handle = self.set_interval(0.1, self._tick)
+        self._render_header()
+        self._render_footer()
+
+    def _tick(self) -> None:
+        for row in self._rows.values():
+            row.tick()
+        self._render_header()
+
+    async def start_dispatch(
+        self, dispatch_id: str, subagent_type: str, label: str
+    ) -> None:
+        if dispatch_id in self._rows:
+            return
+        row = _DispatchRow(subagent_type, label)
+        rows_container = self.query_one(".panel-rows", Vertical)
+        await rows_container.mount(row)
+        self._rows[dispatch_id] = row
+        self._render_header()
+
+    def complete_dispatch(self, dispatch_id: str, duration_ms: int) -> None:
+        row = self._rows.get(dispatch_id)
+        if row is not None:
+            row.complete(duration_ms)
+        self._maybe_finalize()
+
+    def fail_dispatch(self, dispatch_id: str, duration_ms: int, error: str) -> None:
+        row = self._rows.get(dispatch_id)
+        if row is not None:
+            row.fail(duration_ms, error)
+        self._maybe_finalize()
+
+    def _maybe_finalize(self) -> None:
+        if not self._is_active:
+            return
+        if all(row._status != "running" for row in self._rows.values()):
+            self._is_active = False
+            if self._timer_handle is not None:
+                self._timer_handle.stop()
+                self._timer_handle = None
+            self.add_class("--completed")
+            self._render_header()
+            self._render_footer()
+
+    def _summary_counts(self) -> tuple[int, int, int]:
+        running = ok = err = 0
+        for row in self._rows.values():
+            if row._status == "running":
+                running += 1
+            elif row._status == "ok":
+                ok += 1
+            else:
+                err += 1
+        return running, ok, err
+
+    def _render_header(self) -> None:
+        header = self.query_one(".panel-header", Static)
+        running, ok, err = self._summary_counts()
+        line = Text()
+        if self._is_active:
+            line.append("\u250c \u25b6 Expert panel ", style="bold cyan")
+            line.append(
+                f"({running} running, {ok} done, {err} failed)", style="dim cyan"
+            )
+        else:
+            line.append("\u2713 Expert panel ", style="bold green")
+            line.append(f"({ok} done, {err} failed)", style="dim green")
+        header.update(line)
+
+    def _render_footer(self) -> None:
+        footer = self.query_one(".panel-footer", Static)
+        if self._is_active:
+            footer.update(Text("\u2514 running...", style="dim cyan"))
+        else:
+            footer.update(Text(""))

--- a/EvoScientist/commands/base.py
+++ b/EvoScientist/commands/base.py
@@ -65,10 +65,16 @@ class CommandUI(Protocol):
 
 @dataclass
 class ChannelRuntime:
-    """Mutable handle to the agent + thread bound to running channels."""
+    """Mutable handle to the agent + thread bound to running channels.
+
+    Also holds session-scoped bindings mutated by slash commands — the
+    ``active_teams`` list backs the ``/expert`` command, feeding into
+    ``RunRequest.configurable_extra`` at stream call time.
+    """
 
     agent: Any = None
     thread_id: str | None = None
+    active_teams: list[str] = field(default_factory=list)
 
     def bind(self, agent: Any, thread_id: str) -> None:
         self.agent = agent
@@ -77,6 +83,7 @@ class ChannelRuntime:
     def clear(self) -> None:
         self.agent = None
         self.thread_id = None
+        self.active_teams = []
 
 
 @dataclass

--- a/EvoScientist/commands/implementation/__init__.py
+++ b/EvoScientist/commands/implementation/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from . import (
     autoskills,
     channel,
+    experts,
     general,
     mcp,
     model,
@@ -15,6 +16,7 @@ from . import (
 __all__ = [
     "autoskills",
     "channel",
+    "experts",
     "general",
     "mcp",
     "model",

--- a/EvoScientist/commands/implementation/experts.py
+++ b/EvoScientist/commands/implementation/experts.py
@@ -4,8 +4,12 @@
 ``/expert <name>`` — toggle an expert into the current session's
 ``active_teams`` list; the next turn's ``configurable.active_teams`` picks
 this up and ``ActiveTeamMiddleware`` biases the main-agent's delegation
-toward the summoned expert(s).
+toward the invited expert(s).
 ``/expert clear`` — reset the list.
+
+User-facing verbs match the WebUI gallery: **invite** to add an expert,
+**dismiss** to remove one. Internal state field stays ``active_teams``
+for wire compatibility.
 
 Backing store is ``ChannelRuntime.active_teams`` (see
 ``EvoScientist/commands/base.py``). WebUI users get the same effect via
@@ -66,16 +70,16 @@ class ExpertsCommand(Command):
             )
         else:
             ctx.ui.append_system(
-                "No experts summoned. `/expert <name>` to summon one.",
+                "No experts invited. `/expert <name>` to invite one.",
                 style="dim",
             )
 
 
 class ExpertCommand(Command):
-    """Summon, release, or clear expert skills for the current thread."""
+    """Invite, dismiss, or clear expert skills for the current thread."""
 
     name: ClassVar[str] = "/expert"
-    description: ClassVar[str] = "Summon or release an expert skill"
+    description: ClassVar[str] = "Invite or dismiss an expert skill"
     category: ClassVar[str] = "Experts"
     arguments: ClassVar[list[Argument]] = [
         Argument(
@@ -86,7 +90,7 @@ class ExpertCommand(Command):
         )
     ]
     subcommands: ClassVar[list[SubCommand]] = [
-        SubCommand("clear", "Release all summoned experts"),
+        SubCommand("clear", "Dismiss all invited experts"),
     ]
 
     def get_completions(self, tokens: list[str]) -> list[tuple[str, str]]:
@@ -104,7 +108,7 @@ class ExpertCommand(Command):
             ]
         except Exception:
             candidates = []
-        candidates.append(("clear", "Release all summoned experts"))
+        candidates.append(("clear", "Dismiss all invited experts"))
         return [(name, desc) for name, desc in candidates if name.startswith(prefix)]
 
     async def execute(self, ctx: CommandContext, args: list[str]) -> None:
@@ -118,11 +122,11 @@ class ExpertCommand(Command):
 
         if not args:
             ctx.ui.append_system(
-                "Usage: /expert <name>   toggle an expert into the summon list",
+                "Usage: /expert <name>   toggle an expert into the invited list",
                 style="yellow",
             )
             ctx.ui.append_system(
-                "       /expert clear    release all summoned experts",
+                "       /expert clear    dismiss all invited experts",
                 style="dim",
             )
             return
@@ -130,12 +134,12 @@ class ExpertCommand(Command):
         target = args[0].strip()
         if target.lower() == "clear":
             if not runtime.active_teams:
-                ctx.ui.append_system("No experts summoned.", style="dim")
+                ctx.ui.append_system("No experts invited.", style="dim")
                 return
-            released = list(runtime.active_teams)
+            dismissed = list(runtime.active_teams)
             runtime.active_teams = []
             ctx.ui.append_system(
-                f"Released experts: {', '.join(released)}", style="dim"
+                f"Dismissed experts: {', '.join(dismissed)}", style="dim"
             )
             return
 
@@ -151,10 +155,10 @@ class ExpertCommand(Command):
 
         if target in runtime.active_teams:
             runtime.active_teams = [n for n in runtime.active_teams if n != target]
-            ctx.ui.append_system(f"Released expert: {target}", style="dim")
+            ctx.ui.append_system(f"Dismissed expert: {target}", style="dim")
         else:
             runtime.active_teams = [*runtime.active_teams, target]
-            ctx.ui.append_system(f"Summoned expert: {target}", style="green")
+            ctx.ui.append_system(f"Invited expert: {target}", style="green")
         if runtime.active_teams:
             ctx.ui.append_system(
                 f"Active: {', '.join(runtime.active_teams)}", style="dim"

--- a/EvoScientist/commands/implementation/experts.py
+++ b/EvoScientist/commands/implementation/experts.py
@@ -1,0 +1,170 @@
+"""Slash commands for TUI expert-skill selection.
+
+``/experts`` — list installed expert skills.
+``/expert <name>`` — toggle an expert into the current session's
+``active_teams`` list; the next turn's ``configurable.active_teams`` picks
+this up and ``ActiveTeamMiddleware`` biases the main-agent's delegation
+toward the summoned expert(s).
+``/expert clear`` — reset the list.
+
+Backing store is ``ChannelRuntime.active_teams`` (see
+``EvoScientist/commands/base.py``). WebUI users get the same effect via
+its gallery + langgraph-sdk ``config.configurable``; these commands are
+the TUI-side equivalent.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from rich.table import Table
+
+from ..base import Argument, Command, CommandContext, SubCommand
+from ..manager import manager
+
+
+class ExpertsCommand(Command):
+    """List installed expert skills."""
+
+    name: ClassVar[str] = "/experts"
+    description: ClassVar[str] = "List installed expert skills"
+    category: ClassVar[str] = "Experts"
+
+    async def execute(self, ctx: CommandContext, args: list[str]) -> None:
+        from ...tools.skills_manager import list_expert_skills
+
+        experts = list_expert_skills(include_system=True)
+        active = _current_active_teams(ctx)
+
+        if not experts:
+            ctx.ui.append_system("No expert skills installed.", style="dim")
+            ctx.ui.append_system(
+                "Install with: /install-skill <path-or-url>", style="dim"
+            )
+            return
+
+        table = Table(title=f"Expert Skills ({len(experts)})", show_header=True)
+        table.add_column("Name", style="cyan")
+        table.add_column("Role", style="dim")
+        table.add_column("Dispatch", style="dim")
+        table.add_column("Active", style="green")
+        for skill in experts:
+            marker = "*" if skill.name in active else ""
+            table.add_row(
+                skill.name,
+                skill.role or skill.description,
+                skill.default_dispatch or "sync",
+                marker,
+            )
+        ctx.ui.mount_renderable(table)
+
+        if active:
+            ctx.ui.append_system(
+                f"Active: {', '.join(active)}. Toggle with `/expert <name>`, "
+                "clear with `/expert clear`.",
+                style="dim",
+            )
+        else:
+            ctx.ui.append_system(
+                "No experts summoned. `/expert <name>` to summon one.",
+                style="dim",
+            )
+
+
+class ExpertCommand(Command):
+    """Summon, release, or clear expert skills for the current thread."""
+
+    name: ClassVar[str] = "/expert"
+    description: ClassVar[str] = "Summon or release an expert skill"
+    category: ClassVar[str] = "Experts"
+    arguments: ClassVar[list[Argument]] = [
+        Argument(
+            name="name_or_clear",
+            type=str,
+            description="Expert skill name to toggle, or 'clear' to reset",
+            required=True,
+        )
+    ]
+    subcommands: ClassVar[list[SubCommand]] = [
+        SubCommand("clear", "Release all summoned experts"),
+    ]
+
+    def get_completions(self, tokens: list[str]) -> list[tuple[str, str]]:
+        """Complete expert names + the ``clear`` subcommand."""
+        prefix = tokens[0].lower() if tokens else ""
+        # Only complete at the first positional token; deeper is a usage error.
+        if len(tokens) > 1 and tokens[1] != "":
+            return []
+        try:
+            from ...tools.skills_manager import list_expert_skills
+
+            candidates = [
+                (s.name, s.role or s.description)
+                for s in list_expert_skills(include_system=True)
+            ]
+        except Exception:
+            candidates = []
+        candidates.append(("clear", "Release all summoned experts"))
+        return [(name, desc) for name, desc in candidates if name.startswith(prefix)]
+
+    async def execute(self, ctx: CommandContext, args: list[str]) -> None:
+        runtime = ctx.channel_runtime
+        if runtime is None:
+            ctx.ui.append_system(
+                "/expert requires a session runtime; not available in this context.",
+                style="yellow",
+            )
+            return
+
+        if not args:
+            ctx.ui.append_system(
+                "Usage: /expert <name>   toggle an expert into the summon list",
+                style="yellow",
+            )
+            ctx.ui.append_system(
+                "       /expert clear    release all summoned experts",
+                style="dim",
+            )
+            return
+
+        target = args[0].strip()
+        if target.lower() == "clear":
+            if not runtime.active_teams:
+                ctx.ui.append_system("No experts summoned.", style="dim")
+                return
+            released = list(runtime.active_teams)
+            runtime.active_teams = []
+            ctx.ui.append_system(
+                f"Released experts: {', '.join(released)}", style="dim"
+            )
+            return
+
+        from ...tools.skills_manager import list_expert_skills
+
+        available = {s.name for s in list_expert_skills(include_system=True)}
+        if target not in available:
+            ctx.ui.append_system(
+                f"No expert skill named '{target}'. `/experts` lists installed ones.",
+                style="red",
+            )
+            return
+
+        if target in runtime.active_teams:
+            runtime.active_teams = [n for n in runtime.active_teams if n != target]
+            ctx.ui.append_system(f"Released expert: {target}", style="dim")
+        else:
+            runtime.active_teams = [*runtime.active_teams, target]
+            ctx.ui.append_system(f"Summoned expert: {target}", style="green")
+        if runtime.active_teams:
+            ctx.ui.append_system(
+                f"Active: {', '.join(runtime.active_teams)}", style="dim"
+            )
+
+
+def _current_active_teams(ctx: CommandContext) -> list[str]:
+    runtime = ctx.channel_runtime
+    return list(runtime.active_teams) if runtime is not None else []
+
+
+manager.register(ExpertsCommand())
+manager.register(ExpertCommand())

--- a/EvoScientist/commands/implementation/session.py
+++ b/EvoScientist/commands/implementation/session.py
@@ -214,7 +214,22 @@ class NewCommand(Command):
     category = "Session"
 
     async def execute(self, ctx: CommandContext, args: list[str]) -> None:
+        # ``/new`` means fresh state — release any invited experts before
+        # starting the new session. Uniform with the ``ChannelRuntime.clear``
+        # path on channel shutdown; avoids the "why is idea-brainstorm still
+        # active in my new thread?" surprise. Users who want to reuse an
+        # invite in the next thread can re-invite explicitly.
+        runtime = ctx.channel_runtime
+        dismissed: list[str] = []
+        if runtime is not None and runtime.active_teams:
+            dismissed = list(runtime.active_teams)
+            runtime.active_teams = []
         await ctx.ui.start_new_session()
+        if dismissed:
+            ctx.ui.append_system(
+                f"Dismissed experts on new session: {', '.join(dismissed)}",
+                style="dim",
+            )
 
 
 class ClearCommand(Command):

--- a/EvoScientist/gateway/local.py
+++ b/EvoScientist/gateway/local.py
@@ -165,6 +165,7 @@ class LocalGraphGateway:
             metadata=request.metadata,
             media=request.media,
             events=self.events,
+            configurable_extra=request.configurable_extra,
         )
         try:
             async for event in inner:

--- a/EvoScientist/gateway/types.py
+++ b/EvoScientist/gateway/types.py
@@ -41,6 +41,13 @@ class RunRequest:
     metadata: dict[str, Any] | None = None
     media: list[str] | None = None
     target: GraphTarget | None = None
+    configurable_extra: dict[str, Any] | None = None
+    """Extra keys to merge into the LangGraph ``configurable`` dict alongside
+    ``thread_id`` — e.g. ``{"active_teams": [...]}`` from the TUI
+    ``/expert`` command. WebUI callers achieve the same effect via
+    ``langgraph_sdk``'s ``config.configurable`` on their own; this field is
+    the local-gateway equivalent so CLI / TUI / headless serve can bias
+    the run identically."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -98,8 +98,8 @@ async def get_teams(_request: Request) -> JSONResponse:
     filesystem walking + yaml parsing, which langgraph-dev's
     ``blockbuster`` middleware refuses on the async event loop.
 
-    See ``notes/teams-and-workflows/agent-teams-design.md`` for the
-    contract this endpoint fulfills.
+    Response shape (each entry): ``{name, description, byline?,
+    capability_tags?, avatar_hint?}`` — the WebUI gallery consumes these.
     """
     from EvoScientist.tools.skills_manager import list_expert_skills
 

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -75,8 +75,58 @@ async def get_models(_request: Request) -> JSONResponse:
     )
 
 
+async def get_teams(_request: Request) -> JSONResponse:
+    """Return installed expert skills as ``{teams: [...]}`` for the WebUI gallery.
+
+    A "team" in the WebUI vocabulary is an installed expert skill —
+    ``SKILL.md`` with ``type: expert`` frontmatter. The response is a
+    curated, gallery-safe projection: name + description, plus optional
+    ``byline`` / ``capability_tags`` / ``avatar_hint`` when the skill
+    populates them.
+
+    Backend implementation details (SKILL.md body / system prompt, role
+    line, default_dispatch, tool list, source tier, filesystem path,
+    tags) are intentionally NOT projected. The gallery only needs
+    identity + descriptor fields to render the card; anything richer
+    belongs in a dedicated info endpoint.
+
+    Sourced from ``list_expert_skills(include_system=True)`` so
+    first-party experts shipped as builtin skills surface alongside
+    workspace/global installs.
+
+    Offloaded to a thread because the skill loader does synchronous
+    filesystem walking + yaml parsing, which langgraph-dev's
+    ``blockbuster`` middleware refuses on the async event loop.
+
+    See ``notes/teams-and-workflows/agent-teams-design.md`` for the
+    contract this endpoint fulfills.
+    """
+    from EvoScientist.tools.skills_manager import list_expert_skills
+
+    experts = await asyncio.to_thread(list_expert_skills, True)
+    teams = []
+    for info in experts:
+        entry = {
+            "name": info.name,
+            "description": info.description,
+        }
+        # Optional gallery fields — omit when unpopulated so the WebUI
+        # card degrades gracefully (SkillInfo defaults `byline` /
+        # `avatar_hint` to "" and `capability_tags` to [], which we
+        # treat as "not declared").
+        if info.byline:
+            entry["byline"] = info.byline
+        if info.capability_tags:
+            entry["capability_tags"] = list(info.capability_tags)
+        if info.avatar_hint:
+            entry["avatar_hint"] = info.avatar_hint
+        teams.append(entry)
+    return JSONResponse({"teams": teams})
+
+
 app = Starlette(
     routes=[
         Route("/api/models", get_models, methods=["GET"]),
+        Route("/api/teams", get_teams, methods=["GET"]),
     ]
 )

--- a/EvoScientist/middleware/__init__.py
+++ b/EvoScientist/middleware/__init__.py
@@ -4,6 +4,7 @@ Re-exports middleware classes and factory functions so that existing
 ``from EvoScientist.middleware import X`` imports continue to work.
 """
 
+from .active_team import ActiveTeamMiddleware, create_active_team_middleware
 from .ask_user import (
     AskUserMiddleware,
     AskUserRequest,
@@ -39,6 +40,7 @@ from .tool_selector import create_tool_selector_middleware
 from .utils import disable_thinking
 
 __all__ = [
+    "ActiveTeamMiddleware",
     "AskUserMiddleware",
     "AskUserRequest",
     "AskUserWidgetResult",
@@ -54,6 +56,7 @@ __all__ = [
     "SchedulerMiddleware",
     "ToolErrorHandlerMiddleware",
     "compute_context_editing_trigger",
+    "create_active_team_middleware",
     "create_code_interpreter_middleware",
     "create_context_editing_middleware",
     "create_memory_lifecycle_middleware",

--- a/EvoScientist/middleware/active_team.py
+++ b/EvoScientist/middleware/active_team.py
@@ -28,8 +28,6 @@ Not included in the async-subagent middleware stack: an expert running
 as its own graph would otherwise inject a "prefer expert X" cue into
 its own system prompt, where the persona is already baked in. See
 ``EvoScientist.py::_get_default_middleware``.
-
-See ``notes/teams-and-workflows/agent-teams-design.md``.
 """
 
 from __future__ import annotations

--- a/EvoScientist/middleware/active_team.py
+++ b/EvoScientist/middleware/active_team.py
@@ -1,0 +1,131 @@
+"""ActiveTeamMiddleware for EvoScientist agent-teams v1.
+
+Reads ``configurable.active_teams: list[str]`` on every model call and
+appends a system-prompt cue biasing the main agent to consult the
+user-summoned expert(s) via ``task({subagent_type: ...})``.
+
+Backend-stateless team binding: WebUI sends ``active_teams`` on every
+``stream.submit()`` for as long as the summoned expert is active; this
+middleware reads it fresh per turn via ``langgraph.config.get_config()``.
+Matches the plan's decision to reach for the ``configurable`` primitive
+rather than a server-side thread-state store (CLAUDE.md #5).
+
+Naming note: the WIRE FORMAT is ``configurable.active_teams`` (plural,
+legacy from the earlier "teams" framing that survived the pivot per the
+WebUI section of the design note). Under the current expert-skill
+mechanism the semantic content is a list of expert names, but the
+wire key stays ``active_teams`` for WebUI compatibility. Internal
+system-prompt tags use ``<active_expert>`` / ``<active_experts>``
+because that matches what the LLM sees as the semantic target.
+
+No-op when:
+- ``configurable.active_teams`` is absent, empty, non-list, or contains
+  no non-empty string entries.
+- The middleware is invoked outside a runnable context (``get_config``
+  raises).
+
+Not included in the async-subagent middleware stack: an expert running
+as its own graph would otherwise inject a "prefer expert X" cue into
+its own system prompt, where the persona is already baked in. See
+``EvoScientist.py::_get_default_middleware``.
+
+See ``notes/teams-and-workflows/agent-teams-design.md``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+
+_TEMPLATE_SINGLE = (
+    "<active_expert>\n"
+    "The user has activated the expert `{expert}` for this thread. "
+    "Consult it via `task({{subagent_type: '{expert}', ...}})` for "
+    "requests within its scope. It stays available for the whole session "
+    "until the user dismisses it.\n"
+    "</active_expert>"
+)
+
+_TEMPLATE_MULTI = (
+    "<active_experts>\n"
+    "The user has activated the following experts for this thread: "
+    "{experts}. Consult any of them via "
+    "`task({{subagent_type: '<expert_name>', ...}})` based on which fits "
+    "the current request. Do not consult an expert if the request is "
+    "clearly outside its scope.\n"
+    "</active_experts>"
+)
+
+
+def _read_active_teams() -> list[str]:
+    """Read ``configurable.active_teams`` from the current RunnableConfig.
+
+    Returns an empty list when the config is absent, malformed, or the
+    call happens outside a runnable context.
+    """
+    try:
+        from langgraph.config import get_config
+
+        cfg = get_config()
+    except Exception:
+        # Outside a runnable context (most common in tests) or
+        # langgraph not importable — nothing to inject.
+        return []
+    if not isinstance(cfg, dict):
+        return []
+    configurable = cfg.get("configurable") or {}
+    if not isinstance(configurable, dict):
+        return []
+    raw = configurable.get("active_teams")
+    if not isinstance(raw, list):
+        return []
+    return [t for t in raw if isinstance(t, str) and t]
+
+
+class ActiveTeamMiddleware(AgentMiddleware):
+    """Bias delegation toward the user's active expert(s) on every turn."""
+
+    name = "active_team"
+
+    def _cue_for(self, experts: list[str]) -> str:
+        if len(experts) == 1:
+            return _TEMPLATE_SINGLE.format(expert=experts[0])
+        experts_str = ", ".join(f"`{e}`" for e in experts)
+        return _TEMPLATE_MULTI.format(experts=experts_str)
+
+    def modify_request(self, request: ModelRequest) -> ModelRequest:
+        """Append the active-expert cue to the request's system message."""
+        experts = _read_active_teams()
+        if not experts:
+            return request
+        from deepagents.middleware._utils import append_to_system_message
+
+        new_system = append_to_system_message(
+            request.system_message,
+            self._cue_for(experts),
+        )
+        return request.override(system_message=new_system)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        return handler(self.modify_request(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        return await handler(self.modify_request(request))
+
+
+def create_active_team_middleware() -> ActiveTeamMiddleware:
+    """Build ActiveTeamMiddleware."""
+    return ActiveTeamMiddleware()

--- a/EvoScientist/middleware/active_team.py
+++ b/EvoScientist/middleware/active_team.py
@@ -2,10 +2,10 @@
 
 Reads ``configurable.active_teams: list[str]`` on every model call and
 appends a system-prompt cue biasing the main agent to consult the
-user-summoned expert(s) via ``task({subagent_type: ...})``.
+user-invited expert(s) via ``task({subagent_type: ...})``.
 
 Backend-stateless team binding: WebUI sends ``active_teams`` on every
-``stream.submit()`` for as long as the summoned expert is active; this
+``stream.submit()`` for as long as the invited expert is active; this
 middleware reads it fresh per turn via ``langgraph.config.get_config()``.
 Matches the plan's decision to reach for the ``configurable`` primitive
 rather than a server-side thread-state store (CLAUDE.md #5).
@@ -44,7 +44,7 @@ from langchain.agents.middleware.types import (
 
 _TEMPLATE_SINGLE = (
     "<active_expert>\n"
-    "The user has activated the expert `{expert}` for this thread. "
+    "The user has invited the expert `{expert}` to this thread. "
     "Consult it via `task({{subagent_type: '{expert}', ...}})` for "
     "requests within its scope. It stays available for the whole session "
     "until the user dismisses it.\n"
@@ -53,7 +53,7 @@ _TEMPLATE_SINGLE = (
 
 _TEMPLATE_MULTI = (
     "<active_experts>\n"
-    "The user has activated the following experts for this thread: "
+    "The user has invited the following experts to this thread: "
     "{experts}. Consult any of them via "
     "`task({{subagent_type: '<expert_name>', ...}})` based on which fits "
     "the current request. Do not consult an expert if the request is "

--- a/EvoScientist/prompts.py
+++ b/EvoScientist/prompts.py
@@ -341,9 +341,9 @@ Launch multiple sub-agents only when experiments are independent:
 ## Dispatch Mechanisms
 Three ways to reach a sub-agent — pick based on what you need:
 
-- **Sequential `task`** — the default. Emit one `task({subagent_type: ..., description: ...})` tool call, wait for the result, integrate, continue. Use for a single-shot consult, including an **expert consult** when the user has summoned an expert for the thread (see any `<active_expert>` cue in the system prompt).
+- **Sequential `task`** — the default. Emit one `task({subagent_type: ..., description: ...})` tool call, wait for the result, integrate, continue. Use for a single-shot consult, including an **expert consult** when the user has invited an expert to the thread (see any `<active_expert>` cue in the system prompt).
 
-- **In-eval `task()` fan-out via `code_interpreter`** — write a short JS script that dispatches N `task()` calls concurrently and synthesises results in the same eval. Use for independent parallel work: **expert panels** (dispatch to multiple summoned experts and synthesise), ELO-style tournaments, N-way method / dataset comparisons where results are independent. Prefer `Promise.allSettled` over `Promise.all` so one failed dispatch does not fail the whole eval — inspect each entry's `status` and retry only the failed subset.
+- **In-eval `task()` fan-out via `code_interpreter`** — write a short JS script that dispatches N `task()` calls concurrently and synthesises results in the same eval. Use for independent parallel work: **expert panels** (dispatch to multiple invited experts and synthesise), ELO-style tournaments, N-way method / dataset comparisons where results are independent. Prefer `Promise.allSettled` over `Promise.all` so one failed dispatch does not fail the whole eval — inspect each entry's `status` and retry only the failed subset.
 
 - **`start_async_task`** — spawn a long-running background job that returns a task ID immediately; poll with `check_async_task` or continue when the async notification arrives. Use for work that will take minutes to hours (long training runs, exhaustive experiments, whole pipelines). The user can keep working in the main conversation while it runs.
 

--- a/EvoScientist/prompts.py
+++ b/EvoScientist/prompts.py
@@ -338,6 +338,15 @@ Launch multiple sub-agents only when experiments are independent:
 - Debug → fix → re-run — must observe the outcome before proceeding
 - Ablation design — requires knowing which components matter first
 
+## Dispatch Mechanisms
+Three ways to reach a sub-agent — pick based on what you need:
+
+- **Sequential `task`** — the default. Emit one `task({subagent_type: ..., description: ...})` tool call, wait for the result, integrate, continue. Use for a single-shot consult, including an **expert consult** when the user has summoned an expert for the thread (see any `<active_expert>` cue in the system prompt).
+
+- **In-eval `task()` fan-out via `code_interpreter`** — write a short JS script that dispatches N `task()` calls concurrently and synthesises results in the same eval. Use for independent parallel work: **expert panels** (dispatch to multiple summoned experts and synthesise), ELO-style tournaments, N-way method / dataset comparisons where results are independent. Prefer `Promise.allSettled` over `Promise.all` so one failed dispatch does not fail the whole eval — inspect each entry's `status` and retry only the failed subset.
+
+- **`start_async_task`** — spawn a long-running background job that returns a task ID immediately; poll with `check_async_task` or continue when the async notification arrives. Use for work that will take minutes to hours (long training runs, exhaustive experiments, whole pipelines). The user can keep working in the main conversation while it runs.
+
 ## When to Stop Iterating
 After each stage, ask: "Would a critical reviewer accept this evidence?"
 
@@ -359,6 +368,7 @@ After each stage, ask: "Would a critical reviewer accept this evidence?"
 - Bias towards a single sub-agent — add concurrency only when the workload is genuinely independent.
 - Avoid premature decomposition — one focused task per sub-agent.
 - Each sub-agent returns self-contained findings with concrete artifacts.
+- For parallel fan-outs in `code_interpreter`, use `Promise.allSettled` — a single failed dispatch must not fail the whole eval.
 """
 
 # =============================================================================

--- a/EvoScientist/stream/emitter.py
+++ b/EvoScientist/stream/emitter.py
@@ -140,6 +140,73 @@ class StreamEventEmitter:
         )
 
     @staticmethod
+    def panel_dispatch_start(
+        *,
+        eval_id: str,
+        dispatch_id: str,
+        subagent_type: str,
+        label: str,
+        description: str,
+    ) -> StreamEvent:
+        """A ``task()`` dispatch inside a ``code_interpreter`` eval started.
+
+        Sourced from ``langchain_quickjs``'s custom-stream subagent events.
+        Distinct family from ``subagent_start`` because the semantics differ:
+        short-lived expert dispatch inside a QuickJS eval, grouped by
+        ``eval_id`` (parent ``code_interpreter`` tool_call_id), not a full
+        nested subagent turn.
+        """
+        return StreamEvent(
+            "panel_dispatch_start",
+            {
+                "type": "panel_dispatch_start",
+                "eval_id": eval_id,
+                "id": dispatch_id,
+                "subagent_type": subagent_type,
+                "label": label,
+                "description": description,
+            },
+        )
+
+    @staticmethod
+    def panel_dispatch_complete(
+        *,
+        eval_id: str,
+        dispatch_id: str,
+        duration_ms: int,
+    ) -> StreamEvent:
+        """A ``task()`` dispatch inside a ``code_interpreter`` eval finished OK."""
+        return StreamEvent(
+            "panel_dispatch_complete",
+            {
+                "type": "panel_dispatch_complete",
+                "eval_id": eval_id,
+                "id": dispatch_id,
+                "duration_ms": duration_ms,
+            },
+        )
+
+    @staticmethod
+    def panel_dispatch_error(
+        *,
+        eval_id: str,
+        dispatch_id: str,
+        duration_ms: int,
+        error: str,
+    ) -> StreamEvent:
+        """A ``task()`` dispatch inside a ``code_interpreter`` eval raised."""
+        return StreamEvent(
+            "panel_dispatch_error",
+            {
+                "type": "panel_dispatch_error",
+                "eval_id": eval_id,
+                "id": dispatch_id,
+                "duration_ms": duration_ms,
+                "error": error,
+            },
+        )
+
+    @staticmethod
     def done(response: str = "") -> StreamEvent:
         """Done event."""
         return StreamEvent(

--- a/EvoScientist/stream/events.py
+++ b/EvoScientist/stream/events.py
@@ -862,6 +862,7 @@ async def stream_agent_events(
     metadata: dict[str, Any] | None = None,
     media: list[str] | None = None,
     events: "ToolSelectionView | None" = None,
+    configurable_extra: dict[str, Any] | None = None,
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Stream events from a DeepAgents/LangGraph v3 run.
 
@@ -877,6 +878,10 @@ async def stream_agent_events(
         metadata: Optional metadata dict merged into the LangGraph config
             (e.g. agent_name, updated_at for checkpoint persistence).
         media: Optional list of local file paths for attachments.
+        configurable_extra: Optional extra keys merged into ``configurable``
+            alongside ``thread_id`` — e.g. ``{"active_teams": [...]}`` from
+            TUI ``/expert`` bindings, mirroring what WebUI writes via
+            langgraph-sdk. Ignored if ``None`` or empty.
 
     Yields:
         Event dicts: thinking, text, tool_call, tool_result,
@@ -888,7 +893,10 @@ async def stream_agent_events(
 
         events = SessionEventSink()
 
-    config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
+    configurable: dict[str, Any] = {"thread_id": thread_id}
+    if configurable_extra:
+        configurable.update(configurable_extra)
+    config: dict[str, Any] = {"configurable": configurable}
     if metadata:
         config["metadata"] = metadata
     emitter = StreamEventEmitter()

--- a/EvoScientist/stream/events.py
+++ b/EvoScientist/stream/events.py
@@ -255,6 +255,64 @@ class _V3EventProcessor:
             return events
         if method == "input.requested":
             return self._process_input_requested(event.get("params"))
+        if method == "custom":
+            return self._process_custom_event(_event_data(event))
+        return []
+
+    def _process_custom_event(self, data: object) -> list[dict[str, Any]]:
+        """Translate a ``custom`` stream payload into UI events.
+
+        Currently handles the ``subagent`` lifecycle emitted by
+        ``langchain_quickjs`` for in-eval ``task()`` fan-out: ``start`` /
+        ``complete`` / ``error`` become ``panel_dispatch_start`` /
+        ``panel_dispatch_complete`` / ``panel_dispatch_error`` UI events.
+        Unrecognised event types are ignored so future producers can extend
+        the custom channel without breaking existing consumers.
+        """
+        payload = _as_raw_map(data)
+        if payload is None or payload.get("type") != "subagent":
+            return []
+        phase = payload.get("phase")
+        eval_id = payload.get("eval_id")
+        dispatch_id = payload.get("id")
+        if not isinstance(dispatch_id, str):
+            return []
+        eval_id_str = eval_id if isinstance(eval_id, str) else ""
+        if phase == "start":
+            subagent_type = payload.get("subagent_type")
+            label = payload.get("label")
+            description = payload.get("description")
+            return [
+                self.emitter.panel_dispatch_start(
+                    eval_id=eval_id_str,
+                    dispatch_id=dispatch_id,
+                    subagent_type=subagent_type
+                    if isinstance(subagent_type, str)
+                    else "",
+                    label=label if isinstance(label, str) else "",
+                    description=description if isinstance(description, str) else "",
+                ).data
+            ]
+        if phase == "complete":
+            duration_ms = payload.get("duration_ms")
+            return [
+                self.emitter.panel_dispatch_complete(
+                    eval_id=eval_id_str,
+                    dispatch_id=dispatch_id,
+                    duration_ms=duration_ms if isinstance(duration_ms, int) else 0,
+                ).data
+            ]
+        if phase == "error":
+            duration_ms = payload.get("duration_ms")
+            error = payload.get("error")
+            return [
+                self.emitter.panel_dispatch_error(
+                    eval_id=eval_id_str,
+                    dispatch_id=dispatch_id,
+                    duration_ms=duration_ms if isinstance(duration_ms, int) else 0,
+                    error=error if isinstance(error, str) else "",
+                ).data
+            ]
         return []
 
     @classmethod
@@ -851,7 +909,7 @@ async def stream_agent_events(
     _run_raised: bool = False
     event_sink_token = None
     try:
-        from langgraph.stream.transformers import UpdatesTransformer
+        from langgraph.stream.transformers import CustomTransformer, UpdatesTransformer
 
         from ..middleware.events import (
             MiddlewareEventSink,
@@ -867,7 +925,7 @@ async def stream_agent_events(
                 astream_input,
                 config=config,
                 version="v3",
-                transformers=[UpdatesTransformer],
+                transformers=[UpdatesTransformer, CustomTransformer],
             )
         except AttributeError as exc:
             raise RuntimeError(

--- a/EvoScientist/subagents/expert_container.py
+++ b/EvoScientist/subagents/expert_container.py
@@ -1,0 +1,151 @@
+"""Expert-subagent-spec factory for the v1 agent-teams feature.
+
+Turns an installed **expert skill** (a `SkillInfo` with `type == "expert"`) into
+a deepagents subagent spec dict compatible with `subagents=[...]` on
+`create_deep_agent`. The main agent's `_build_base_kwargs` folds these specs
+into its subagent list at construction time so the `task` tool can dispatch to
+each installed expert for sync consult; the same registry is reused by the
+QuickJS `task()` global for panel mode.
+
+The generic-container principle from #361 lives in THIS FUNCTION — one
+construction path for all experts, sourcing behaviour from the skill file
+rather than a per-expert YAML. There's no deployed graph per expert in v1;
+that's async-thread territory (v2) and blocked on the deepagents
+`AsyncSubAgent` config-passthrough gap. See:
+
+    notes/teams-and-workflows/agent-teams-design.md
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from ..tools.skills_manager import SkillInfo
+
+_logger = logging.getLogger(__name__)
+
+# Match the same YAML frontmatter block that `_parse_skill_md` recognises so
+# `_body_of` and the SkillInfo parser stay in sync. If the frontmatter regex
+# there evolves, update here too.
+_FRONTMATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n?", re.DOTALL)
+
+# Default toolset for expert subagents. Kept minimal — most experts are
+# "reason about the incoming description and produce structured output";
+# they can reach installed utility skills via the `/skills/` mount.
+#
+# `skill_manager` is included so experts can inspect what utility skills are
+# available at runtime (e.g. `idea-brainstorm` checks for `paper-navigator`
+# before starting its literature-review phase). Widening beyond these two
+# defaults should be a deliberate decision (e.g. adding `execute` only when
+# we know experts need to run scripts — deepagents' built-in file/execute
+# tools are already available regardless of this list).
+_DEFAULT_EXPERT_TOOLS: tuple[str, ...] = ("think_tool", "skill_manager")
+
+# Default skills mount — expert subagents get the same read-only skills view
+# as any other subagent (matches `research.yaml` / `writing.yaml` shape).
+_DEFAULT_EXPERT_SKILLS: tuple[str, ...] = ("/skills/",)
+
+
+def _body_of(skill_info: SkillInfo) -> str:
+    """Return the SKILL.md body (post-frontmatter content).
+
+    Reads the file fresh — SkillInfo doesn't cache the body. Returns an empty
+    string if the file can't be read; the caller is responsible for deciding
+    whether an empty prompt is acceptable (the current factory logs a warning
+    and passes it through so the malformed skill surfaces at dispatch time
+    rather than at agent build).
+    """
+    skill_md = skill_info.path / "SKILL.md"
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        _logger.warning(
+            "Expert skill %r: could not read SKILL.md at %s (%s)",
+            skill_info.name,
+            skill_md,
+            exc,
+        )
+        return ""
+    return _FRONTMATTER_RE.sub("", content, count=1).lstrip()
+
+
+def _compose_system_prompt(skill_info: SkillInfo, body: str) -> str:
+    """Compose the expert's system_prompt from its role + SKILL.md body.
+
+    The `role` frontmatter (one-line role summary) is prepended as an
+    orientation line; the body carries the persona voice, rubrics, and
+    output-style instructions (all written in second person addressing the
+    expert itself, per the expert-skill authoring convention).
+    """
+    if skill_info.role:
+        return f"You are {skill_info.role}.\n\n{body}".rstrip() + "\n"
+    return body if body.endswith("\n") else body + "\n"
+
+
+def build_expert_subagent_spec(
+    skill_info: SkillInfo,
+    tool_registry: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a deepagents subagent spec dict from an expert skill.
+
+    Args:
+        skill_info: An expert skill (``type == "expert"``). The caller is
+            responsible for filtering — passing a utility skill here builds a
+            spec anyway (utility skills just don't have persona content in
+            the body, so the result is nonsensical rather than broken).
+        tool_registry: Same registry `load_subagents` uses to resolve tool
+            names to callables (e.g. `{"think_tool": think_tool, ...}`).
+            Unresolved tools are skipped with a warning, matching
+            `_build_one` in `EvoScientist/utils.py`.
+
+    Returns:
+        A subagent spec dict with the same shape ``load_subagents`` produces:
+        ``{name, description, system_prompt, tools, skills, _async}``. Ready
+        to append to the main agent's `subagents=[...]` list.
+    """
+    tool_registry = tool_registry or {}
+    body = _body_of(skill_info)
+    system_prompt = _compose_system_prompt(skill_info, body)
+
+    resolved_tools: list[Any] = []
+    for tool_name in _DEFAULT_EXPERT_TOOLS:
+        if tool_name in tool_registry:
+            resolved_tools.append(tool_registry[tool_name])
+        else:
+            _logger.warning(
+                "Expert skill %r: default tool %r not in registry, skipping",
+                skill_info.name,
+                tool_name,
+            )
+
+    return {
+        "name": skill_info.name,
+        "description": skill_info.description,
+        "system_prompt": system_prompt,
+        "tools": resolved_tools,
+        "skills": list(_DEFAULT_EXPERT_SKILLS),
+        # v1 is sync-consult + panel only; both use the in-process subagent
+        # registry, not the async graph path. Async-thread mode = v2.
+        "_async": False,
+    }
+
+
+def build_expert_subagent_specs(
+    tool_registry: dict[str, Any] | None = None,
+    *,
+    include_system: bool = True,
+) -> list[dict[str, Any]]:
+    """Build spec dicts for every installed expert skill.
+
+    Thin wrapper over ``list_expert_skills()`` + ``build_expert_subagent_spec``.
+    Called by the main-agent construction path (``_build_base_kwargs``) to
+    fold experts into the ``subagents=[...]`` list.
+    """
+    from ..tools.skills_manager import list_expert_skills
+
+    return [
+        build_expert_subagent_spec(info, tool_registry=tool_registry)
+        for info in list_expert_skills(include_system=include_system)
+    ]

--- a/EvoScientist/subagents/expert_container.py
+++ b/EvoScientist/subagents/expert_container.py
@@ -11,25 +11,17 @@ The generic-container principle from #361 lives in THIS FUNCTION — one
 construction path for all experts, sourcing behaviour from the skill file
 rather than a per-expert YAML. There's no deployed graph per expert in v1;
 that's async-thread territory (v2) and blocked on the deepagents
-`AsyncSubAgent` config-passthrough gap. See:
-
-    notes/teams-and-workflows/agent-teams-design.md
+`AsyncSubAgent` config-passthrough gap.
 """
 
 from __future__ import annotations
 
 import logging
-import re
 from typing import Any
 
-from ..tools.skills_manager import SkillInfo
+from ..tools.skills_manager import SkillInfo, _split_frontmatter_and_body
 
 _logger = logging.getLogger(__name__)
-
-# Match the same YAML frontmatter block that `_parse_skill_md` recognises so
-# `_body_of` and the SkillInfo parser stay in sync. If the frontmatter regex
-# there evolves, update here too.
-_FRONTMATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n?", re.DOTALL)
 
 # Default toolset for expert subagents. Kept minimal — most experts are
 # "reason about the incoming description and produce structured output";
@@ -51,12 +43,13 @@ _DEFAULT_EXPERT_SKILLS: tuple[str, ...] = ("/skills/",)
 def _body_of(skill_info: SkillInfo) -> str:
     """Return the SKILL.md body (post-frontmatter content).
 
-    Reads the file fresh — SkillInfo doesn't cache the body. Returns an empty
-    string if the file can't be read; the caller is responsible for deciding
-    whether an empty prompt is acceptable (the current factory logs a warning
-    and passes it through so the malformed skill surfaces at dispatch time
-    rather than at agent build).
+    Prefers the body cached on ``SkillInfo`` by ``_parse_skill_md``. Falls
+    back to reading SKILL.md fresh if the cached body is empty — that
+    handles skills constructed by hand (external callers) without a body
+    field populated. Returns an empty string if the file can't be read.
     """
+    if skill_info.body:
+        return skill_info.body
     skill_md = skill_info.path / "SKILL.md"
     try:
         content = skill_md.read_text(encoding="utf-8")
@@ -68,7 +61,8 @@ def _body_of(skill_info: SkillInfo) -> str:
             exc,
         )
         return ""
-    return _FRONTMATTER_RE.sub("", content, count=1).lstrip()
+    _, body = _split_frontmatter_and_body(content)
+    return body
 
 
 def _compose_system_prompt(skill_info: SkillInfo, body: str) -> str:

--- a/EvoScientist/tools/skill_manager.py
+++ b/EvoScientist/tools/skill_manager.py
@@ -12,6 +12,7 @@ def skill_manager(
     name: str = "",
     tag: str = "",
     include_system: bool = False,
+    skill_type: Literal["all", "expert", "utility"] = "all",
 ) -> str:
     """Manage user-installable skills: install from GitHub or local path, list available skills, browse remote skills, get details, or uninstall.
 
@@ -27,6 +28,8 @@ def skill_manager(
     action="list":
       List installed skills. By default only shows user-installed skills.
       Set include_system=True to also show built-in system skills.
+      Set skill_type="expert" to show only expert skills (agent teams);
+      set skill_type="utility" to exclude them; leave as "all" (default) for no filter.
       Built-in skills evolve over time, so use action="list" to see the current set.
 
     action="browse" (optional tag):
@@ -36,7 +39,8 @@ def skill_manager(
 
     action="info" (requires name):
       Get details (description, source, path, tags) about a specific skill by name.
-      Searches both user and system skills.
+      Expert skills also surface their role, byline, capability tags, and default
+      dispatch mode. Searches both user and system skills.
 
     action="uninstall" (requires name):
       Remove a user-installed skill by name. System skills cannot be uninstalled.
@@ -47,6 +51,7 @@ def skill_manager(
         name: Required for info and uninstall — the skill name (for example, one returned by action="list")
         tag: Optional for browse — filter by tag (e.g. "core", "writing", "experiments", "research")
         include_system: Only for list — set True to include built-in system skills in the output
+        skill_type: Only for list — one of "all" (default; no filter), "expert" (agent-team skills), or "utility"
 
     Returns:
         Result message
@@ -79,7 +84,16 @@ def skill_manager(
 
     elif action == "list":
         skills = list_skills(include_system=include_system)
+        # `skill_type="all"` (default) is the no-filter case. A specific
+        # value ("expert" or "utility") narrows the list to that type.
+        # Empty string is NOT a legal input — Gemini's function-declaration
+        # schema rejects empty enum values (was the root cause of a live
+        # smoke failure); the `Literal` above defends against it.
+        if skill_type in ("expert", "utility"):
+            skills = [s for s in skills if s.type == skill_type]
         if not skills:
+            if skill_type in ("expert", "utility"):
+                return f"No {skill_type} skills found."
             if include_system:
                 return "No skills found."
             return "No user skills installed. Use action='install' to add skills, or set include_system=True to see built-in skills."
@@ -147,13 +161,29 @@ def skill_manager(
                 f"Skill not found: {name}. "
                 f"Use action='list' with include_system=True to see all available skills."
             )
-        tags_str = f"\nTags: {', '.join(info.tags)}" if info.tags else ""
-        return (
-            f"Name: {info.name}\n"
-            f"Description: {info.description}\n"
-            f"Source: {info.source}\n"
-            f"Path: {info.path}{tags_str}"
-        )
+        lines = [
+            f"Name: {info.name}",
+            f"Description: {info.description}",
+            f"Source: {info.source}",
+            f"Path: {info.path}",
+        ]
+        if info.tags:
+            lines.append(f"Tags: {', '.join(info.tags)}")
+        # Expert-skill surface (agent-teams v1): only shown when the
+        # skill declared `type: expert` in its SKILL.md frontmatter.
+        if info.type == "expert":
+            lines.append("Type: expert")
+            if info.role:
+                lines.append(f"Role: {info.role}")
+            if info.byline:
+                lines.append(f"Byline: {info.byline}")
+            if info.capability_tags:
+                lines.append(f"Capability tags: {', '.join(info.capability_tags)}")
+            if info.avatar_hint:
+                lines.append(f"Avatar hint: {info.avatar_hint}")
+            if info.default_dispatch:
+                lines.append(f"Default dispatch: {info.default_dispatch}")
+        return "\n".join(lines)
 
     else:
         return f"Unknown action: {action}. Use 'install', 'list', 'browse', 'uninstall', or 'info'."

--- a/EvoScientist/tools/skills_manager.py
+++ b/EvoScientist/tools/skills_manager.py
@@ -57,6 +57,16 @@ class SkillInfo:
     path: Path
     source: str  # "workspace", "global", or "builtin"
     tags: list[str] = field(default_factory=list)
+    # Expert-skill fields for the v1 agent-teams feature. All default
+    # to utility-skill values so existing skills stay unchanged and their
+    # SKILL.md files need no edits. See:
+    # notes/teams-and-workflows/agent-teams-design.md
+    type: str = "utility"  # "utility" (default) or "expert"
+    role: str = ""  # one-line role summary shown to the orchestrator LLM
+    byline: str = ""  # WebUI gallery byline
+    capability_tags: list[str] = field(default_factory=list)  # WebUI chips
+    avatar_hint: str = ""  # WebUI icon hint
+    default_dispatch: str = ""  # "sync" | "panel" (expert skills only)
 
 
 def _normalize_tags(raw: object) -> list[str]:
@@ -206,7 +216,9 @@ def installed_provenance() -> dict[str, dict[str, str | None]]:
 
 
 def _parse_skill_md(skill_md_path: Path, *, source: str = "") -> SkillInfo:
-    """Parse SKILL.md frontmatter to extract name, description, and tags.
+    """Parse SKILL.md frontmatter to extract name, description, tags, and
+    (for expert skills) role / byline / capability_tags / avatar_hint /
+    default_dispatch.
 
     SKILL.md format:
         ---
@@ -215,6 +227,14 @@ def _parse_skill_md(skill_md_path: Path, *, source: str = "") -> SkillInfo:
         tags: [tag1, tag2]
         metadata:
           tags: [tag1, tag2]   # fallback location
+        # Expert-skill fields (all optional; only meaningful when
+        # ``type: expert`` — see agent-teams-design.md):
+        type: expert
+        role: One-line role summary
+        byline: Short persona name for gallery
+        capability_tags: [Tag One, Tag Two]
+        avatar_hint: lightbulb
+        default_dispatch: sync
         ---
         # Skill Title
         ...
@@ -229,13 +249,30 @@ def _parse_skill_md(skill_md_path: Path, *, source: str = "") -> SkillInfo:
     parent = skill_md_path.parent
     content = skill_md_path.read_text(encoding="utf-8")
 
-    def _info(name: str, description: str, tags: list[str] | None = None) -> SkillInfo:
+    def _info(
+        name: str,
+        description: str,
+        tags: list[str] | None = None,
+        *,
+        type_: str = "utility",
+        role: str = "",
+        byline: str = "",
+        capability_tags: list[str] | None = None,
+        avatar_hint: str = "",
+        default_dispatch: str = "",
+    ) -> SkillInfo:
         return SkillInfo(
             name=name,
             description=description,
             path=parent,
             source=source,
             tags=tags or [],
+            type=type_,
+            role=role,
+            byline=byline,
+            capability_tags=capability_tags or [],
+            avatar_hint=avatar_hint,
+            default_dispatch=default_dispatch,
         )
 
     # Extract YAML frontmatter
@@ -254,10 +291,29 @@ def _parse_skill_md(skill_md_path: Path, *, source: str = "") -> SkillInfo:
             metadata = frontmatter.get("metadata")
             if isinstance(metadata, dict):
                 tags = _normalize_tags(metadata.get("tags"))
+        # Expert-skill fields. Only trusted when explicit; unknown
+        # ``type`` values silently fall back to "utility" so a typo
+        # doesn't accidentally register a skill as an expert.
+        raw_type = frontmatter.get("type")
+        type_ = raw_type if raw_type in ("expert", "utility") else "utility"
+        role = frontmatter.get("role") or ""
+        byline = frontmatter.get("byline") or ""
+        capability_tags = _normalize_tags(frontmatter.get("capability_tags"))
+        avatar_hint = frontmatter.get("avatar_hint") or ""
+        raw_dispatch = frontmatter.get("default_dispatch")
+        default_dispatch = raw_dispatch if raw_dispatch in ("sync", "panel") else ""
         return _info(
             frontmatter.get("name", parent.name),
             frontmatter.get("description", "(no description)"),
             tags,
+            type_=type_,
+            role=str(role) if not isinstance(role, str) else role,
+            byline=str(byline) if not isinstance(byline, str) else byline,
+            capability_tags=capability_tags,
+            avatar_hint=str(avatar_hint)
+            if not isinstance(avatar_hint, str)
+            else avatar_hint,
+            default_dispatch=default_dispatch,
         )
     except yaml.YAMLError:
         return _info(parent.name, "(invalid frontmatter)")
@@ -761,6 +817,28 @@ def list_skills(include_system: bool = False) -> list[SkillInfo]:
         _add_tier(Path(SKILLS_DIR), source="builtin")
 
     return skills
+
+
+def list_expert_skills(include_system: bool = True) -> list[SkillInfo]:
+    """List installed expert skills (agent-teams v1).
+
+    Filters ``list_skills()`` output to entries whose SKILL.md frontmatter
+    declares ``type: expert``. Defaults ``include_system=True`` because
+    first-party experts (`idea-brainstorm`, etc.) ship under the builtin
+    skills tier; user-installed experts still surface from the workspace
+    and global tiers alongside them.
+
+    Consumed by:
+      - ``GET /api/teams`` (WebUI gallery listing).
+      - Main-agent construction (folds expert skills into the
+        ``subagents=[...]`` list so the ``task`` tool can dispatch to
+        them for sync consult).
+      - The ``skill_manager`` @tool's ``type=expert`` filter.
+
+    Returns:
+        List of ``SkillInfo`` for each expert skill.
+    """
+    return [s for s in list_skills(include_system=include_system) if s.type == "expert"]
 
 
 def uninstall_skill(name: str) -> dict:

--- a/EvoScientist/tools/skills_manager.py
+++ b/EvoScientist/tools/skills_manager.py
@@ -59,14 +59,45 @@ class SkillInfo:
     tags: list[str] = field(default_factory=list)
     # Expert-skill fields for the v1 agent-teams feature. All default
     # to utility-skill values so existing skills stay unchanged and their
-    # SKILL.md files need no edits. See:
-    # notes/teams-and-workflows/agent-teams-design.md
+    # SKILL.md files need no edits.
     type: str = "utility"  # "utility" (default) or "expert"
     role: str = ""  # one-line role summary shown to the orchestrator LLM
     byline: str = ""  # WebUI gallery byline
     capability_tags: list[str] = field(default_factory=list)  # WebUI chips
     avatar_hint: str = ""  # WebUI icon hint
     default_dispatch: str = ""  # "sync" | "panel" (expert skills only)
+    # SKILL.md body (post-frontmatter). Populated by ``_parse_skill_md`` so
+    # the expert-container factory doesn't have to re-read the file on every
+    # main-agent construction. Empty for skills built by hand or when the
+    # source SKILL.md has no body content.
+    body: str = ""
+
+
+# Shared frontmatter split regex. Captures three parts:
+#   1. leading fence (``^---\s*\n``)
+#   2. frontmatter YAML (``.*?``)
+#   3. trailing fence + optional newline (``\n---\s*\n?``)
+# Used by both ``_parse_skill_md`` (needs the YAML) and the expert-container
+# factory (needs the body); a single source of truth for "what is the
+# frontmatter block" so schema extensions don't drift across call sites.
+_FRONTMATTER_SPLIT_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
+
+
+def _split_frontmatter_and_body(content: str) -> tuple[str, str]:
+    """Return ``(frontmatter_yaml, body)`` for a SKILL.md text.
+
+    ``frontmatter_yaml`` is the raw YAML block between the ``---`` fences
+    (still a string, not parsed). ``body`` is the post-fence content with
+    leading whitespace stripped. When there is no valid frontmatter block,
+    ``frontmatter_yaml`` is ``""`` and the whole content becomes the body —
+    matches the legacy expert-container behaviour of passing plain-body
+    files through unchanged.
+    """
+    match = _FRONTMATTER_SPLIT_RE.match(content)
+    if not match:
+        return "", content.lstrip()
+    body = content[match.end() :].lstrip()
+    return match.group(1), body
 
 
 def _normalize_tags(raw: object) -> list[str]:
@@ -260,6 +291,7 @@ def _parse_skill_md(skill_md_path: Path, *, source: str = "") -> SkillInfo:
         capability_tags: list[str] | None = None,
         avatar_hint: str = "",
         default_dispatch: str = "",
+        body: str = "",
     ) -> SkillInfo:
         return SkillInfo(
             name=name,
@@ -273,18 +305,19 @@ def _parse_skill_md(skill_md_path: Path, *, source: str = "") -> SkillInfo:
             capability_tags=capability_tags or [],
             avatar_hint=avatar_hint,
             default_dispatch=default_dispatch,
+            body=body,
         )
 
-    # Extract YAML frontmatter
-    frontmatter_match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
-    if not frontmatter_match:
-        # No frontmatter, use directory name
-        return _info(parent.name, "(no description)")
+    frontmatter_yaml, body = _split_frontmatter_and_body(content)
+    if not frontmatter_yaml:
+        # No frontmatter, use directory name; still cache the body so
+        # the expert-container factory doesn't have to re-read.
+        return _info(parent.name, "(no description)", body=body)
 
     try:
-        frontmatter = yaml.safe_load(frontmatter_match.group(1))
+        frontmatter = yaml.safe_load(frontmatter_yaml)
         if not isinstance(frontmatter, dict):
-            return _info(parent.name, "(empty frontmatter)")
+            return _info(parent.name, "(empty frontmatter)", body=body)
         # Tags: check top-level first, fall back to metadata.tags
         tags = _normalize_tags(frontmatter.get("tags"))
         if not tags:
@@ -314,9 +347,10 @@ def _parse_skill_md(skill_md_path: Path, *, source: str = "") -> SkillInfo:
             if not isinstance(avatar_hint, str)
             else avatar_hint,
             default_dispatch=default_dispatch,
+            body=body,
         )
     except yaml.YAMLError:
-        return _info(parent.name, "(invalid frontmatter)")
+        return _info(parent.name, "(invalid frontmatter)", body=body)
 
 
 def _parse_github_url(url: str) -> tuple[str, str | None, str | None]:

--- a/tests/stream_v3_fakes.py
+++ b/tests/stream_v3_fakes.py
@@ -113,6 +113,18 @@ def message_tool_call_block(
     )
 
 
+def custom_subagent_event(
+    payload: dict[str, Any],
+    namespace: Iterable[Any] = (),
+) -> dict[str, Any]:
+    """Build a ``custom``-method v3 event carrying a subagent-lifecycle payload.
+
+    Mirrors the shape ``langchain_quickjs._subagent`` emits via
+    ``stream_writer(event)`` for in-eval ``task()`` fan-out.
+    """
+    return protocol_event("custom", payload, namespace)
+
+
 def tool_started(
     name: str,
     args: dict[str, Any] | None = None,

--- a/tests/stream_v3_fakes.py
+++ b/tests/stream_v3_fakes.py
@@ -22,11 +22,14 @@ async def collect_events(
     thread_id: str = "t1",
     *,
     events=None,
+    configurable_extra: dict[str, Any] | None = None,
 ):
     """Collect stream_agent_events output for tests.
 
     ``events`` is the frontend tool-selection sink to drive suppression /
     selection rendering (defaults to the silent NoOpSink inside the stream).
+    ``configurable_extra`` is forwarded verbatim to ``stream_agent_events``
+    for tests that assert plumbing into the LangGraph ``configurable`` dict.
     """
     collected = []
     async for ev in stream_agent_events(
@@ -34,6 +37,7 @@ async def collect_events(
         message,
         thread_id,
         events=events,
+        configurable_extra=configurable_extra,
     ):
         collected.append(ev)
     return collected

--- a/tests/test_active_team_middleware.py
+++ b/tests/test_active_team_middleware.py
@@ -1,0 +1,217 @@
+"""Tests for EvoScientist.middleware.active_team."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import SystemMessage
+
+from EvoScientist.middleware.active_team import (
+    ActiveTeamMiddleware,
+    _read_active_teams,
+    create_active_team_middleware,
+)
+
+
+def _request():
+    """A minimal ModelRequest stand-in supporting the fields the middleware
+    reads (`system_message`) and the `.override(**kwargs)` mutator."""
+    request = SimpleNamespace(
+        state={},
+        runtime=object(),
+        system_message=SystemMessage(content="base system"),
+    )
+    request.override = lambda **kwargs: SimpleNamespace(
+        **{
+            "state": request.state,
+            "runtime": request.runtime,
+            "system_message": kwargs.get("system_message", request.system_message),
+        }
+    )
+    return request
+
+
+def _system_text(modified) -> str:
+    system_message = modified.system_message
+    assert system_message is not None
+    return str(system_message.content)
+
+
+def _mock_config():
+    cfg = MagicMock()
+    cfg.enable_ask_user = False
+    cfg.auto_mode = False
+    cfg.auto_approve = False
+    cfg.model_fallbacks = None
+    cfg.auxiliary_model = ""
+    cfg.auxiliary_provider = ""
+    cfg.code_interpreter_timeout = 60
+    cfg.code_interpreter_max_result_chars = 6000
+    return cfg
+
+
+# ---- unit tests: _read_active_teams behavior --------------------------------
+
+
+@patch("langgraph.config.get_config")
+def test_read_active_teams_returns_list_when_present(mock_get_config):
+    mock_get_config.return_value = {
+        "configurable": {"active_teams": ["idea-brainstorm"]},
+    }
+    assert _read_active_teams() == ["idea-brainstorm"]
+
+
+@patch("langgraph.config.get_config")
+def test_read_active_teams_returns_empty_when_configurable_missing(mock_get_config):
+    mock_get_config.return_value = {}
+    assert _read_active_teams() == []
+
+
+@patch("langgraph.config.get_config")
+def test_read_active_teams_returns_empty_when_active_teams_missing(mock_get_config):
+    mock_get_config.return_value = {"configurable": {"other_field": "x"}}
+    assert _read_active_teams() == []
+
+
+@patch("langgraph.config.get_config")
+def test_read_active_teams_returns_empty_when_value_not_list(mock_get_config):
+    """WebUI mistakenly sends a scalar instead of a list; must not crash."""
+    mock_get_config.return_value = {
+        "configurable": {"active_teams": "idea-brainstorm"},
+    }
+    assert _read_active_teams() == []
+
+
+@patch("langgraph.config.get_config")
+def test_read_active_teams_filters_non_string_entries(mock_get_config):
+    mock_get_config.return_value = {
+        "configurable": {
+            "active_teams": ["idea-brainstorm", None, 42, "", "lit-review"]
+        },
+    }
+    assert _read_active_teams() == ["idea-brainstorm", "lit-review"]
+
+
+@patch("langgraph.config.get_config", side_effect=RuntimeError("outside context"))
+def test_read_active_teams_returns_empty_outside_runnable_context(mock_get_config):
+    assert _read_active_teams() == []
+
+
+# ---- unit tests: middleware behavior ---------------------------------------
+
+
+@patch("langgraph.config.get_config")
+def test_middleware_no_op_when_active_teams_absent(mock_get_config):
+    mock_get_config.return_value = {"configurable": {}}
+    middleware = ActiveTeamMiddleware()
+    request = _request()
+    modified = middleware.modify_request(request)
+    # No override applied: original request returned as-is.
+    assert modified is request
+
+
+@patch("langgraph.config.get_config")
+def test_middleware_no_op_when_active_teams_empty_list(mock_get_config):
+    mock_get_config.return_value = {"configurable": {"active_teams": []}}
+    middleware = ActiveTeamMiddleware()
+    request = _request()
+    modified = middleware.modify_request(request)
+    assert modified is request
+
+
+@patch("langgraph.config.get_config")
+def test_middleware_appends_single_expert_cue(mock_get_config):
+    mock_get_config.return_value = {
+        "configurable": {"active_teams": ["idea-brainstorm"]},
+    }
+    middleware = ActiveTeamMiddleware()
+    modified = middleware.modify_request(_request())
+    text = _system_text(modified)
+    assert "<active_expert>" in text
+    assert "`idea-brainstorm`" in text
+    assert "Consult it via `task(" in text
+    assert "base system" in text  # original preserved
+
+
+@patch("langgraph.config.get_config")
+def test_middleware_appends_multi_expert_cue(mock_get_config):
+    mock_get_config.return_value = {
+        "configurable": {"active_teams": ["idea-brainstorm", "literature-review"]},
+    }
+    middleware = ActiveTeamMiddleware()
+    modified = middleware.modify_request(_request())
+    text = _system_text(modified)
+    assert "<active_experts>" in text
+    assert "`idea-brainstorm`" in text
+    assert "`literature-review`" in text
+    assert "Consult any of them" in text
+    assert "base system" in text
+
+
+@patch("langgraph.config.get_config")
+def test_middleware_appends_cue_for_unknown_expert_names(mock_get_config):
+    """Middleware doesn't validate names against the registry; main decides."""
+    mock_get_config.return_value = {
+        "configurable": {"active_teams": ["nonexistent-expert"]},
+    }
+    middleware = ActiveTeamMiddleware()
+    modified = middleware.modify_request(_request())
+    text = _system_text(modified)
+    assert "`nonexistent-expert`" in text
+
+
+@patch("langgraph.config.get_config", side_effect=RuntimeError("outside context"))
+def test_middleware_no_op_outside_runnable_context(mock_get_config):
+    middleware = ActiveTeamMiddleware()
+    request = _request()
+    modified = middleware.modify_request(request)
+    assert modified is request
+
+
+# ---- composition tests: _get_default_middleware ----------------------------
+
+
+@patch(
+    "EvoScientist.middleware.create_tool_selector_middleware",
+    return_value=[MagicMock(), MagicMock()],
+)
+@patch("EvoScientist.EvoScientist._ensure_chat_model")
+@patch("EvoScientist.EvoScientist._ensure_config")
+def test_default_middleware_includes_active_team_for_main_agent(
+    mock_config, mock_model, mock_tool_selector
+):
+    mock_config.return_value = _mock_config()
+    mock_model.return_value = MagicMock(profile={"max_input_tokens": 200_000})
+
+    from EvoScientist.EvoScientist import _get_default_middleware
+
+    middleware = _get_default_middleware()
+
+    assert any(isinstance(m, ActiveTeamMiddleware) for m in middleware)
+
+
+@patch(
+    "EvoScientist.middleware.create_tool_selector_middleware",
+    return_value=[MagicMock(), MagicMock()],
+)
+@patch("EvoScientist.EvoScientist._ensure_chat_model")
+@patch("EvoScientist.EvoScientist._ensure_config")
+def test_default_middleware_excludes_active_team_for_async_subagent(
+    mock_config, mock_model, mock_tool_selector
+):
+    mock_config.return_value = _mock_config()
+    mock_model.return_value = MagicMock(profile={"max_input_tokens": 200_000})
+
+    from EvoScientist.EvoScientist import _get_default_middleware
+
+    middleware = _get_default_middleware(for_async_subagent=True)
+
+    assert not any(isinstance(m, ActiveTeamMiddleware) for m in middleware)
+
+
+# ---- factory --------------------------------------------------------------
+
+
+def test_factory_returns_middleware_instance():
+    assert isinstance(create_active_team_middleware(), ActiveTeamMiddleware)

--- a/tests/test_expert_container.py
+++ b/tests/test_expert_container.py
@@ -100,6 +100,21 @@ class TestBodyOf:
         assert "# Body Only" in body
         assert "Content here." in body
 
+    def test_prefers_cached_body_over_disk_read(self, tmp_path):
+        """When ``SkillInfo.body`` is populated (the ``_parse_skill_md`` path),
+        ``_body_of`` uses it directly without touching disk. Guards against
+        the double-read regression flagged by pre-PR review."""
+        info = SkillInfo(
+            name="cached",
+            description="d",
+            path=tmp_path / "does-not-exist",
+            source="workspace",
+            type="expert",
+            body="Cached body content from SkillInfo.",
+        )
+        body = _body_of(info)
+        assert body == "Cached body content from SkillInfo."
+
 
 # =============================================================================
 # _compose_system_prompt

--- a/tests/test_expert_container.py
+++ b/tests/test_expert_container.py
@@ -1,0 +1,277 @@
+"""Tests for EvoScientist.subagents.expert_container factory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from EvoScientist.subagents.expert_container import (
+    _body_of,
+    _compose_system_prompt,
+    build_expert_subagent_spec,
+    build_expert_subagent_specs,
+)
+from EvoScientist.tools.skills_manager import SkillInfo
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _write_expert_skill_file(
+    parent: Path,
+    name: str,
+    *,
+    body: str = "You are a test expert.\n\nDo the thing.\n",
+    role: str = "test expert",
+    description: str = "A test expert skill",
+) -> Path:
+    """Write a minimal expert SKILL.md file and return the parent directory."""
+    skill_dir = parent / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: {description}
+type: expert
+role: {role}
+---
+{body}"""
+    )
+    return skill_dir
+
+
+def _skill_info(
+    path: Path,
+    *,
+    name: str = "expert-a",
+    description: str = "A test expert skill",
+    role: str = "test expert",
+) -> SkillInfo:
+    return SkillInfo(
+        name=name,
+        description=description,
+        path=path,
+        source="workspace",
+        type="expert",
+        role=role,
+    )
+
+
+class _FakeTool:
+    """Stand-in for a resolved tool callable — the factory only cares that
+    the value is present in the registry, not what it is."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+# =============================================================================
+# _body_of
+# =============================================================================
+
+
+class TestBodyOf:
+    def test_extracts_body_after_frontmatter(self, tmp_path):
+        skill_dir = _write_expert_skill_file(tmp_path, "expert-a")
+        info = _skill_info(skill_dir)
+        body = _body_of(info)
+        assert body.startswith("You are a test expert.")
+        assert "Do the thing." in body
+        assert "---" not in body
+        assert "type: expert" not in body
+
+    def test_returns_empty_on_missing_file(self, tmp_path, caplog):
+        # A SkillInfo pointing at a nonexistent SKILL.md — factory should
+        # gracefully degrade with a warning rather than raise.
+        info = _skill_info(tmp_path / "nonexistent")
+        body = _body_of(info)
+        assert body == ""
+        # Warning surfaced — SEV so the malformed skill isn't invisible.
+        assert any("could not read SKILL.md" in r.message for r in caplog.records)
+
+    def test_handles_no_frontmatter(self, tmp_path):
+        """A SKILL.md with no frontmatter — body is the whole file."""
+        skill_dir = tmp_path / "no-fm"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# Body Only\n\nContent here.\n")
+        info = _skill_info(skill_dir, name="no-fm")
+        body = _body_of(info)
+        assert "# Body Only" in body
+        assert "Content here." in body
+
+
+# =============================================================================
+# _compose_system_prompt
+# =============================================================================
+
+
+class TestComposeSystemPrompt:
+    def test_prepends_role_line_when_present(self):
+        info = SkillInfo(
+            name="expert-a",
+            description="d",
+            path=Path("/tmp"),
+            source="workspace",
+            type="expert",
+            role="research idea brainstormer",
+        )
+        prompt = _compose_system_prompt(info, "Follow these rules.\n")
+        assert prompt.startswith("You are research idea brainstormer.\n")
+        assert "Follow these rules." in prompt
+
+    def test_omits_role_line_when_absent(self):
+        info = SkillInfo(
+            name="expert-a",
+            description="d",
+            path=Path("/tmp"),
+            source="workspace",
+            type="expert",
+            role="",
+        )
+        prompt = _compose_system_prompt(info, "Do the thing.\n")
+        assert not prompt.startswith("You are")
+        assert prompt.rstrip() == "Do the thing."
+
+
+# =============================================================================
+# build_expert_subagent_spec
+# =============================================================================
+
+
+class TestBuildExpertSubagentSpec:
+    def test_produces_expected_shape(self, tmp_path):
+        skill_dir = _write_expert_skill_file(
+            tmp_path,
+            "expert-a",
+            body="Second-person persona instructions.\n",
+            role="research idea brainstormer",
+            description="Brainstorms research ideas",
+        )
+        info = _skill_info(
+            skill_dir,
+            name="expert-a",
+            description="Brainstorms research ideas",
+            role="research idea brainstormer",
+        )
+        registry = {
+            "think_tool": _FakeTool("think_tool"),
+            "skill_manager": _FakeTool("skill_manager"),
+        }
+        spec = build_expert_subagent_spec(info, tool_registry=registry)
+
+        # Same field set as `load_subagents._build_one` returns for a YAML subagent.
+        assert set(spec.keys()) == {
+            "name",
+            "description",
+            "system_prompt",
+            "tools",
+            "skills",
+            "_async",
+        }
+        assert spec["name"] == "expert-a"
+        assert spec["description"] == "Brainstorms research ideas"
+        assert spec["_async"] is False
+        assert spec["skills"] == ["/skills/"]
+        assert spec["tools"] == [
+            registry["think_tool"],
+            registry["skill_manager"],
+        ]
+        # Role prepended, body preserved.
+        assert spec["system_prompt"].startswith("You are research idea brainstormer.\n")
+        assert "Second-person persona instructions." in spec["system_prompt"]
+
+    def test_missing_tool_in_registry_is_skipped_not_raised(self, tmp_path, caplog):
+        skill_dir = _write_expert_skill_file(tmp_path, "expert-a")
+        info = _skill_info(skill_dir)
+        # Registry has no `think_tool`. Factory logs a warning and returns
+        # an empty tools list rather than raising.
+        spec = build_expert_subagent_spec(info, tool_registry={})
+        assert spec["tools"] == []
+        assert any(
+            "default tool 'think_tool' not in registry" in r.message
+            for r in caplog.records
+        )
+
+    def test_tool_registry_optional(self, tmp_path):
+        """Passing no registry is legal (used by tests / adhoc introspection)."""
+        skill_dir = _write_expert_skill_file(tmp_path, "expert-a")
+        info = _skill_info(skill_dir)
+        spec = build_expert_subagent_spec(info)
+        # No registry → tools empty; other fields still populated.
+        assert spec["tools"] == []
+        assert spec["name"] == "expert-a"
+        assert spec["system_prompt"]
+
+
+# =============================================================================
+# build_expert_subagent_specs (bulk over list_expert_skills)
+# =============================================================================
+
+
+class TestBuildExpertSubagentSpecs:
+    def test_returns_one_spec_per_installed_expert_skill(self, tmp_path):
+        # Two expert skills + one utility skill.
+        _write_expert_skill_file(tmp_path, "expert-a")
+        _write_expert_skill_file(tmp_path, "expert-b")
+        util = tmp_path / "util-c"
+        util.mkdir()
+        (util / "SKILL.md").write_text(
+            """---
+name: util-c
+description: Not an expert
+---
+
+# Body
+"""
+        )
+
+        registry = {
+            "think_tool": _FakeTool("think_tool"),
+            "skill_manager": _FakeTool("skill_manager"),
+        }
+        # Patch USER_SKILLS_DIR to point at our temp dir; patch GLOBAL and
+        # SKILLS_DIR to empty locations so `list_expert_skills(include_system=True)`
+        # only surfaces our two experts.
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        with (
+            patch("EvoScientist.paths.USER_SKILLS_DIR", tmp_path),
+            patch("EvoScientist.paths.GLOBAL_SKILLS_DIR", empty_dir),
+            patch("EvoScientist.EvoScientist.SKILLS_DIR", str(empty_dir)),
+        ):
+            specs = build_expert_subagent_specs(tool_registry=registry)
+
+        names = sorted(s["name"] for s in specs)
+        assert names == ["expert-a", "expert-b"]
+        for s in specs:
+            assert s["_async"] is False
+            assert s["skills"] == ["/skills/"]
+            assert s["tools"] == [
+                registry["think_tool"],
+                registry["skill_manager"],
+            ]
+
+    def test_returns_empty_when_no_expert_skills(self, tmp_path):
+        # A utility skill only — no experts.
+        util = tmp_path / "util-only"
+        util.mkdir()
+        (util / "SKILL.md").write_text(
+            """---
+name: util-only
+description: Utility
+---
+
+# Body
+"""
+        )
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        with (
+            patch("EvoScientist.paths.USER_SKILLS_DIR", tmp_path),
+            patch("EvoScientist.paths.GLOBAL_SKILLS_DIR", empty_dir),
+            patch("EvoScientist.EvoScientist.SKILLS_DIR", str(empty_dir)),
+        ):
+            specs = build_expert_subagent_specs(tool_registry={})
+        assert specs == []

--- a/tests/test_experts_command.py
+++ b/tests/test_experts_command.py
@@ -70,9 +70,9 @@ class TestExpertsList:
             ],
         ):
             await ExpertsCommand().execute(ctx, args=[])
-        # A Rich Table was mounted, and the no-experts-summoned hint appeared.
+        # A Rich Table was mounted, and the no-experts-invited hint appeared.
         assert len(ui.mounted) == 1
-        assert any("No experts summoned" in text for text, _ in ui.lines)
+        assert any("No experts invited" in text for text, _ in ui.lines)
 
     async def test_empty_list_prints_help_hint(self):
         ctx, ui = _make_ctx()
@@ -118,7 +118,7 @@ class TestExpertToggle:
         )
         assert ctx.channel_runtime.active_teams == []
 
-    async def test_summon_adds_to_active_teams(self):
+    async def test_invite_adds_to_active_teams(self):
         ctx, ui = _make_ctx()
         with patch(
             "EvoScientist.tools.skills_manager.list_expert_skills",
@@ -126,9 +126,9 @@ class TestExpertToggle:
         ):
             await ExpertCommand().execute(ctx, args=["idea-brainstorm"])
         assert ctx.channel_runtime.active_teams == ["idea-brainstorm"]
-        assert any("Summoned expert: idea-brainstorm" in text for text, _ in ui.lines)
+        assert any("Invited expert: idea-brainstorm" in text for text, _ in ui.lines)
 
-    async def test_toggle_releases_when_already_summoned(self):
+    async def test_toggle_dismisses_when_already_invited(self):
         ctx, ui = _make_ctx(active_teams=["idea-brainstorm"])
         with patch(
             "EvoScientist.tools.skills_manager.list_expert_skills",
@@ -136,21 +136,21 @@ class TestExpertToggle:
         ):
             await ExpertCommand().execute(ctx, args=["idea-brainstorm"])
         assert ctx.channel_runtime.active_teams == []
-        assert any("Released expert: idea-brainstorm" in text for text, _ in ui.lines)
+        assert any("Dismissed expert: idea-brainstorm" in text for text, _ in ui.lines)
 
-    async def test_clear_releases_all(self):
+    async def test_clear_dismisses_all(self):
         ctx, ui = _make_ctx(active_teams=["idea-brainstorm", "second"])
         await ExpertCommand().execute(ctx, args=["clear"])
         assert ctx.channel_runtime.active_teams == []
         assert any(
-            "Released experts: idea-brainstorm, second" in text for text, _ in ui.lines
+            "Dismissed experts: idea-brainstorm, second" in text for text, _ in ui.lines
         )
 
     async def test_clear_on_empty_list_reports_nothing_to_do(self):
         ctx, ui = _make_ctx()
         await ExpertCommand().execute(ctx, args=["clear"])
         assert ctx.channel_runtime.active_teams == []
-        assert any("No experts summoned" in text for text, _ in ui.lines)
+        assert any("No experts invited" in text for text, _ in ui.lines)
 
     async def test_no_channel_runtime_prints_warning(self):
         ui = _FakeUI()

--- a/tests/test_experts_command.py
+++ b/tests/test_experts_command.py
@@ -1,0 +1,159 @@
+"""Unit tests for /experts and /expert slash commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+from EvoScientist.commands.base import ChannelRuntime, CommandContext
+from EvoScientist.commands.implementation.experts import (
+    ExpertCommand,
+    ExpertsCommand,
+)
+
+
+class _FakeUI:
+    """Minimal CommandUI capturing outputs for assertion."""
+
+    supports_interactive = False
+
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, str]] = []
+        self.mounted: list[Any] = []
+
+    def append_system(self, text: str, style: str = "dim") -> None:
+        self.lines.append((text, style))
+
+    def mount_renderable(self, renderable: Any) -> None:
+        self.mounted.append(renderable)
+
+
+@dataclass
+class _FakeSkillInfo:
+    """Enough of ``SkillInfo`` for the commands to render."""
+
+    name: str
+    description: str = ""
+    role: str = ""
+    default_dispatch: str = ""
+    type: str = "expert"
+    tags: list[str] = field(default_factory=list)
+    source: str = "builtin"
+
+
+def _make_ctx(active_teams: list[str] | None = None) -> tuple[CommandContext, _FakeUI]:
+    ui = _FakeUI()
+    runtime = ChannelRuntime()
+    if active_teams:
+        runtime.active_teams = list(active_teams)
+    ctx = CommandContext(
+        agent=None,
+        thread_id="t1",
+        ui=ui,
+        channel_runtime=runtime,
+    )
+    return ctx, ui
+
+
+class TestExpertsList:
+    async def test_lists_installed_experts_in_table(self):
+        ctx, ui = _make_ctx()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[
+                _FakeSkillInfo(
+                    name="idea-brainstorm",
+                    role="Research idea brainstormer",
+                    default_dispatch="sync",
+                ),
+            ],
+        ):
+            await ExpertsCommand().execute(ctx, args=[])
+        # A Rich Table was mounted, and the no-experts-summoned hint appeared.
+        assert len(ui.mounted) == 1
+        assert any("No experts summoned" in text for text, _ in ui.lines)
+
+    async def test_empty_list_prints_help_hint(self):
+        ctx, ui = _make_ctx()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[],
+        ):
+            await ExpertsCommand().execute(ctx, args=[])
+        assert any("No expert skills installed" in text for text, _ in ui.lines)
+        assert not ui.mounted
+
+    async def test_active_expert_marked_in_table(self):
+        ctx, ui = _make_ctx(active_teams=["idea-brainstorm"])
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[
+                _FakeSkillInfo(
+                    name="idea-brainstorm",
+                    role="Research idea brainstormer",
+                    default_dispatch="sync",
+                ),
+            ],
+        ):
+            await ExpertsCommand().execute(ctx, args=[])
+        assert any("Active: idea-brainstorm" in text for text, _ in ui.lines)
+
+
+class TestExpertToggle:
+    async def test_missing_arg_prints_usage(self):
+        ctx, ui = _make_ctx()
+        await ExpertCommand().execute(ctx, args=[])
+        assert any("Usage:" in text for text, _ in ui.lines)
+
+    async def test_unknown_expert_errors(self):
+        ctx, ui = _make_ctx()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_FakeSkillInfo(name="idea-brainstorm")],
+        ):
+            await ExpertCommand().execute(ctx, args=["not-an-expert"])
+        assert any(
+            "No expert skill named 'not-an-expert'" in text for text, _ in ui.lines
+        )
+        assert ctx.channel_runtime.active_teams == []
+
+    async def test_summon_adds_to_active_teams(self):
+        ctx, ui = _make_ctx()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_FakeSkillInfo(name="idea-brainstorm")],
+        ):
+            await ExpertCommand().execute(ctx, args=["idea-brainstorm"])
+        assert ctx.channel_runtime.active_teams == ["idea-brainstorm"]
+        assert any("Summoned expert: idea-brainstorm" in text for text, _ in ui.lines)
+
+    async def test_toggle_releases_when_already_summoned(self):
+        ctx, ui = _make_ctx(active_teams=["idea-brainstorm"])
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_FakeSkillInfo(name="idea-brainstorm")],
+        ):
+            await ExpertCommand().execute(ctx, args=["idea-brainstorm"])
+        assert ctx.channel_runtime.active_teams == []
+        assert any("Released expert: idea-brainstorm" in text for text, _ in ui.lines)
+
+    async def test_clear_releases_all(self):
+        ctx, ui = _make_ctx(active_teams=["idea-brainstorm", "second"])
+        await ExpertCommand().execute(ctx, args=["clear"])
+        assert ctx.channel_runtime.active_teams == []
+        assert any(
+            "Released experts: idea-brainstorm, second" in text for text, _ in ui.lines
+        )
+
+    async def test_clear_on_empty_list_reports_nothing_to_do(self):
+        ctx, ui = _make_ctx()
+        await ExpertCommand().execute(ctx, args=["clear"])
+        assert ctx.channel_runtime.active_teams == []
+        assert any("No experts summoned" in text for text, _ in ui.lines)
+
+    async def test_no_channel_runtime_prints_warning(self):
+        ui = _FakeUI()
+        ctx = CommandContext(agent=None, thread_id="t1", ui=ui, channel_runtime=None)
+        await ExpertCommand().execute(ctx, args=["idea-brainstorm"])
+        assert any("/expert requires a session runtime" in text for text, _ in ui.lines)

--- a/tests/test_langgraph_dev_http.py
+++ b/tests/test_langgraph_dev_http.py
@@ -1,6 +1,6 @@
-"""Smoke test for the /api/models route mounted via langgraph.json's
-``http`` field. We test the FastAPI app directly — no need to spin up
-langgraph dev.
+"""Smoke tests for the /api/models and /api/teams routes mounted via
+langgraph.json's ``http`` field. We test the Starlette app directly — no
+need to spin up langgraph dev.
 """
 
 from __future__ import annotations
@@ -161,3 +161,138 @@ def test_ollama_discovery_skipped_when_base_url_absent():
         {"name": n, "model_id": m, "provider": p}
         for n, m, p in list_models_by_provider()
     ]
+
+
+# ---- /api/teams -----------------------------------------------------------
+
+
+def _expert_info(
+    name: str,
+    *,
+    description: str = "",
+    byline: str = "",
+    capability_tags: list[str] | None = None,
+    avatar_hint: str = "",
+):
+    """Build a SkillInfo for an expert skill (agent-teams v1)."""
+    from pathlib import Path
+
+    from EvoScientist.tools.skills_manager import SkillInfo
+
+    return SkillInfo(
+        name=name,
+        description=description or f"{name} description",
+        path=Path(f"/skills/{name}"),
+        source="builtin",
+        type="expert",
+        byline=byline,
+        capability_tags=list(capability_tags or []),
+        avatar_hint=avatar_hint,
+    )
+
+
+def test_get_teams_returns_installed_expert_skills():
+    experts = [
+        _expert_info("expert-a", description="First expert"),
+        _expert_info("expert-b", description="Second expert"),
+    ]
+    with patch(
+        "EvoScientist.tools.skills_manager.list_expert_skills",
+        return_value=experts,
+    ):
+        resp = client.get("/api/teams")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "teams" in body
+    names = [t["name"] for t in body["teams"]]
+    assert names == ["expert-a", "expert-b"]
+
+
+def test_get_teams_omits_backend_implementation_fields():
+    """Never leak SKILL.md body / role / dispatch / source / path / etc.
+    onto the gallery endpoint — those are backend-only."""
+    experts = [_expert_info("expert-a")]
+    with patch(
+        "EvoScientist.tools.skills_manager.list_expert_skills",
+        return_value=experts,
+    ):
+        body = client.get("/api/teams").json()
+    entry = body["teams"][0]
+    forbidden = {
+        "system_prompt",
+        "role",
+        "default_dispatch",
+        "type",
+        "source",
+        "path",
+        "tools",
+        "skills",
+        "tags",
+        "_async",
+    }
+    assert not (set(entry.keys()) & forbidden), (
+        f"leaked backend fields: {set(entry.keys()) & forbidden}"
+    )
+
+
+def test_get_teams_projects_optional_gallery_metadata_when_present():
+    experts = [
+        _expert_info(
+            "idea-brainstorm",
+            description="Multi-round brainstorm",
+            byline="Research idea brainstormer",
+            capability_tags=["Iteration", "ELO ranking"],
+            avatar_hint="lightbulb",
+        ),
+    ]
+    with patch(
+        "EvoScientist.tools.skills_manager.list_expert_skills",
+        return_value=experts,
+    ):
+        body = client.get("/api/teams").json()
+    entry = body["teams"][0]
+    assert entry["name"] == "idea-brainstorm"
+    assert entry["description"] == "Multi-round brainstorm"
+    assert entry["byline"] == "Research idea brainstormer"
+    assert entry["capability_tags"] == ["Iteration", "ELO ranking"]
+    assert entry["avatar_hint"] == "lightbulb"
+
+
+def test_get_teams_omits_optional_fields_when_absent():
+    """Gallery card should degrade gracefully when an expert declares
+    only the minimum (name, description, type: expert)."""
+    experts = [_expert_info("minimal-expert")]  # no byline / tags / avatar
+    with patch(
+        "EvoScientist.tools.skills_manager.list_expert_skills",
+        return_value=experts,
+    ):
+        body = client.get("/api/teams").json()
+    entry = body["teams"][0]
+    assert set(entry.keys()) == {"name", "description"}
+
+
+def test_get_teams_returns_empty_list_when_no_experts_installed():
+    with patch(
+        "EvoScientist.tools.skills_manager.list_expert_skills",
+        return_value=[],
+    ):
+        body = client.get("/api/teams").json()
+    assert body == {"teams": []}
+
+
+def test_get_teams_calls_loader_with_include_system_true():
+    """First-party experts ship as builtin skills; the endpoint must
+    include the builtin tier or the gallery will be empty on a fresh
+    workspace with no user-installed experts."""
+    calls = []
+
+    def spy(include_system=False):
+        calls.append(include_system)
+        return []
+
+    with patch(
+        "EvoScientist.tools.skills_manager.list_expert_skills",
+        new=spy,
+    ):
+        client.get("/api/teams")
+    assert calls == [True]

--- a/tests/test_new_command.py
+++ b/tests/test_new_command.py
@@ -34,3 +34,54 @@ class TestNewCommand:
         ctx = CommandContext(agent=None, thread_id="tid", ui=ui)
         # No AttributeError even though ctx.agent is None
         await NewCommand().execute(ctx, [])
+
+    async def test_clears_invited_experts_and_announces(self):
+        """/new dismisses invited experts uniformly with channel-shutdown clear."""
+        from EvoScientist.commands.base import ChannelRuntime, CommandContext
+        from EvoScientist.commands.implementation.session import NewCommand
+
+        ui = MagicMock()
+        ui.start_new_session = AsyncMock()
+        runtime = ChannelRuntime()
+        runtime.active_teams = ["idea-brainstorm"]
+        ctx = CommandContext(
+            agent=None,
+            thread_id="tid",
+            ui=ui,
+            channel_runtime=runtime,
+        )
+        await NewCommand().execute(ctx, [])
+        assert runtime.active_teams == []
+        messages = [call.args[0] for call in ui.append_system.call_args_list]
+        assert any(
+            "Dismissed experts on new session: idea-brainstorm" in msg
+            for msg in messages
+        )
+
+    async def test_no_announcement_when_no_experts_invited(self):
+        """No noise on ``/new`` when the invite list is already empty."""
+        from EvoScientist.commands.base import ChannelRuntime, CommandContext
+        from EvoScientist.commands.implementation.session import NewCommand
+
+        ui = MagicMock()
+        ui.start_new_session = AsyncMock()
+        runtime = ChannelRuntime()
+        ctx = CommandContext(
+            agent=None,
+            thread_id="tid",
+            ui=ui,
+            channel_runtime=runtime,
+        )
+        await NewCommand().execute(ctx, [])
+        ui.append_system.assert_not_called()
+
+    async def test_no_announcement_without_channel_runtime(self):
+        """Runs cleanly when no ChannelRuntime is attached."""
+        from EvoScientist.commands.base import CommandContext
+        from EvoScientist.commands.implementation.session import NewCommand
+
+        ui = MagicMock()
+        ui.start_new_session = AsyncMock()
+        ctx = CommandContext(agent=None, thread_id="tid", ui=ui, channel_runtime=None)
+        await NewCommand().execute(ctx, [])
+        ui.append_system.assert_not_called()

--- a/tests/test_panel_widget.py
+++ b/tests/test_panel_widget.py
@@ -1,0 +1,81 @@
+"""Unit tests for PanelWidget (TUI in-eval fan-out live view).
+
+Widget-mount / compose paths need a Textual App context and are exercised
+through the interactive TUI end-to-end. These tests cover construction and
+state-transition helpers that do not touch the compositor.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+
+class TestPanelWidgetState:
+    """PanelWidget state transitions independent of the compositor."""
+
+    def test_construction(self):
+        from EvoScientist.cli.widgets.panel_widget import PanelWidget
+
+        w = PanelWidget("ci_eval_1")
+        assert w.eval_id == "ci_eval_1"
+        assert w.dispatch_count == 0
+        assert w._is_active is True
+
+    def test_summary_counts_all_running(self):
+        from EvoScientist.cli.widgets.panel_widget import PanelWidget, _DispatchRow
+
+        w = PanelWidget("e1")
+        w._rows["d1"] = _DispatchRow("innovator", "a")
+        w._rows["d2"] = _DispatchRow("pragmatist", "b")
+        running, ok, err = w._summary_counts()
+        assert (running, ok, err) == (2, 0, 0)
+
+    def test_summary_counts_mixed(self):
+        from EvoScientist.cli.widgets.panel_widget import PanelWidget, _DispatchRow
+
+        w = PanelWidget("e1")
+        r1 = _DispatchRow("innovator", "a")
+        r2 = _DispatchRow("pragmatist", "b")
+        r3 = _DispatchRow("critic", "c")
+        r1._status = "ok"
+        r2._status = "err"
+        w._rows["d1"] = r1
+        w._rows["d2"] = r2
+        w._rows["d3"] = r3
+        running, ok, err = w._summary_counts()
+        assert (running, ok, err) == (1, 1, 1)
+
+
+class TestDispatchRow(unittest.TestCase):
+    """_DispatchRow state transitions."""
+
+    def test_construction_sets_running(self):
+        from EvoScientist.cli.widgets.panel_widget import _DispatchRow
+
+        row = _DispatchRow("idea-brainstorm", "innovator voice")
+        assert row._subagent_type == "idea-brainstorm"
+        assert row._label == "innovator voice"
+        assert row._status == "running"
+        assert row._duration_ms is None
+
+    def test_status_transitions(self):
+        from EvoScientist.cli.widgets.panel_widget import _DispatchRow
+
+        row = _DispatchRow("x", "y")
+        assert row._status == "running"
+        # Direct state change for unit test (no DOM).
+        row._status = "ok"
+        row._duration_ms = 1234
+        assert row._status == "ok"
+        assert row._duration_ms == 1234
+        row._status = "err"
+        row._error = "boom"
+        assert row._error == "boom"
+
+    def test_elapsed_display_uses_recorded_duration(self):
+        from EvoScientist.cli.widgets.panel_widget import _DispatchRow
+
+        row = _DispatchRow("x", "y")
+        row._duration_ms = 2500
+        display = row._elapsed_display()
+        assert "2.5" in display

--- a/tests/test_skills_manager.py
+++ b/tests/test_skills_manager.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from EvoScientist.tools.skills_manager import (
+    SkillInfo,
     _is_github_url,
     _load_manifest,
     _parse_github_url,
@@ -17,6 +18,7 @@ from EvoScientist.tools.skills_manager import (
     install_skill,
     installed_provenance,
     installed_sources,
+    list_expert_skills,
     list_skills,
     list_skills_by_tag,
     resolve_remote_head,
@@ -943,3 +945,323 @@ class TestSkillManagerList:
             result = skill_manager.invoke({"action": "list", "include_system": False})
 
         assert "No user skills installed" in result
+
+
+# =============================================================================
+# Tests for expert-skill fields (agent-teams v1)
+# =============================================================================
+
+
+def _write_expert_skill(
+    parent: Path,
+    name: str,
+    *,
+    role: str = "One-line role",
+    byline: str = "Test persona",
+    capability_tags: list[str] | None = None,
+    avatar_hint: str = "star",
+    default_dispatch: str = "sync",
+    include_description: bool = True,
+) -> Path:
+    """Write an expert SKILL.md under parent/<name>/ and return the skill dir."""
+    skill_dir = parent / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    tags_str = "[" + ", ".join(capability_tags or []) + "]" if capability_tags else "[]"
+    desc_line = f"description: A {name} expert skill\n" if include_description else ""
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: {name}
+{desc_line}type: expert
+role: {role}
+byline: {byline}
+capability_tags: {tags_str}
+avatar_hint: {avatar_hint}
+default_dispatch: {default_dispatch}
+---
+
+# {name}
+
+Expert-skill body.
+"""
+    )
+    return skill_dir
+
+
+class TestParseSkillMdExpertFields:
+    """`_parse_skill_md` extracts expert-skill frontmatter fields onto SkillInfo."""
+
+    def test_utility_default_when_type_absent(self, sample_skill_dir):
+        """Existing skills (no `type` field) default to utility with empty expert fields."""
+        result = _parse_skill_md(sample_skill_dir / "SKILL.md")
+        assert result.type == "utility"
+        assert result.role == ""
+        assert result.byline == ""
+        assert result.capability_tags == []
+        assert result.avatar_hint == ""
+        assert result.default_dispatch == ""
+
+    def test_expert_fields_extracted(self, tmp_path):
+        skill_dir = _write_expert_skill(
+            tmp_path,
+            "expert-a",
+            role="Expert in A",
+            byline="A Byline",
+            capability_tags=["tag-1", "tag-2"],
+            avatar_hint="atom",
+            default_dispatch="panel",
+        )
+        result = _parse_skill_md(skill_dir / "SKILL.md")
+        assert result.type == "expert"
+        assert result.role == "Expert in A"
+        assert result.byline == "A Byline"
+        assert result.capability_tags == ["tag-1", "tag-2"]
+        assert result.avatar_hint == "atom"
+        assert result.default_dispatch == "panel"
+
+    def test_unknown_type_falls_back_to_utility(self, tmp_path):
+        """A typo in `type` (e.g. `charcter`) must not silently register as an expert."""
+        skill_dir = tmp_path / "typo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            """---
+name: typo-skill
+description: Has a bad type value
+type: charcter
+role: This should be ignored
+---
+
+# Body
+"""
+        )
+        result = _parse_skill_md(skill_dir / "SKILL.md")
+        assert result.type == "utility"
+        # Other expert fields DO parse when present, but the skill is
+        # only surfaced through expert routing when type=="expert".
+        # (No assertion on `role` here — that's design choice, not contract.)
+
+    def test_invalid_default_dispatch_falls_back_to_empty(self, tmp_path):
+        skill_dir = tmp_path / "bad-dispatch"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            """---
+name: bad-dispatch
+description: Has a bad default_dispatch
+type: expert
+role: Some role
+default_dispatch: asynchronous
+---
+
+# Body
+"""
+        )
+        result = _parse_skill_md(skill_dir / "SKILL.md")
+        assert result.type == "expert"
+        assert result.default_dispatch == ""  # rejected, not passed through
+
+    def test_capability_tags_accepts_comma_string(self, tmp_path):
+        """capability_tags falls back to comma-separated string parsing (like `tags`)."""
+        skill_dir = tmp_path / "comma-tags"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            """---
+name: comma-tags
+description: Comma-separated capability tags
+type: expert
+capability_tags: alpha, beta, gamma
+---
+
+# Body
+"""
+        )
+        result = _parse_skill_md(skill_dir / "SKILL.md")
+        assert result.capability_tags == ["alpha", "beta", "gamma"]
+
+
+class TestListExpertSkills:
+    """`list_expert_skills()` filters `list_skills()` to `type == 'expert'`."""
+
+    def test_returns_only_expert_skills(self, tmp_path):
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        # An expert skill and a utility skill, both in workspace tier.
+        _write_expert_skill(workspace_dir, "expert-a")
+        util = workspace_dir / "util-b"
+        util.mkdir()
+        (util / "SKILL.md").write_text(
+            """---
+name: util-b
+description: Plain utility skill
+---
+
+# Body
+"""
+        )
+        with (
+            patch("EvoScientist.paths.USER_SKILLS_DIR", workspace_dir),
+            patch("EvoScientist.paths.GLOBAL_SKILLS_DIR", global_dir),
+        ):
+            all_skills = list_skills()
+            expert_skills = list_expert_skills(include_system=False)
+        assert {s.name for s in all_skills} == {"expert-a", "util-b"}
+        assert [s.name for s in expert_skills] == ["expert-a"]
+
+    def test_empty_when_no_expert_skills_installed(self, tmp_path):
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        global_dir = tmp_path / "global"
+        global_dir.mkdir()
+        util = workspace_dir / "util-only"
+        util.mkdir()
+        (util / "SKILL.md").write_text(
+            """---
+name: util-only
+description: Utility
+---
+
+# Body
+"""
+        )
+        with (
+            patch("EvoScientist.paths.USER_SKILLS_DIR", workspace_dir),
+            patch("EvoScientist.paths.GLOBAL_SKILLS_DIR", global_dir),
+        ):
+            expert_skills = list_expert_skills(include_system=False)
+        assert expert_skills == []
+
+
+class TestSkillManagerToolExpertSurface:
+    """`skill_manager` @tool exposes the expert-skill fields and filter."""
+
+    def _mock_skills(self):
+        return [
+            SkillInfo(
+                name="expert-a",
+                description="A brainstorm expert",
+                path=Path("/skills/expert-a"),
+                source="builtin",
+                tags=["research"],
+                type="expert",
+                role="Research idea brainstormer",
+                byline="Ideation persona",
+                capability_tags=["Iteration", "ELO"],
+                avatar_hint="lightbulb",
+                default_dispatch="sync",
+            ),
+            SkillInfo(
+                name="util-b",
+                description="A utility skill",
+                path=Path("/skills/util-b"),
+                source="workspace",
+                tags=["core"],
+            ),
+        ]
+
+    def test_list_filters_to_expert_when_skill_type_set(self):
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        with patch(
+            "EvoScientist.tools.skills_manager.list_skills",
+            return_value=self._mock_skills(),
+        ):
+            out = skill_manager.invoke(
+                {"action": "list", "include_system": True, "skill_type": "expert"}
+            )
+        assert "expert-a" in out
+        assert "util-b" not in out
+
+    def test_skill_type_enum_contains_no_empty_string(self):
+        """Gemini's function-declaration schema rejects empty enum values
+        (`GenerateContentRequest.tools[N].function_declarations[N].parameters.properties[skill_type].enum[0]: cannot be empty`).
+        The `skill_type` argument must use a non-empty sentinel (`"all"`)
+        as its no-filter default, never `""`.
+
+        This test guards against silently reintroducing the empty-string
+        default that broke the live agent-teams smoke on 2026-07-17.
+        """
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        schema = skill_manager.args_schema.model_json_schema()
+        skill_type_prop = schema.get("properties", {}).get("skill_type", {})
+        # Pydantic/JSON-schema serialization of a Literal[...] shows up as
+        # `enum` on the property directly OR nested under `anyOf`.
+        enum_values: list[str] = []
+        if "enum" in skill_type_prop:
+            enum_values = list(skill_type_prop["enum"])
+        else:
+            for branch in skill_type_prop.get("anyOf", []):
+                if "enum" in branch:
+                    enum_values.extend(branch["enum"])
+        assert enum_values, "skill_type Literal should surface as enum in the schema"
+        assert "" not in enum_values, (
+            f"Empty string in skill_type enum will break Gemini: {enum_values}"
+        )
+
+    def test_list_all_sentinel_is_no_filter(self):
+        """`skill_type='all'` (the default) must return every skill —
+        it's the no-filter case, not a bucket that only 'all' skills fall into."""
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        with patch(
+            "EvoScientist.tools.skills_manager.list_skills",
+            return_value=self._mock_skills(),
+        ):
+            out = skill_manager.invoke(
+                {"action": "list", "include_system": True, "skill_type": "all"}
+            )
+        # Both should appear — 'all' is not a filter to a bucket named "all".
+        assert "expert-a" in out
+        assert "util-b" in out
+
+    def test_list_all_when_skill_type_absent(self):
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        with patch(
+            "EvoScientist.tools.skills_manager.list_skills",
+            return_value=self._mock_skills(),
+        ):
+            out = skill_manager.invoke({"action": "list", "include_system": True})
+        assert "expert-a" in out
+        assert "util-b" in out
+
+    def test_list_returns_message_when_filter_matches_nothing(self):
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        with patch(
+            "EvoScientist.tools.skills_manager.list_skills",
+            return_value=self._mock_skills()[1:],  # only the utility
+        ):
+            out = skill_manager.invoke(
+                {"action": "list", "include_system": True, "skill_type": "expert"}
+            )
+        assert "No expert skills found" in out
+
+    def test_info_surfaces_expert_fields(self):
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        with patch(
+            "EvoScientist.tools.skills_manager.get_skill_info",
+            return_value=self._mock_skills()[0],
+        ):
+            out = skill_manager.invoke({"action": "info", "name": "expert-a"})
+        assert "Type: expert" in out
+        assert "Role: Research idea brainstormer" in out
+        assert "Byline: Ideation persona" in out
+        assert "Capability tags: Iteration, ELO" in out
+        assert "Avatar hint: lightbulb" in out
+        assert "Default dispatch: sync" in out
+
+    def test_info_omits_expert_block_for_utility_skills(self):
+        from EvoScientist.tools.skill_manager import skill_manager
+
+        with patch(
+            "EvoScientist.tools.skills_manager.get_skill_info",
+            return_value=self._mock_skills()[1],
+        ):
+            out = skill_manager.invoke({"action": "info", "name": "util-b"})
+        assert "Type: expert" not in out
+        assert "Role:" not in out
+        assert "Byline:" not in out
+        assert "Capability tags:" not in out
+        assert "Default dispatch:" not in out

--- a/tests/test_skills_manager.py
+++ b/tests/test_skills_manager.py
@@ -1018,6 +1018,26 @@ class TestParseSkillMdExpertFields:
         assert result.avatar_hint == "atom"
         assert result.default_dispatch == "panel"
 
+    def test_body_populated_from_skill_md(self, tmp_path):
+        """`SkillInfo.body` carries the post-frontmatter content so the expert
+        container factory can build the system_prompt without re-reading disk."""
+        skill_dir = _write_expert_skill(tmp_path, "expert-body")
+        result = _parse_skill_md(skill_dir / "SKILL.md")
+        assert "# expert-body" in result.body
+        assert "Expert-skill body." in result.body
+        # Frontmatter fences must NOT leak into the body.
+        assert "---" not in result.body
+
+    def test_body_captured_when_no_frontmatter(self, tmp_path):
+        """Skills without a frontmatter block still cache their full text as
+        the body — the expert-container factory can then use it without a
+        second disk read."""
+        skill_dir = tmp_path / "no-frontmatter"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("Just body content, no fences.\n")
+        result = _parse_skill_md(skill_dir / "SKILL.md")
+        assert result.body.strip() == "Just body content, no fences."
+
     def test_unknown_type_falls_back_to_utility(self, tmp_path):
         """A typo in `type` (e.g. `charcter`) must not silently register as an expert."""
         skill_dir = tmp_path / "typo-skill"

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -158,6 +158,26 @@ class TestV3ProtocolStreaming:
         assert "stream_mode" not in kwargs
         assert "subgraphs" not in kwargs
 
+    async def test_configurable_extra_merged_into_config(self):
+        """``configurable_extra`` from RunRequest lands next to thread_id."""
+        agent = FakeV3Agent([message_delta("hi")])
+        await collect_events(
+            agent,
+            thread_id="t1",
+            configurable_extra={"active_teams": ["idea-brainstorm"]},
+        )
+        _, kwargs = agent.astream_events.call_args
+        configurable = kwargs["config"]["configurable"]
+        assert configurable["thread_id"] == "t1"
+        assert configurable["active_teams"] == ["idea-brainstorm"]
+
+    async def test_configurable_extra_none_leaves_thread_id_only(self):
+        """When no extras are passed, only ``thread_id`` sits under configurable."""
+        agent = FakeV3Agent([message_delta("hi")])
+        await collect_events(agent, thread_id="t1")
+        _, kwargs = agent.astream_events.call_args
+        assert kwargs["config"]["configurable"] == {"thread_id": "t1"}
+
     async def test_streamed_non_selector_json_is_replayed(self):
         """Normal JSON answers are not swallowed by selector JSON buffering."""
         agent = FakeV3Agent(

--- a/tests/test_stream_events.py
+++ b/tests/test_stream_events.py
@@ -29,6 +29,7 @@ from tests.stream_v3_fakes import (
     SubscriptionSensitiveV3Agent,
     async_iter,
     collect_events,
+    custom_subagent_event,
     message_delta,
     message_finish,
     message_tool_call_block,
@@ -1249,6 +1250,157 @@ class TestUsageStatsExtraction:
         events = await collect_events(agent)
         usage_events = [e for e in events if e.get("type") == "usage_stats"]
         assert len(usage_events) == 0
+
+
+class TestPanelDispatchEvents:
+    """Custom-stream subagent lifecycle from in-eval task() fan-out."""
+
+    async def test_start_event_becomes_panel_dispatch_start(self):
+        agent = FakeV3Agent(
+            [
+                custom_subagent_event(
+                    {
+                        "type": "subagent",
+                        "phase": "start",
+                        "id": "ptc_task_abc12345",
+                        "eval_id": "ci_eval_1",
+                        "subagent_type": "idea-brainstorm",
+                        "label": "innovator voice",
+                        "description": "generate one bold candidate",
+                    }
+                ),
+            ]
+        )
+        events = await collect_events(agent)
+        starts = [e for e in events if e.get("type") == "panel_dispatch_start"]
+        assert len(starts) == 1
+        start = starts[0]
+        assert start["id"] == "ptc_task_abc12345"
+        assert start["eval_id"] == "ci_eval_1"
+        assert start["subagent_type"] == "idea-brainstorm"
+        assert start["label"] == "innovator voice"
+        assert start["description"] == "generate one bold candidate"
+
+    async def test_complete_event_becomes_panel_dispatch_complete(self):
+        agent = FakeV3Agent(
+            [
+                custom_subagent_event(
+                    {
+                        "type": "subagent",
+                        "phase": "complete",
+                        "id": "ptc_task_abc12345",
+                        "eval_id": "ci_eval_1",
+                        "duration_ms": 1234,
+                    }
+                ),
+            ]
+        )
+        events = await collect_events(agent)
+        completes = [e for e in events if e.get("type") == "panel_dispatch_complete"]
+        assert len(completes) == 1
+        assert completes[0]["id"] == "ptc_task_abc12345"
+        assert completes[0]["duration_ms"] == 1234
+
+    async def test_error_event_becomes_panel_dispatch_error(self):
+        agent = FakeV3Agent(
+            [
+                custom_subagent_event(
+                    {
+                        "type": "subagent",
+                        "phase": "error",
+                        "id": "ptc_task_abc12345",
+                        "eval_id": "ci_eval_1",
+                        "duration_ms": 42,
+                        "error": "boom",
+                    }
+                ),
+            ]
+        )
+        events = await collect_events(agent)
+        errors = [e for e in events if e.get("type") == "panel_dispatch_error"]
+        assert len(errors) == 1
+        assert errors[0]["error"] == "boom"
+        assert errors[0]["duration_ms"] == 42
+
+    async def test_unknown_custom_type_ignored(self):
+        """Custom payloads whose ``type`` is not ``subagent`` don't emit events."""
+        agent = FakeV3Agent(
+            [
+                custom_subagent_event({"type": "something-else", "value": 1}),
+            ]
+        )
+        events = await collect_events(agent)
+        assert not any(e.get("type", "").startswith("panel_dispatch") for e in events)
+
+    async def test_missing_id_dropped(self):
+        """A malformed subagent event without ``id`` is silently dropped."""
+        agent = FakeV3Agent(
+            [
+                custom_subagent_event(
+                    {
+                        "type": "subagent",
+                        "phase": "start",
+                        "subagent_type": "x",
+                        "label": "y",
+                    }
+                ),
+            ]
+        )
+        events = await collect_events(agent)
+        assert not any(e.get("type", "").startswith("panel_dispatch") for e in events)
+
+    async def test_grouped_fanout_shares_eval_id(self):
+        """Parallel dispatches from one eval share the same ``eval_id``."""
+        agent = FakeV3Agent(
+            [
+                custom_subagent_event(
+                    {
+                        "type": "subagent",
+                        "phase": "start",
+                        "id": "d1",
+                        "eval_id": "e1",
+                        "subagent_type": "innovator",
+                        "label": "a",
+                        "description": "d",
+                    }
+                ),
+                custom_subagent_event(
+                    {
+                        "type": "subagent",
+                        "phase": "start",
+                        "id": "d2",
+                        "eval_id": "e1",
+                        "subagent_type": "pragmatist",
+                        "label": "b",
+                        "description": "d",
+                    }
+                ),
+                custom_subagent_event(
+                    {
+                        "type": "subagent",
+                        "phase": "complete",
+                        "id": "d1",
+                        "eval_id": "e1",
+                        "duration_ms": 100,
+                    }
+                ),
+                custom_subagent_event(
+                    {
+                        "type": "subagent",
+                        "phase": "complete",
+                        "id": "d2",
+                        "eval_id": "e1",
+                        "duration_ms": 200,
+                    }
+                ),
+            ]
+        )
+        events = await collect_events(agent)
+        panel_events = [
+            e for e in events if e.get("type", "").startswith("panel_dispatch")
+        ]
+        assert len(panel_events) == 4
+        assert {e["eval_id"] for e in panel_events} == {"e1"}
 
 
 class TestSummarizationHelpers:


### PR DESCRIPTION
## Summary

Implements #361 ("About Agent Teams"). Ships the expert-skill mechanism (Part 3 core), TUI visibility for in-eval `task()` fan-out (Part 1), and the routing guidance in `DELEGATION_STRATEGY` (Part 2 prompt side). Two Part 2 skill rewrites and Part 3's async-thread dispatch mode are deferred to their own PRs, called out below.

Nine commits, one per phase, staged so each is independently reviewable and revertable.

## Mapping to #361

### Part 1 - TUI visibility for in-eval fan-out

Shipped in commit `5509f42` ("feat: surface QuickJS panel dispatches in TUI"). Display-layer only, no runtime changes, as specified.

- `CustomTransformer` registered alongside `UpdatesTransformer` in `EvoScientist/stream/events.py`, so the v3 stream now asks for the `custom` mode.
- `_V3EventProcessor.process()` handles `method == "custom"` and translates the `langchain_quickjs` subagent lifecycle payloads (start/complete/error) into three new UI event families on the emitter: `panel_dispatch_start`, `panel_dispatch_complete`, `panel_dispatch_error`. Grouped by `eval_id` (the parent `code_interpreter` tool_call_id).
- New `PanelWidget` (Textual) in `EvoScientist/cli/widgets/panel_widget.py` - one bordered container per eval, one row per dispatch. Each row shows subagent_type + label + live elapsed timer + status dot (running / ok / err). Header live-counts (`N running, M done, K failed`) and flips to a green completion state when all rows settle.
- Three new branches in `EvoScientist/cli/tui_interactive.py` mount / update / finalize panel widgets on the new event types.

Live-verified end-to-end on `idea-brainstorm` panel-mode fan-out (see "Test plan" below).

### Part 2 - Routing guidance in DELEGATION_STRATEGY

Prompt side shipped in commit `afcaf8b` ("feat: document sync / QuickJS panel / async dispatch modes in DELEGATION_STRATEGY").

- Explicit routing block in `EvoScientist/prompts.py::DELEGATION_STRATEGY` documenting when to use each of the three dispatch modes: sequential `task`, in-eval `task()` fan-out via `code_interpreter`, and `start_async_task`.
- `Promise.allSettled` guardrail included per the issue's "Additional context" note (one failed dispatch should not fail the whole eval).

Skill-side rewrites (`research-ideation` ELO tournament, `paper-review` 5-aspect pass) are **NOT** in this branch. They are separate PRs under Part 2's skill-side track, called out as deferred in the plan and design note (`notes/teams-and-workflows/agent-teams-design.md`, "Deferred to their own branches / owners").

### Part 3 - Agent Teams: expert-skill mechanism

Shipped in commits `e677a83` through `12c5607`, plus `691cb5d` and `e5027bb` for the TUI selection UX.

- **Schema and loader** (`e677a83`): `type: expert` frontmatter (default `type: utility` for existing skills), plus optional `role`, `byline`, `capability_tags`, `avatar_hint`, `default_dispatch: sync | panel`. `SkillInfo` dataclass extended. `list_expert_skills()` helper added. `skill_manager` @tool got an optional `type` filter for `list` and `info` actions. Backward-compatible with all existing utility skills.
- **Generic container** (`b986258`): `build_expert_subagent_spec(skill_info)` and `build_expert_subagent_specs()` in `EvoScientist/subagents/expert_container.py`. Main-agent `_build_base_kwargs` and `load_mcp_and_build_kwargs` fold installed expert skills into the `subagents=[...]` list passed to `create_deep_agent`, so the `task` tool's schema enumerates them dynamically. One factory function, no per-expert graph registrations - matches the issue's "one generic agent container parameterized by the skill" requirement.
- **`GET /api/teams` HTTP endpoint** (`a73c72e`): powers the WebUI gallery. Filters `list_expert_skills(True)` and projects `name`, `description`, and optional `byline` / `capability_tags` / `avatar_hint`.
- **`ActiveTeamMiddleware`** (`14ebac5`): reads `configurable.active_teams: list[str]` on every model call, appends a `<active_expert>` / `<active_experts>` cue biasing the main agent to consult the invited expert(s). Not attached to async subagents (their persona is already baked into their own system prompt).
- **First shipped expert skill: `idea-brainstorm`** (`8373780`). Six-phase pipeline (literature review, three-voice iterative refinement, ELO ranking, champion proposal). `default_dispatch: sync`. Precondition check for the `paper-navigator` skill for literature grounding.
- **TUI expert-selection commands** (`691cb5d`): `/experts` lists installed expert skills in a Rich table (name, role, dispatch, active marker). `/expert <name>` toggles into the current session's invite list. `/expert clear` releases all. Backing store is `ChannelRuntime.active_teams`, threaded through a new `RunRequest.configurable_extra` field into `stream_agent_events` and merged into `config["configurable"]`. Mirrors the WebUI gallery for TUI users.
- **Wording alignment with WebUI** (`e5027bb`): user-facing verbs shifted to `invite` / `dismiss` to match the gallery. `configurable.active_teams` wire format kept unchanged for compatibility.

Sync `task` dispatch and QuickJS panel fan-out are both live-verified. The third dispatch mode named in the issue (**async agent thread** for a resident multi-turn expert conversation) is **NOT** shipped in this PR - see "Deferred" below.

## Deferred to their own PRs

- **Part 2 skill rewrites**: `research-ideation` (ELO tournament as a QuickJS workflow) and `paper-review` (5-aspect fan-out). Prompt-side routing guidance ships here; the skill scripts do not.
- **Part 3 async-thread dispatch**: the issue calls out three dispatch modes; sync and panel ship here, async-thread does not. Blocked on `deepagents.AsyncSubAgent` not cleanly accepting a config passthrough at dispatch time, which the container needs to bind a specific expert skill to a running async thread. Two paths noted in the design (upstream PR against deepagents, or embedding the skill name in the graph_id and parsing on the remote end); neither is on the critical path for the v1 feature. Design note names the specific gap.
- **WebUI in-eval-fan-out panel**: WebUI already receives the new `panel_dispatch_*` events via SSE (same stream, same processor). A frontend panel there is a follow-up in `@evoscientist/webui`, not blocked on backend changes.
- **Expert-skill install index / marketplace**: experts install through the existing `skill_manager` (same as utility skills). No dedicated discovery UI in v1. Contract note flags it as a v2 concern.

## Caveats and questionable design decisions

Honest list of trade-offs a reviewer should push back on if they disagree:

1. **`PanelWidget` and `SubAgentWidget` both render for the same panel-mode dispatches.** Every QuickJS `task()` call surfaces on two independent stream paths: the new `custom` events (Phase 7) and the existing DeepAgents `stream.subagents` projection. In the TUI you get the panel widget AND three "Cooking with idea-brainstorm" blocks below it. The scoping note recommended de-duplicating (option A) but v1 ships them side-by-side because cross-stream correlation adds real complexity and the two views convey different things (panel = live parallelism overview; per-subagent widget = drill-down into what each subagent actually did). If reviewers find the duplication noisy, dedupe is a small follow-up.

2. **`active_teams` wire format stayed plural.** The historical name from before the pivot to expert-skills; kept because the WebUI already ships with it and rewrites would be gratuitous churn. Semantic content is now a list of expert names. Documented in the middleware docstring.

3. **`ChannelRuntime.active_teams` is cleared on `/new`.** Initial draft persisted the invite list across `/new` (session-scoped semantics). Code review flagged the surprise; user pushback confirmed `/new` should be a real reset. Behaviour landed in a post-review polish commit alongside the double-read fix: `/new` releases invited experts and announces what was dismissed. Uniform with `ChannelRuntime.clear()` on channel shutdown.

4. **Expert skills share the same directory as utility skills** (`EvoScientist/skills/`), discriminated by frontmatter. Alternative: a separate `EvoScientist/experts/`. Chose flat-with-discriminator because it matches how `skill_manager install` already works and avoids introducing a second install path.

5. **`build_expert_subagent_specs` rebuilds on every main-agent construction.** No spec-level caching by skill_name. Fine at the current one-shipped-expert scale; profile before caching if it becomes a concern. The double-read of SKILL.md flagged by pre-PR review has been addressed: `SkillInfo` now carries the body populated at parse time, and `_body_of` uses it directly. A shared `_split_frontmatter_and_body` helper collapses the previously duplicated regex.

6. **`configurable_extra` on `RunRequest` is an untyped dict-passthrough.** Loose form matches langgraph-sdk's own `configurable` shape and keeps the API-surface change minimal. A typed extension-key protocol would be more principled but felt over-designed for one caller.

7. **`_DispatchRow` widget ended up as `Widget` with a `render()` override after two failed alternatives** (`Static` subclass had `visual = None` past first paint; `Vertical` with inner `Static` hit a container-child compose race). The final shape is documented in-file. Signal: Textual's best practices for single-line widgets are less obvious than I originally assumed, and this branch's iteration history around that widget lives in the commit trail if a follow-up needs the trace.

8. **`idea-brainstorm` uses `default_dispatch: sync` but internally runs three voices** (Innovator / Pragmatist / Critic). Voices are in-turn within one agent, not `task()` fan-out to sub-experts, so the panel widget does not light up when the skill's internal pipeline runs. This is by design (the skill is a single expert with three modes of thinking) but blurs the "panel = multiple experts" framing. A future `research-ideation` rewrite that fans out to three separate voice-experts via QuickJS would be a cleaner panel demo.

9. **Only one expert skill shipped.** `idea-brainstorm` is the only `type: expert` skill in the tree. Any WebUI "expert gallery" demo currently shows a one-item list. Other experts will land as they get authored / migrated - not a blocker for the feature itself.

## Structure of the branch

Nine commits, roughly one per phase, in this order:

- `e677a83` feat: add expert-skill schema and type filter to skill_manager
- `b986258` feat: fold installed expert skills into main-agent subagent registry
- `a73c72e` feat: add GET /api/teams listing expert skills for gallery
- `14ebac5` feat: bias main-agent delegation toward configurable.active_teams
- `afcaf8b` feat: document sync / QuickJS panel / async dispatch modes in DELEGATION_STRATEGY
- `8373780` feat: ship idea-brainstorm expert skill
- `5509f42` feat: surface QuickJS panel dispatches in TUI
- `691cb5d` feat: add /experts and /expert TUI commands for expert-skill summoning
- `e5027bb` feat: align expert-selection wording with WebUI (invite/dismiss)

Each commit is independently reviewable and can be reverted in isolation.

## Test plan

Automated tests:

- [ ] `uv run pytest tests/test_skills_manager.py` - schema and loader coverage for `type: expert` + new fields.
- [ ] `uv run pytest tests/test_active_team_middleware.py` - middleware fires with correct cue when `active_teams` is set, no-op when empty.
- [ ] `uv run pytest tests/test_langgraph_dev_http.py` - `GET /api/teams` returns expert-skill entries.
- [ ] `uv run pytest tests/test_stream_events.py::TestPanelDispatchEvents` - custom-stream subagent lifecycle → `panel_dispatch_*` UI events.
- [ ] `uv run pytest tests/test_stream_events.py::TestV3ProtocolStreaming::test_configurable_extra_merged_into_config` - `configurable_extra` plumbing.
- [ ] `uv run pytest tests/test_panel_widget.py` - widget state transitions.
- [ ] `uv run pytest tests/test_experts_command.py` - `/experts` / `/expert` command behavior.

Live-verified during development (documented in the branch's session traces):

- [x] Sync consult: main agent dispatches to `idea-brainstorm` when invited, full six-phase pipeline runs end-to-end (~136s wall-clock).
- [x] QuickJS panel mode: prompt with three parallel `task()` calls inside `code_interpreter` → single `PanelWidget` mounts with three rows, live spinners + elapsed timers, all three rows finalize on completion.
- [x] `/experts` lists `idea-brainstorm` correctly; `/expert idea-brainstorm` mutates `ChannelRuntime.active_teams`; introspection prompt confirms the `<active_expert>` cue lands in the model's system prompt on the next turn; `/expert clear` verified at the middleware layer (temporary debug log confirmed `experts=[]` on the turn after `clear`).
- [x] WebUI e2e for `GET /api/teams` confirmed on the parallel WebUI branch during Phase 3.

Regression:

- [x] Full test suite: 2990 passed, 10 skipped, 13 failed - all 13 failures reproduce on `origin/main` and are unrelated (pre-existing `test_code_interpreter_middleware` and `test_tui_banner_position` failures).
- [x] Parallel-dispatch probe (`notes/teams-and-workflows/probes/parallel_task_dispatch.py`) unchanged from `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expert skill discovery and selection with `/experts` and `/expert` commands.
  * Expert selections now influence agent responses and delegation.
  * Added `/api/teams` for displaying available expert skills.
  * Added an interactive panel showing expert dispatch progress, completion times, and failures.
  * Added support for parallel expert dispatches with improved streaming updates.

* **Bug Fixes**
  * Starting a new session now clears previously invited experts and reports which were dismissed.

* **Tests**
  * Added coverage for expert selection, dispatch panels, streaming events, API responses, and session resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->