### PR TITLE
fix(tool_selector): degrade to all tools on mandatory-thinking forced tool_choice 400

### DIFF
--- a/EvoScientist/middleware/tool_selector.py
+++ b/EvoScientist/middleware/tool_selector.py
@@ -114,6 +114,22 @@ def _available_always_include(
     return sorted(candidates & available_names)
 
 
+def _is_thinking_tool_choice_error(exc: BaseException) -> bool:
+    """True for the deterministic "forced tool_choice vs thinking" HTTP 400.
+
+    Endpoints with mandatory server-side thinking (kimi-coding's kimi-k2.6,
+    Moonshot's kimi-k3) reject a forced ``tool_choice`` with
+    "tool_choice 'specified' is incompatible with thinking enabled" — and
+    ``disable_thinking`` cannot help because their thinking cannot be turned
+    off client-side. This is a permanent shape/config failure, not a
+    transient provider error, so the selector should degrade to "use all
+    tools" instead of surfacing it (which kills every run of any agent whose
+    tool count exceeds the selection threshold).
+    """
+    msg = str(exc).lower()
+    return "tool_choice" in msg and "thinking" in msg
+
+
 class _ConditionalToolSelectorMiddleware(AgentMiddleware):
     """Wraps LLMToolSelectorMiddleware with a tool-count threshold.
 
@@ -201,6 +217,15 @@ class _ConditionalToolSelectorMiddleware(AgentMiddleware):
             from .error_normalization import _is_provider_error
 
             if isinstance(exc, ProviderStreamError) or _is_provider_error(exc):
+                if _is_thinking_tool_choice_error(exc):
+                    # Mandatory-thinking endpoint can never accept the forced
+                    # tool_choice — degrade to all tools (see helper docstring).
+                    logger.warning(
+                        "Tool selector: provider rejects forced tool_choice "
+                        "with thinking enabled; using all tools"
+                    )
+                    _end_selection()
+                    return handler(request)
                 # Auth / quota / connection failures on the selector's
                 # own model. Falling back to "use all tools" would hit
                 # the same provider anyway (same client, likely same
@@ -256,6 +281,15 @@ class _ConditionalToolSelectorMiddleware(AgentMiddleware):
             from .error_normalization import _is_provider_error
 
             if isinstance(exc, ProviderStreamError) or _is_provider_error(exc):
+                if _is_thinking_tool_choice_error(exc):
+                    # Mandatory-thinking endpoint can never accept the forced
+                    # tool_choice — degrade to all tools (see helper docstring).
+                    logger.warning(
+                        "Tool selector: provider rejects forced tool_choice "
+                        "with thinking enabled; using all tools"
+                    )
+                    _end_selection()
+                    return await handler(request)
                 # See sync path — surface provider errors, degrade only
                 # on shape / config failures.
                 raise


### PR DESCRIPTION
## Problem

When an agent's tool count exceeds `DEFAULT_TOOL_THRESHOLD` (26) — e.g. the `scheduler` graph once MCP servers are attached — `LLMToolSelectorMiddleware` activates and performs its tool-selection call via `with_structured_output`, which sends a forced `tool_choice`.

Endpoints with **mandatory server-side thinking** (kimi-coding's `kimi-k2.6`, Moonshot's `kimi-k3`) always reject a forced `tool_choice`:

```
Error code: 400 - {'error': {'type': 'invalid_request_error',
'message': "tool_choice 'specified' is incompatible with thinking enabled"}}
```

`disable_thinking()` cannot help here because thinking on these endpoints cannot be turned off client-side.

The conditional wrapper's exception handler classifies this 400 as a provider error (`ProviderStreamError`) and **re-raises it** — on the rationale that falling back would hit the same provider anyway. But this error is not transient: it fails deterministically on every call, so **every run of any agent with >26 tools dies immediately** when using such a model.

## Fix

Add `_is_thinking_tool_choice_error()` to recognize this specific deterministic shape/config failure, and degrade to "use all tools" (the existing behavior for structured-output shape failures) on both the sync (`wrap_model_call`) and async (`awrap_model_call`) paths, with a WARNING log so the degradation is visible.

Tool selection is a latency/cost optimization; failing open to the full tool list is always safe, whereas surfacing this particular error kills the run outright.

## Reproduction

1. Configure EvoScientist with a mandatory-thinking model (e.g. `provider: kimi-coding`, `model: kimi-k2.6`).
2. Attach enough MCP servers to push any graph above 26 tools.
3. Run that agent (in our case: a scheduled run on the `scheduler` graph).
4. Every run fails in <1s with the 400 above; no agent turn ever executes.

## Scope

- Only the "forced tool_choice vs mandatory thinking" 400 is downgraded; genuine auth/quota/connectivity provider errors are still surfaced as before.
- 34 lines added, no behavior change for providers that accept forced `tool_choice`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with providers that reject forced tool selection when server-side thinking is enabled.
  * Automatically falls back to running with all available tools instead of surfacing the provider error.
  * Applied the fallback consistently to both synchronous and asynchronous requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->