### PR TITLE
fix: log missing async-subagent tools at DEBUG, not WARNING

### DIFF
--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -499,9 +499,14 @@ def _build_base_kwargs(
         tool_registry["tavily_search"] = tavily_search
     base_tools = [think_tool, skill_manager]
 
+    # ``async_swap_pending=True`` because ``_maybe_swap_async_subagents``
+    # below re-resolves tools for async subagents against the deployed
+    # graph's own registry (via ``subagents/_factory.py``). A tool missing
+    # from ``tool_registry`` for an async spec logs at DEBUG, not WARNING.
     subs = load_subagents(
         SUBAGENTS_CONFIG,
         tool_registry=tool_registry,
+        async_swap_pending=True,
     )
     _ensure_general_purpose_subagent(subs)
     _inject_subagent_middleware(
@@ -569,9 +574,12 @@ def load_mcp_and_build_kwargs(
 
     mcp_main = mcp_by_agent.pop("main", [])
 
+    # Same rationale as ``_build_base_kwargs``: async subagents get
+    # re-resolved downstream by the deployed graph's factory registry.
     subs = load_subagents(
         SUBAGENTS_CONFIG,
         tool_registry=registry,
+        async_swap_pending=True,
     )
 
     _ensure_general_purpose_subagent(subs)

--- a/EvoScientist/utils.py
+++ b/EvoScientist/utils.py
@@ -114,6 +114,7 @@ def load_subagents(
     *,
     tool_registry: dict[str, Any],
     prompt_refs: dict[str, str] | None = None,
+    async_swap_pending: bool = False,
 ) -> list[dict[str, Any]]:
     """Load subagent definitions from a directory of YAML files and wire up tools.
 
@@ -139,6 +140,17 @@ def load_subagents(
           tools: [tavily_search, think_tool]
           system_prompt: |
             ...
+
+    ``async_swap_pending`` tells the loader that an async-subagent swap will
+    run downstream against a different tool registry (typically the deployed
+    graph's own registry in ``subagents/_factory.py``). When True, a tool
+    missing from ``tool_registry`` for an ``async: true`` spec is logged at
+    DEBUG (it will be re-resolved by the async graph). When False, the
+    caller IS the terminal registry — any missing tool is a genuine typo
+    and logs at WARNING. Sync in-process callers
+    (``EvoScientist._build_base_kwargs``, ``load_mcp_and_build_kwargs``)
+    should pass True; the factory
+    (``subagents/_factory.build_async_subagent_graph``) leaves it False.
     """
     prompt_refs = prompt_refs or {}
 
@@ -233,11 +245,11 @@ def load_subagents(
             for t in spec["tools"]:
                 if t in tool_registry:
                     resolved.append(tool_registry[t])
-                elif async_val:
-                    # Async sub-agents are re-resolved against the deployed
-                    # graph's own tool registry (see subagents/_factory.py) —
-                    # the in-process registry is intentionally minimal for
-                    # them. A missing tool here is expected, not degraded.
+                elif async_val and async_swap_pending:
+                    # Caller expects an async-subagent swap downstream against
+                    # a different registry. The in-process registry is
+                    # intentionally minimal for async agents — a miss here is
+                    # not degraded state.
                     logger.debug(
                         "Subagent %r: tool %r not in the in-process registry; "
                         "resolved by the async graph",
@@ -245,6 +257,8 @@ def load_subagents(
                         t,
                     )
                 else:
+                    # Terminal registry (factory) OR sync subagent — a missing
+                    # tool is a genuine typo and won't be resolved anywhere.
                     logger.warning(
                         "Subagent %r: tool %r not in registry, skipping", name, t
                     )
@@ -266,12 +280,17 @@ def load_subagent(
     *,
     tool_registry: dict[str, Any],
     prompt_refs: dict[str, str] | None = None,
+    async_swap_pending: bool = False,
 ) -> dict[str, Any]:
-    """Load a single sub-agent by name from YAML."""
+    """Load a single sub-agent by name from YAML.
+
+    See :func:`load_subagents` for ``async_swap_pending`` semantics.
+    """
     for agent in load_subagents(
         config_path,
         tool_registry=tool_registry,
         prompt_refs=prompt_refs,
+        async_swap_pending=async_swap_pending,
     ):
         if agent.get("name") == name:
             return agent

--- a/EvoScientist/utils.py
+++ b/EvoScientist/utils.py
@@ -212,18 +212,9 @@ def load_subagents(
         if "skills" in spec:
             subagent["skills"] = spec["skills"]
 
-        if "tools" in spec:
-            resolved = []
-            for t in spec["tools"]:
-                if t in tool_registry:
-                    resolved.append(tool_registry[t])
-                else:
-                    logger.warning(
-                        "Subagent %r: tool %r not in registry, skipping", name, t
-                    )
-            subagent["tools"] = resolved
-
-        # Internal field: carries the ``async:`` yaml flag through to
+        # Compute the async flag up-front so the tools-resolution block below
+        # can pick the right log level for missing tools. Internal field:
+        # carries the ``async:`` yaml flag through to
         # ``_maybe_swap_async_subagents`` so the swap doesn't need a second
         # yaml pass to discover async-flagged agents. Underscore prefix marks
         # it as internal — must be popped before passing to deepagents.
@@ -236,6 +227,29 @@ def load_subagents(
                 f"Subagent {name!r}: 'async' must be a boolean, "
                 f"got {type(async_val).__name__}: {async_val!r}"
             )
+
+        if "tools" in spec:
+            resolved = []
+            for t in spec["tools"]:
+                if t in tool_registry:
+                    resolved.append(tool_registry[t])
+                elif async_val:
+                    # Async sub-agents are re-resolved against the deployed
+                    # graph's own tool registry (see subagents/_factory.py) —
+                    # the in-process registry is intentionally minimal for
+                    # them. A missing tool here is expected, not degraded.
+                    logger.debug(
+                        "Subagent %r: tool %r not in the in-process registry; "
+                        "resolved by the async graph",
+                        name,
+                        t,
+                    )
+                else:
+                    logger.warning(
+                        "Subagent %r: tool %r not in registry, skipping", name, t
+                    )
+            subagent["tools"] = resolved
+
         subagent["_async"] = async_val
 
         return subagent

--- a/tests/test_load_subagents.py
+++ b/tests/test_load_subagents.py
@@ -166,13 +166,15 @@ def test_missing_tool_on_sync_subagent_logs_warning(tmp_path, caplog):
     assert any("nonexistent_tool" in r.getMessage() for r in warnings)
 
 
-def test_missing_tool_on_async_subagent_logs_debug(tmp_path, caplog):
-    """Async sub-agents with a tool missing from the in-process registry log at DEBUG.
+def test_missing_tool_on_async_subagent_logs_debug_when_swap_pending(tmp_path, caplog):
+    """Sync in-process callers pass ``async_swap_pending=True`` — a tool
+    missing for an ``async: true`` spec logs at DEBUG because the async
+    graph's own registry will re-resolve it downstream
+    (``subagents/_factory.py``).
 
-    Async sub-agents are re-resolved against the deployed graph's own tool
-    registry (``subagents/_factory.py:59``) — the in-process registry is
-    intentionally minimal for them. A missing tool here is expected, not
-    degraded state; logging at WARNING every startup cries wolf.
+    Regression guard for the spurious startup WARNING that pre-fix logs
+    fired on every ``EvoSci`` startup even though the tool was wired at
+    runtime by the deployed graph.
     """
     config_path = _write_yaml(
         tmp_path,
@@ -186,13 +188,51 @@ def test_missing_tool_on_async_subagent_logs_debug(tmp_path, caplog):
         """,
     )
     with caplog.at_level("DEBUG", logger="EvoScientist.utils"):
-        subs = load_subagents(config_path, tool_registry={})
+        subs = load_subagents(config_path, tool_registry={}, async_swap_pending=True)
     assert subs[0]["_async"] is True
     assert subs[0]["tools"] == []
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
     assert not any("nonexistent_tool" in r.getMessage() for r in warnings)
     debugs = [r for r in caplog.records if r.levelname == "DEBUG"]
     assert any(
+        "nonexistent_tool" in r.getMessage() and "async graph" in r.getMessage()
+        for r in debugs
+    )
+
+
+def test_missing_tool_on_async_subagent_logs_warning_at_terminal_registry(
+    tmp_path, caplog
+):
+    """When ``async_swap_pending`` is False (the default), the caller IS the
+    terminal registry — the factory boundary
+    (``subagents/_factory.build_async_subagent_graph``). A tool missing for
+    an ``async: true`` spec is a genuine typo that won't be resolved anywhere
+    downstream, so log at WARNING.
+
+    Without this guard, an earlier version of the fix (unconditional DEBUG for
+    every async spec) silently hid factory-boundary typos. Reviewer flagged
+    this as the last remaining gap.
+    """
+    config_path = _write_yaml(
+        tmp_path,
+        "scheduler.yaml",
+        """
+        scheduler:
+          description: Fires on cron
+          system_prompt: ""
+          tools: [nonexistent_tool]
+          async: true
+        """,
+    )
+    with caplog.at_level("DEBUG", logger="EvoScientist.utils"):
+        # Default: async_swap_pending=False → factory-boundary semantics.
+        subs = load_subagents(config_path, tool_registry={})
+    assert subs[0]["_async"] is True
+    assert subs[0]["tools"] == []
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("nonexistent_tool" in r.getMessage() for r in warnings)
+    debugs = [r for r in caplog.records if r.levelname == "DEBUG"]
+    assert not any(
         "nonexistent_tool" in r.getMessage() and "async graph" in r.getMessage()
         for r in debugs
     )

--- a/tests/test_load_subagents.py
+++ b/tests/test_load_subagents.py
@@ -139,3 +139,60 @@ def test_non_dict_spec_error_includes_filename_and_name(tmp_path):
     )
     with pytest.raises(ValueError, match=r"weird\.yaml.*weird-agent"):
         load_subagents(config_path, tool_registry={})
+
+
+def test_missing_tool_on_sync_subagent_logs_warning(tmp_path, caplog):
+    """Sync sub-agents with a tool missing from the registry log at WARNING.
+
+    Sync sub-agents run in-process under the main agent and rely on the
+    in-process registry to wire every tool they declare. A missing tool
+    IS a genuine degradation — surfaces it as a warning.
+    """
+    config_path = _write_yaml(
+        tmp_path,
+        "planner.yaml",
+        """
+        planner-agent:
+          description: Plans experiments
+          system_prompt: ""
+          tools: [nonexistent_tool]
+        """,
+    )
+    with caplog.at_level("DEBUG", logger="EvoScientist.utils"):
+        subs = load_subagents(config_path, tool_registry={})
+    assert subs[0]["_async"] is False
+    assert subs[0]["tools"] == []
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("nonexistent_tool" in r.getMessage() for r in warnings)
+
+
+def test_missing_tool_on_async_subagent_logs_debug(tmp_path, caplog):
+    """Async sub-agents with a tool missing from the in-process registry log at DEBUG.
+
+    Async sub-agents are re-resolved against the deployed graph's own tool
+    registry (``subagents/_factory.py:59``) — the in-process registry is
+    intentionally minimal for them. A missing tool here is expected, not
+    degraded state; logging at WARNING every startup cries wolf.
+    """
+    config_path = _write_yaml(
+        tmp_path,
+        "scheduler.yaml",
+        """
+        scheduler:
+          description: Fires on cron
+          system_prompt: ""
+          tools: [nonexistent_tool]
+          async: true
+        """,
+    )
+    with caplog.at_level("DEBUG", logger="EvoScientist.utils"):
+        subs = load_subagents(config_path, tool_registry={})
+    assert subs[0]["_async"] is True
+    assert subs[0]["tools"] == []
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert not any("nonexistent_tool" in r.getMessage() for r in warnings)
+    debugs = [r for r in caplog.records if r.levelname == "DEBUG"]
+    assert any(
+        "nonexistent_tool" in r.getMessage() and "async graph" in r.getMessage()
+        for r in debugs
+    )


### PR DESCRIPTION
## Summary

`load_subagents` unconditionally logged `Subagent 'scheduler': tool 'skill_manager' not in registry, skipping` at WARNING on every EvoSci startup, even though the tool IS wired at runtime. The warning was a load-order artefact between two functions that don't know about each other; it doesn't reflect degraded state for `async: true` sub-agents. This PR splits the log level based on the sub-agent's async flag so the warning only fires when it actually means something.

Extracted from PR #352 review discussion (see @X-iZhang's comment on the tool_registry boundary).

## What's actually happening

1. `EvoScientist._build_base_kwargs` calls `load_subagents` with the sync in-process `tool_registry`, which intentionally excludes `skill_manager` (skill library management is a main-agent boundary - sync sub-agents inherit skill *usage* via `skills: ["/skills/"]` but not library management).
2. `scheduler.yaml` declares `skill_manager` in its `tools:` list, so `load_subagents._build_one` logs the WARNING and drops the tool from the resolved list.
3. Later, `_maybe_swap_async_subagents` sees `_async: true` on the scheduler spec, replaces it with an `AsyncSubAgent(graph_id="scheduler", url=...)` proxy pointing at the langgraph-dev subprocess.
4. The deployed scheduler graph is built by `subagents/_factory.py` against ITS OWN tool registry, which does contain `skill_manager` (`_factory.py:59`). At runtime the tool IS available.

So for any `async: true` sub-agent whose YAML declares a tool the sync registry doesn't carry, the WARNING is spurious - the async graph re-resolves it. For a genuine sync sub-agent missing a tool, the WARNING is accurate and worth keeping.

## Change

`EvoScientist/utils.py::load_subagents._build_one`: compute the async flag before the tools-resolution loop, then log missing tools at DEBUG when the sub-agent is async (with a message that names where the tool WILL be resolved), and keep the WARNING for sync sub-agents.

```python
elif async_val:
    logger.debug(
        "Subagent %r: tool %r not in the in-process registry; "
        "resolved by the async graph", name, t,
    )
else:
    logger.warning(
        "Subagent %r: tool %r not in registry, skipping", name, t,
    )
```

No behavior change beyond log level - the tool is still dropped from the in-process resolved list in both cases (the async graph brings its own).

## Genuine degraded window

`_maybe_swap_async_subagents` falls back to the in-process spec (no async swap) in two cases: `enable_async_subagents=False`, and langgraph dev unreachable at startup (see `EvoScientist.py:432` - it logs its own WARNING for this). In both cases the async sub-agent runs sync in-process without the tool it wanted. This PR does NOT change that behavior - the fallback path already logs its own warning at the swap boundary, which is where the degradation actually happens. Silencing the load-time warning removes the noise without hiding the real signal.

## Tests

`tests/test_load_subagents.py` gains two tests:

- `test_missing_tool_on_sync_subagent_logs_warning` - sync spec missing a tool -> WARNING in caplog, tool dropped.
- `test_missing_tool_on_async_subagent_logs_debug` - async spec missing a tool -> DEBUG in caplog (no WARNING), tool still dropped.

Both use `caplog.at_level("DEBUG", logger="EvoScientist.utils")` and assert on log records directly.

9 tests in the module, all passing.

## Verification

- `uv run pytest tests/test_load_subagents.py -q` - 9 pass.
- Manual: fresh `EvoSci` startup no longer emits the spurious warning; a genuine typo in a sync YAML's `tools:` list still surfaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing tools during sub-agent loading for async setups.
  * Async sub-agents can now defer tool resolution to the deployed async graph without extra warnings; missing tools are logged at debug level when swap-pending is enabled.
  * Sync sub-agents continue to warn and skip unavailable tools as before.
* **Tests**
  * Added regression tests validating warning vs debug logging for missing tools across sync and async scenarios (including the default terminal-boundary behavior).
* **Internal Updates**
  * Updated sub-agent spec construction to enable the async swap-pending behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->