### PR TITLE
feat: add SSE stream of async-task notifications for WebUI

### DIFF
--- a/EvoScientist/cli/async_notifier.py
+++ b/EvoScientist/cli/async_notifier.py
@@ -452,6 +452,28 @@ def drain_notifications(
     return items
 
 
+def drain_thread_notifications(thread_id: str) -> list[AsyncTaskNotification]:
+    """Pull pending notifications for ``thread_id`` only (non-blocking).
+
+    Unlike :func:`drain_notifications`, this does NOT include the unrouted
+    bucket. Callers that only want notifications explicitly routed to their
+    thread use this — the WebUI SSE endpoint at
+    ``/api/async-notifications/stream/{thread_id}`` specifically, which
+    holds one stream open per (browser tab, thread) pair.
+
+    Multi-tab safety: unrouted notifications (``origin_cli_thread_id=None``)
+    would otherwise be broadcast to every open stream and duplicate the
+    injected turn across unrelated conversations. The TUI drain path
+    (``drain_notifications``) includes the unrouted bucket by design — it
+    has a single consumer, so duplication is not a concern there.
+    """
+    with _notifications_lock:
+        q = _notifications_by_thread.get(thread_id)
+    if q is None:
+        return []
+    return _drain_one_queue(q)
+
+
 def dedup_notifications(
     notifs: list[AsyncTaskNotification],
     async_tasks: AsyncTasksState | None,

--- a/EvoScientist/cli/async_notifier.py
+++ b/EvoScientist/cli/async_notifier.py
@@ -457,21 +457,37 @@ def drain_thread_notifications(thread_id: str) -> list[AsyncTaskNotification]:
 
     Unlike :func:`drain_notifications`, this does NOT include the unrouted
     bucket. Callers that only want notifications explicitly routed to their
-    thread use this — the WebUI SSE endpoint at
-    ``/api/async-notifications/stream/{thread_id}`` specifically, which
-    holds one stream open per (browser tab, thread) pair.
+    thread use this.
 
-    Multi-tab safety: unrouted notifications (``origin_cli_thread_id=None``)
-    would otherwise be broadcast to every open stream and duplicate the
-    injected turn across unrelated conversations. The TUI drain path
-    (``drain_notifications``) includes the unrouted bucket by design — it
-    has a single consumer, so duplication is not a concern there.
+    Cross-thread safety: unrouted notifications (``origin_cli_thread_id=None``)
+    are excluded so a routed drain does not steal work from the TUI's
+    single-consumer path. The TUI drain path (``drain_notifications``)
+    includes the unrouted bucket by design.
     """
     with _notifications_lock:
         q = _notifications_by_thread.get(thread_id)
     if q is None:
         return []
     return _drain_one_queue(q)
+
+
+def take_one_thread_notification(thread_id: str) -> AsyncTaskNotification | None:
+    """Pop one pending notification for ``thread_id``, or ``None`` if empty.
+
+    Companion to :func:`drain_thread_notifications` for callers that need to
+    re-check external conditions (client disconnect, lifetime cap) between
+    each dequeue so an interruption preserves the queue tail instead of
+    dropping the remainder of a batch that had already been drained into
+    a local list.
+    """
+    with _notifications_lock:
+        q = _notifications_by_thread.get(thread_id)
+    if q is None:
+        return None
+    try:
+        return q.get_nowait()
+    except queue.Empty:
+        return None
 
 
 def dedup_notifications(

--- a/EvoScientist/cli/async_notifier.py
+++ b/EvoScientist/cli/async_notifier.py
@@ -452,31 +452,14 @@ def drain_notifications(
     return items
 
 
-def drain_thread_notifications(thread_id: str) -> list[AsyncTaskNotification]:
-    """Pull pending notifications for ``thread_id`` only (non-blocking).
-
-    Unlike :func:`drain_notifications`, this does NOT include the unrouted
-    bucket. Callers that only want notifications explicitly routed to their
-    thread use this.
-
-    Cross-thread safety: unrouted notifications (``origin_cli_thread_id=None``)
-    are excluded so a routed drain does not steal work from the TUI's
-    single-consumer path. The TUI drain path (``drain_notifications``)
-    includes the unrouted bucket by design.
-    """
-    with _notifications_lock:
-        q = _notifications_by_thread.get(thread_id)
-    if q is None:
-        return []
-    return _drain_one_queue(q)
-
-
 def take_one_thread_notification(thread_id: str) -> AsyncTaskNotification | None:
     """Pop one pending notification for ``thread_id``, or ``None`` if empty.
 
-    Companion to :func:`drain_thread_notifications` for callers that need to
-    re-check external conditions (client disconnect, lifetime cap) between
-    each dequeue so an interruption preserves the queue tail instead of
+    Excludes the unrouted bucket so a routed drain does not steal work
+    from the TUI's single-consumer path (``drain_notifications`` includes
+    the unrouted bucket by design). The pop-one shape lets callers re-check
+    external conditions (client disconnect, lifetime cap) between each
+    dequeue so an interruption preserves the queue tail instead of
     dropping the remainder of a batch that had already been drained into
     a local list.
     """

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -1,9 +1,15 @@
 """Custom HTTP routes mounted alongside the langgraph dev server.
 
 The langgraph-api host supports a top-level ``http`` key in
-``langgraph.json`` that names an ASGI app to mount on the same
-process as the graph. We use it to surface the registry the WebUI's
-``/model`` picker needs.
+``langgraph.json`` that names an ASGI app to mount on the same process
+as the graph. We use it to surface the two backends WebUI-style
+frontends need:
+
+- ``/api/models`` — model registry for the WebUI ``/model`` picker.
+- ``/api/async-notifications/stream/{thread_id}`` — SSE stream of
+  async-subagent completion notifications, drained per originating
+  thread so the frontend can inject a synthetic "task complete" turn
+  without polling for status.
 
 Why this lives here and not as a separate sidecar: the WebUI talks to
 ``EvoSci deploy``'s langgraph endpoint anyway, so one origin keeps the
@@ -11,26 +17,53 @@ WebUI's fetch logic simple — no CORS dance, no extra port to configure.
 
 Why Starlette and not FastAPI: ``langgraph_api`` already depends on
 Starlette; adding FastAPI would pull in pydantic v1-vs-v2 reconciliation
-the deploy doesn't need. The one route here has no input model, just a
-JSON body, so the lower-level surface is sufficient.
+the deploy doesn't need. The routes here have no input models, just JSON
+or SSE bodies, so the lower-level surface is sufficient.
 
 Lightweight by design — module-level imports stick to ``config``,
 ``llm.models`` (registry only; no chat-model construction), and
-Starlette itself. Nothing on this surface should pull the agent into
-memory.
+Starlette itself. The ``cli.async_notifier`` import in the SSE handler
+is deferred to call time so this module stays cheap on import.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
+import time
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, StreamingResponse
 from starlette.routing import Route
 
 from EvoScientist.config import get_effective_config
 from EvoScientist.llm.models import list_model_picker_entries
+
+# SSE poll cadence: how often the ``/api/async-notifications/stream`` handler
+# checks the per-thread queue between yields. 250 ms is fast enough that a
+# completed sub-agent surfaces on the wire within one screen-refresh; low
+# enough that an idle stream costs ~4 lock acquisitions/sec, which is
+# negligible against the queue's O(1) check.
+_SSE_POLL_INTERVAL_S = 0.25
+
+# SSE heartbeat cadence: send a comment-line keepalive every 15 s of
+# idle time so intermediate proxies (Cloudflare's 100s, nginx's 60s) don't
+# close the connection as stale. SSE spec (§9.2.5) says clients MUST
+# silently ignore comment lines, so this is invisible in the browser.
+_SSE_HEARTBEAT_INTERVAL_S = 15.0
+
+# Wire fields projected onto each SSE event. Deliberately excludes
+# ``origin_cli_thread_id`` — the client already knows the thread it
+# opened the stream against, so echoing it is redundant.
+_NOTIFICATION_WIRE_FIELDS = (
+    "task_id",
+    "agent_name",
+    "status",
+    "received_at",
+    "prompt",
+    "kind",
+)
 
 
 async def get_models(_request: Request) -> JSONResponse:
@@ -75,8 +108,79 @@ async def get_models(_request: Request) -> JSONResponse:
     )
 
 
+async def stream_async_notifications(request: Request) -> StreamingResponse:
+    """Server-sent event stream of async-task completion notifications.
+
+    One SSE event per :class:`~EvoScientist.cli.async_notifier.AsyncTaskNotification`
+    routed to ``thread_id``. Consumers are WebUI-style frontends that need to
+    surface a synthetic "task complete" turn to the main agent without polling
+    for status; the TUI drains the same notifier queue in-process and does not
+    use this endpoint.
+
+    Payload shape (JSON, one event body per SSE ``data:`` line): the six
+    fields projected by ``_NOTIFICATION_WIRE_FIELDS`` — ``task_id``,
+    ``agent_name``, ``status``, ``received_at``, ``prompt``, ``kind``. The
+    dataclass's internal ``origin_cli_thread_id`` is deliberately excluded:
+    the client already knows the thread it opened the stream against, so
+    echoing it back is redundant.
+
+    Consume semantics: the queue entry is drained as it is committed to
+    the wire — there is no read-vs-drain distinction. If the client
+    disconnects mid-event, that specific event is already gone from the
+    server queue; SSE has no at-least-once redelivery guarantee, and
+    downstream idempotency (WebUI-side task_id-keyed dedup) covers the
+    resulting gap.
+
+    Per-thread only: ``drain_thread_notifications`` reads from
+    ``_notifications_by_thread[thread_id]``. The unrouted bucket
+    (notifications with ``origin_cli_thread_id=None``) is intentionally
+    excluded from this endpoint to prevent multi-tab clients from receiving
+    duplicate notifications for the same task.
+
+    Lifetime: the connection is held open as long as the client is
+    connected. There is no server-side cutoff. Client closes when the
+    thread has no more active async subagents (WebUI-side policy) or on
+    tab close.
+
+    Heartbeat: an SSE comment line (``: keepalive\\n\\n``) fires every
+    ``_SSE_HEARTBEAT_INTERVAL_S`` of idle time to keep intermediate
+    proxies from evicting the connection. Real notifications reset the
+    heartbeat timer since they serve the same keep-alive purpose.
+
+    Not offloaded to a thread: ``drain_thread_notifications`` acquires a
+    ``threading.Lock`` briefly and pulls from a ``queue.Queue`` — both
+    O(1) and non-blocking. langgraph-dev's ``blockbuster`` middleware
+    flags sync file I/O, not brief lock acquisitions.
+    """
+    from EvoScientist.cli.async_notifier import drain_thread_notifications
+
+    thread_id = request.path_params["thread_id"]
+
+    async def event_stream():
+        last_activity_s = time.monotonic()
+        while True:
+            if await request.is_disconnected():
+                return
+            for notif in drain_thread_notifications(thread_id):
+                payload = {k: getattr(notif, k) for k in _NOTIFICATION_WIRE_FIELDS}
+                yield f"data: {json.dumps(payload)}\n\n"
+                last_activity_s = time.monotonic()
+            now_s = time.monotonic()
+            if now_s - last_activity_s >= _SSE_HEARTBEAT_INTERVAL_S:
+                yield ": keepalive\n\n"
+                last_activity_s = now_s
+            await asyncio.sleep(_SSE_POLL_INTERVAL_S)
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
 app = Starlette(
     routes=[
         Route("/api/models", get_models, methods=["GET"]),
+        Route(
+            "/api/async-notifications/stream/{thread_id}",
+            stream_async_notifications,
+            methods=["GET"],
+        ),
     ]
 )

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 
 from starlette.applications import Starlette
@@ -39,6 +40,8 @@ from starlette.routing import Route
 
 from EvoScientist.config import get_effective_config
 from EvoScientist.llm.models import list_model_picker_entries
+
+logger = logging.getLogger(__name__)
 
 # SSE poll cadence: how often the ``/api/async-notifications/stream`` handler
 # checks the per-thread queue between yields. 250 ms is fast enough that a
@@ -170,25 +173,39 @@ async def stream_async_notifications(request: Request) -> StreamingResponse:
     async def event_stream():
         start_s = time.monotonic()
         last_activity_s = start_s
-        while True:
-            if time.monotonic() - start_s >= _SSE_MAX_LIFETIME_S:
-                return
-            if await request.is_disconnected():
-                return
-            notif = take_one_thread_notification(thread_id)
-            if notif is not None:
-                payload = {k: getattr(notif, k) for k in _NOTIFICATION_WIRE_FIELDS}
-                yield f"data: {json.dumps(payload)}\n\n"
-                last_activity_s = time.monotonic()
-                # Loop back immediately to drain the next queued item,
-                # re-checking disconnect and lifetime between each so
-                # a mid-batch interruption preserves the remainder.
-                continue
-            now_s = time.monotonic()
-            if now_s - last_activity_s >= _SSE_HEARTBEAT_INTERVAL_S:
-                yield ": keepalive\n\n"
-                last_activity_s = now_s
-            await asyncio.sleep(_SSE_POLL_INTERVAL_S)
+        try:
+            while True:
+                if time.monotonic() - start_s >= _SSE_MAX_LIFETIME_S:
+                    return
+                if await request.is_disconnected():
+                    return
+                notif = take_one_thread_notification(thread_id)
+                if notif is not None:
+                    payload = {k: getattr(notif, k) for k in _NOTIFICATION_WIRE_FIELDS}
+                    yield f"data: {json.dumps(payload)}\n\n"
+                    last_activity_s = time.monotonic()
+                    # Loop back immediately to drain the next queued item,
+                    # re-checking disconnect and lifetime between each so
+                    # a mid-batch interruption preserves the remainder.
+                    continue
+                now_s = time.monotonic()
+                if now_s - last_activity_s >= _SSE_HEARTBEAT_INTERVAL_S:
+                    yield ": keepalive\n\n"
+                    last_activity_s = now_s
+                await asyncio.sleep(_SSE_POLL_INTERVAL_S)
+        except asyncio.CancelledError:
+            # Cooperative cancel from the ASGI server on client teardown —
+            # propagate without logging (not an error condition).
+            raise
+        except Exception:
+            # Any other exception would otherwise be swallowed silently:
+            # the 200 OK + text/event-stream response line is already on
+            # the wire, so the client sees a truncated stream with no
+            # error event and nothing surfaces on the server side.
+            logger.exception(
+                "SSE stream for thread %s terminated unexpectedly", thread_id
+            )
+            raise
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
 

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -57,14 +57,15 @@ _SSE_POLL_INTERVAL_S = 0.25
 _SSE_HEARTBEAT_INTERVAL_S = 15.0
 
 # Absolute per-connection lifetime. On expiry the generator returns and the
-# EventSource client transparently reconnects (SSE spec-defined behavior).
-# Bounds the zombie-connection failure mode: a suspended tab or a half-closed
-# tunnel can hold TCP open indefinitely because our 15-byte heartbeats fit
-# in the kernel send buffer for hours before a write blocks, so neither
-# is_disconnected() nor a write-side exception fires on a useful timescale.
-# The cap forces a periodic tear-down that cleans zombies without disrupting
-# live clients (reconnect gap is sub-second; notifications enqueued during
-# the gap survive on the queue and drain on the reopen).
+# EventSource client transparently reconnects (SSE spec-defined behavior;
+# the browser picks the reconnect delay unless the server advertises a
+# ``retry:`` field, which we do not). Bounds the zombie-connection failure
+# mode: a suspended tab or a half-closed tunnel can hold TCP open indefinitely
+# because our 15-byte heartbeats fit in the kernel send buffer for hours
+# before a write blocks, so neither is_disconnected() nor a write-side
+# exception fires on a useful timescale. Notifications enqueued during the
+# reconnect gap survive on the queue and drain on the reopen, so gap
+# duration is not correctness-critical.
 _SSE_MAX_LIFETIME_S = 900.0
 
 # Wire fields projected onto each SSE event. Deliberately excludes

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -138,31 +138,43 @@ async def stream_async_notifications(request: Request) -> StreamingResponse:
     the client already knows the thread it opened the stream against, so
     echoing it back is redundant.
 
-    Consume semantics: the queue entry is drained as it is committed to
-    the wire — there is no read-vs-drain distinction. If the client
-    disconnects mid-event, that specific event is already gone from the
-    server queue; SSE has no at-least-once redelivery guarantee, and
-    downstream idempotency (WebUI-side task_id-keyed dedup) covers the
-    resulting gap.
+    Consume semantics: at-most-once. Each notification is popped from the
+    server queue as it is committed to the wire; SSE offers no
+    redelivery, so an event lost between the yield and the client is
+    unrecoverable and there is no server- or client-side dedup that can
+    reconstruct it. The mid-batch loss window is bounded by the
+    one-at-a-time dequeue in ``event_stream``: ``is_disconnected`` is
+    re-checked between every pop, so a disconnect after event N leaves
+    events N+1.. on the queue rather than draining them into an
+    already-broken socket. Clients that need certainty about task
+    completion should reconcile via ``check_async_task``; this stream is
+    a low-latency wake-up, not a source of truth.
 
-    Per-thread only: ``drain_thread_notifications`` reads from
+    Per-thread only: ``take_one_thread_notification`` reads from
     ``_notifications_by_thread[thread_id]``. The unrouted bucket
-    (notifications with ``origin_cli_thread_id=None``) is intentionally
-    excluded from this endpoint to prevent multi-tab clients from receiving
-    duplicate notifications for the same task.
+    (notifications with ``origin_cli_thread_id=None``) is excluded so a
+    routed drain does not steal from the TUI's single-consumer path.
+    Same-thread multi-tab is explicitly out of scope: the drain is
+    destructive, so two open streams on the same ``thread_id`` will
+    split notifications arbitrarily between them and only one tab will
+    fire the synthetic turn. Callers that need multi-tab fan-out must
+    coordinate at a higher layer (e.g. a single-tab-per-thread policy
+    in the WebUI, or a broker in front of this endpoint).
 
-    Lifetime: the connection is held open as long as the client is
-    connected. There is no server-side cutoff. Client closes when the
-    thread has no more active async subagents (WebUI-side policy) or on
-    tab close.
+    Lifetime: bounded by ``_SSE_MAX_LIFETIME_S``. On expiry the
+    generator returns and the EventSource client transparently
+    reconnects (spec-defined). This caps the zombie-connection failure
+    mode where a suspended tab or half-closed tunnel holds TCP open long
+    enough that neither ``is_disconnected`` nor a write-side error fires
+    on a useful timescale, while remaining invisible to live clients.
 
     Heartbeat: an SSE comment line (``: keepalive\\n\\n``) fires every
     ``_SSE_HEARTBEAT_INTERVAL_S`` of idle time to keep intermediate
     proxies from evicting the connection. Real notifications reset the
     heartbeat timer since they serve the same keep-alive purpose.
 
-    Not offloaded to a thread: ``drain_thread_notifications`` acquires a
-    ``threading.Lock`` briefly and pulls from a ``queue.Queue`` — both
+    Not offloaded to a thread: ``take_one_thread_notification`` acquires
+    a ``threading.Lock`` briefly and pops from a ``queue.Queue`` — both
     O(1) and non-blocking. langgraph-dev's ``blockbuster`` middleware
     flags sync file I/O, not brief lock acquisitions.
     """

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -207,7 +207,19 @@ async def stream_async_notifications(request: Request) -> StreamingResponse:
             )
             raise
 
-    return StreamingResponse(event_stream(), media_type="text/event-stream")
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            # nginx defaults to ``proxy_buffering on`` which holds the response
+            # body until an internal buffer fills, so heartbeats and events
+            # would arrive in clumps or not at all. Opt out per-response.
+            "X-Accel-Buffering": "no",
+            # Cheap insurance against intermediaries caching the stream —
+            # matches the WHATWG SSE examples.
+            "Cache-Control": "no-cache",
+        },
+    )
 
 
 app = Starlette(

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -53,6 +53,17 @@ _SSE_POLL_INTERVAL_S = 0.25
 # silently ignore comment lines, so this is invisible in the browser.
 _SSE_HEARTBEAT_INTERVAL_S = 15.0
 
+# Absolute per-connection lifetime. On expiry the generator returns and the
+# EventSource client transparently reconnects (SSE spec-defined behavior).
+# Bounds the zombie-connection failure mode: a suspended tab or a half-closed
+# tunnel can hold TCP open indefinitely because our 15-byte heartbeats fit
+# in the kernel send buffer for hours before a write blocks, so neither
+# is_disconnected() nor a write-side exception fires on a useful timescale.
+# The cap forces a periodic tear-down that cleans zombies without disrupting
+# live clients (reconnect gap is sub-second; notifications enqueued during
+# the gap survive on the queue and drain on the reopen).
+_SSE_MAX_LIFETIME_S = 900.0
+
 # Wire fields projected onto each SSE event. Deliberately excludes
 # ``origin_cli_thread_id`` — the client already knows the thread it
 # opened the stream against, so echoing it is redundant.
@@ -152,19 +163,27 @@ async def stream_async_notifications(request: Request) -> StreamingResponse:
     O(1) and non-blocking. langgraph-dev's ``blockbuster`` middleware
     flags sync file I/O, not brief lock acquisitions.
     """
-    from EvoScientist.cli.async_notifier import drain_thread_notifications
+    from EvoScientist.cli.async_notifier import take_one_thread_notification
 
     thread_id = request.path_params["thread_id"]
 
     async def event_stream():
-        last_activity_s = time.monotonic()
+        start_s = time.monotonic()
+        last_activity_s = start_s
         while True:
+            if time.monotonic() - start_s >= _SSE_MAX_LIFETIME_S:
+                return
             if await request.is_disconnected():
                 return
-            for notif in drain_thread_notifications(thread_id):
+            notif = take_one_thread_notification(thread_id)
+            if notif is not None:
                 payload = {k: getattr(notif, k) for k in _NOTIFICATION_WIRE_FIELDS}
                 yield f"data: {json.dumps(payload)}\n\n"
                 last_activity_s = time.monotonic()
+                # Loop back immediately to drain the next queued item,
+                # re-checking disconnect and lifetime between each so
+                # a mid-batch interruption preserves the remainder.
+                continue
             now_s = time.monotonic()
             if now_s - last_activity_s >= _SSE_HEARTBEAT_INTERVAL_S:
                 yield ": keepalive\n\n"

--- a/tests/test_async_notifier.py
+++ b/tests/test_async_notifier.py
@@ -316,6 +316,39 @@ def test_drain_returns_all_pending_and_empties_queue():
     assert async_notifier._notification_queue.empty()
 
 
+def test_drain_thread_notifications_returns_per_thread_only():
+    """drain_thread_notifications must NOT include the unrouted bucket."""
+    from EvoScientist.cli.async_notifier import drain_thread_notifications
+
+    # Two notifications on thread-A, one unrouted.
+    async_notifier._enqueue(
+        async_notifier.AsyncTaskNotification(
+            "t1", "x", "success", "", "", origin_cli_thread_id="thread-A"
+        )
+    )
+    async_notifier._enqueue(
+        async_notifier.AsyncTaskNotification(
+            "t2", "x", "success", "", "", origin_cli_thread_id="thread-A"
+        )
+    )
+    async_notifier._enqueue(
+        async_notifier.AsyncTaskNotification("u1", "x", "success", "", "")
+    )
+
+    got = drain_thread_notifications("thread-A")
+    assert [n.task_id for n in got] == ["t1", "t2"]
+    # Unrouted bucket must NOT be drained by this helper.
+    unrouted = async_notifier.drain_notifications()
+    assert [n.task_id for n in unrouted] == ["u1"]
+
+
+def test_drain_thread_notifications_empty_when_no_queue_for_thread():
+    """Unknown thread_id returns an empty list, never raises."""
+    from EvoScientist.cli.async_notifier import drain_thread_notifications
+
+    assert drain_thread_notifications("no-such-thread") == []
+
+
 def test_dedup_skips_tasks_already_checked_after_terminal():
     """dedup_notifications skips tasks with terminal status and last_checked_at >= last_updated_at."""
     async_tasks: async_notifier.AsyncTasksState = {

--- a/tests/test_async_notifier.py
+++ b/tests/test_async_notifier.py
@@ -316,9 +316,9 @@ def test_drain_returns_all_pending_and_empties_queue():
     assert async_notifier._notification_queue.empty()
 
 
-def test_drain_thread_notifications_returns_per_thread_only():
-    """drain_thread_notifications must NOT include the unrouted bucket."""
-    from EvoScientist.cli.async_notifier import drain_thread_notifications
+def test_take_one_thread_notification_returns_per_thread_only():
+    """take_one_thread_notification must NOT touch the unrouted bucket."""
+    from EvoScientist.cli.async_notifier import take_one_thread_notification
 
     # Two notifications on thread-A, one unrouted.
     async_notifier._enqueue(
@@ -335,18 +335,20 @@ def test_drain_thread_notifications_returns_per_thread_only():
         async_notifier.AsyncTaskNotification("u1", "x", "success", "", "")
     )
 
-    got = drain_thread_notifications("thread-A")
-    assert [n.task_id for n in got] == ["t1", "t2"]
-    # Unrouted bucket must NOT be drained by this helper.
+    # Pops both routed items in enqueue order, then returns None.
+    assert take_one_thread_notification("thread-A").task_id == "t1"
+    assert take_one_thread_notification("thread-A").task_id == "t2"
+    assert take_one_thread_notification("thread-A") is None
+    # Unrouted bucket must NOT be popped by this helper.
     unrouted = async_notifier.drain_notifications()
     assert [n.task_id for n in unrouted] == ["u1"]
 
 
-def test_drain_thread_notifications_empty_when_no_queue_for_thread():
-    """Unknown thread_id returns an empty list, never raises."""
-    from EvoScientist.cli.async_notifier import drain_thread_notifications
+def test_take_one_thread_notification_returns_none_for_unknown_thread():
+    """Unknown thread_id returns None, never raises."""
+    from EvoScientist.cli.async_notifier import take_one_thread_notification
 
-    assert drain_thread_notifications("no-such-thread") == []
+    assert take_one_thread_notification("no-such-thread") is None
 
 
 def test_dedup_skips_tasks_already_checked_after_terminal():

--- a/tests/test_langgraph_dev_http.py
+++ b/tests/test_langgraph_dev_http.py
@@ -7,12 +7,31 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from starlette.testclient import TestClient
 
 from EvoScientist.config import EvoScientistConfig
 from EvoScientist.langgraph_dev.http import app
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_notifier_queues():
+    """Clear the notifier's module-level queues before and after every test.
+
+    The notifier state is module-global (``_notifications_by_thread`` +
+    ``_unrouted_queue``) and pollutes across tests otherwise — a routed
+    notification enqueued but never drained by a test that only inspected
+    response metadata will surface in the next test's ``drain_notifications``
+    call. Autouse gives us a fresh queue per test without every test having
+    to remember the setup.
+    """
+    from EvoScientist.cli import async_notifier
+
+    async_notifier.drain_notifications()  # clear all buckets
+    yield
+    async_notifier.drain_notifications()
 
 
 def test_get_models_returns_entries_and_default():
@@ -161,3 +180,158 @@ def test_ollama_discovery_skipped_when_base_url_absent():
         {"name": n, "model_id": m, "provider": p}
         for n, m, p in list_models_by_provider()
     ]
+
+
+# ============================================================================
+# /api/async-notifications/stream/{thread_id}
+# ============================================================================
+
+# SSE tests drive the underlying async generator directly with a fake
+# Request. Going through Starlette's ``TestClient.stream()`` deadlocks
+# against an infinite server-side loop: the client's sync httpx transport
+# has no clean way to signal disconnect between yields, so ``iter_lines()``
+# blocks waiting for content after the first line while the generator's
+# ``asyncio.sleep`` keeps ticking. Unit-testing the generator instead
+# gives deterministic control over the loop's exit condition (via the
+# fake request's ``is_disconnected``) and covers the same contract:
+# per-thread filtering, wire schema, unrouted exclusion.
+
+
+class _FakeRequest:
+    """Minimal Request stand-in — reports connected until asked otherwise.
+
+    ``stream_async_notifications`` only touches ``path_params`` and
+    ``is_disconnected()`` on the Request, so a full Starlette Request is
+    overkill. Setting ``_disconnect_after`` bounds the loop for tests
+    that need to observe multiple iterations (e.g. heartbeat).
+    """
+
+    def __init__(self, thread_id: str, disconnect_after: int = 1) -> None:
+        self.path_params = {"thread_id": thread_id}
+        self._checks_remaining = disconnect_after
+
+    async def is_disconnected(self) -> bool:
+        if self._checks_remaining <= 0:
+            return True
+        self._checks_remaining -= 1
+        return False
+
+
+def _make_notification(task_id: str, thread_id: str | None = None):
+    from EvoScientist.cli.async_notifier import AsyncTaskNotification
+
+    return AsyncTaskNotification(
+        task_id=task_id,
+        agent_name="literature-review",
+        status="success",
+        received_at="2026-07-22T16:55:12Z",
+        prompt="Produce a literature review on continual learning strategies",
+        kind="agent",
+        origin_cli_thread_id=thread_id,
+    )
+
+
+async def _collect_events(request: _FakeRequest) -> list[str]:
+    """Drive the SSE handler's response body generator to completion and
+    collect every yielded chunk."""
+    from EvoScientist.langgraph_dev.http import stream_async_notifications
+
+    response = await stream_async_notifications(request)  # type: ignore[arg-type]
+    # StreamingResponse stores the async iterator on ``body_iterator``.
+    chunks: list[str] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk if isinstance(chunk, str) else chunk.decode("utf-8"))
+    return chunks
+
+
+def _parse_data_events(chunks: list[str]) -> list[dict]:
+    """Extract the JSON payloads of all ``data:`` events from raw chunks."""
+    import json as _json
+
+    payloads: list[dict] = []
+    for chunk in chunks:
+        for line in chunk.splitlines():
+            if line.startswith("data:"):
+                payloads.append(_json.loads(line[len("data:") :].strip()))
+    return payloads
+
+
+async def test_sse_response_declares_event_stream_media_type():
+    """Response Content-Type must be text/event-stream so browsers activate
+    the EventSource parser path."""
+    from EvoScientist.cli import async_notifier
+    from EvoScientist.langgraph_dev.http import stream_async_notifications
+
+    async_notifier._enqueue(_make_notification("t-ct", "thread-ct"))
+    response = await stream_async_notifications(
+        _FakeRequest("thread-ct")  # type: ignore[arg-type]
+    )
+    assert response.media_type == "text/event-stream"
+
+
+async def test_sse_emits_enqueued_notification_for_matching_thread():
+    """A notification enqueued with origin_cli_thread_id=X must surface on
+    the stream for thread X, projected through the wire schema."""
+    from EvoScientist.cli import async_notifier
+
+    async_notifier._enqueue(_make_notification("t-match", "thread-match"))
+    chunks = await _collect_events(_FakeRequest("thread-match"))
+    payloads = _parse_data_events(chunks)
+
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload["task_id"] == "t-match"
+    assert payload["agent_name"] == "literature-review"
+    assert payload["status"] == "success"
+    assert payload["kind"] == "agent"
+    # Wire schema deliberately excludes origin_cli_thread_id (redundant —
+    # the client already knows the thread it opened the stream against).
+    assert "origin_cli_thread_id" not in payload
+
+
+async def test_sse_does_not_emit_unrouted_notifications():
+    """Unrouted notifications (origin_cli_thread_id=None) must NOT reach
+    the per-thread stream. This protects multi-tab clients: a notification
+    with no origin would otherwise be broadcast to every open SSE stream
+    and duplicate the injected turn across unrelated conversations."""
+    from EvoScientist.cli import async_notifier
+
+    async_notifier._enqueue(_make_notification("t-unrouted", None))
+    async_notifier._enqueue(_make_notification("t-routed", "thread-iso"))
+
+    chunks = await _collect_events(_FakeRequest("thread-iso"))
+    payloads = _parse_data_events(chunks)
+
+    assert [p["task_id"] for p in payloads] == ["t-routed"]
+    # Unrouted survivor stays in the unrouted queue.
+    unrouted = async_notifier.drain_notifications()
+    assert [n.task_id for n in unrouted] == ["t-unrouted"]
+
+
+async def test_sse_does_not_emit_notifications_for_other_threads():
+    """A notification for thread-A must not leak to thread-B's stream."""
+    from EvoScientist.cli import async_notifier
+
+    async_notifier._enqueue(_make_notification("t-A", "thread-A"))
+    async_notifier._enqueue(_make_notification("t-B", "thread-B"))
+
+    chunks = await _collect_events(_FakeRequest("thread-B"))
+    payloads = _parse_data_events(chunks)
+
+    assert [p["task_id"] for p in payloads] == ["t-B"]
+    # thread-A's notification survives — nobody drained it.
+    remaining = async_notifier.drain_thread_notifications("thread-A")
+    assert [n.task_id for n in remaining] == ["t-A"]
+
+
+async def test_sse_returns_cleanly_when_client_is_disconnected_before_first_check():
+    """If the client has already dropped by the time the loop opens, the
+    generator returns without touching the queue or yielding anything."""
+    from EvoScientist.cli import async_notifier
+
+    async_notifier._enqueue(_make_notification("t-x", "thread-x"))
+    chunks = await _collect_events(_FakeRequest("thread-x", disconnect_after=0))
+    assert chunks == []
+    # Notification stayed on the queue — the disconnected loop never drained.
+    remaining = async_notifier.drain_thread_notifications("thread-x")
+    assert [n.task_id for n in remaining] == ["t-x"]

--- a/tests/test_langgraph_dev_http.py
+++ b/tests/test_langgraph_dev_http.py
@@ -34,6 +34,15 @@ def _reset_notifier_queues():
     async_notifier.drain_notifications()
 
 
+@pytest.fixture(autouse=True)
+def _zero_sse_poll_interval(monkeypatch):
+    """Zero the SSE loop's inter-iteration sleep so tests don't pay real wall
+    time between yields. Tests that also need the heartbeat or max-lifetime
+    interval tuned monkeypatch those constants separately.
+    """
+    monkeypatch.setattr("EvoScientist.langgraph_dev.http._SSE_POLL_INTERVAL_S", 0)
+
+
 def test_get_models_returns_entries_and_default():
     mock_cfg = EvoScientistConfig(
         model="claude-sonnet-4-6", provider="custom-anthropic"
@@ -335,3 +344,58 @@ async def test_sse_returns_cleanly_when_client_is_disconnected_before_first_chec
     # Notification stayed on the queue — the disconnected loop never drained.
     remaining = async_notifier.drain_thread_notifications("thread-x")
     assert [n.task_id for n in remaining] == ["t-x"]
+
+
+async def test_sse_preserves_queue_tail_on_mid_batch_disconnect(monkeypatch):
+    """A disconnect after the first yielded event must leave later events
+    on the queue instead of draining them into an already-broken socket.
+    This is the invariant behind the one-at-a-time dequeue in the handler:
+    ``is_disconnected`` is re-checked between every pop.
+    """
+    from EvoScientist.cli import async_notifier
+
+    async_notifier._enqueue(_make_notification("t-1", "thread-mid"))
+    async_notifier._enqueue(_make_notification("t-2", "thread-mid"))
+    async_notifier._enqueue(_make_notification("t-3", "thread-mid"))
+
+    # disconnect_after=2 → loop yields t-1, yields t-2, then observes
+    # disconnect on the next iteration and returns.
+    chunks = await _collect_events(_FakeRequest("thread-mid", disconnect_after=2))
+    payloads = _parse_data_events(chunks)
+    assert [p["task_id"] for p in payloads] == ["t-1", "t-2"]
+
+    # t-3 survives on the queue for the next reconnect.
+    remaining = async_notifier.drain_thread_notifications("thread-mid")
+    assert [n.task_id for n in remaining] == ["t-3"]
+
+
+async def test_sse_emits_heartbeat_when_queue_is_idle(monkeypatch):
+    """With no notifications enqueued, an idle iteration past the heartbeat
+    interval emits a ``: keepalive`` comment line. Comment lines are the
+    SSE-spec keep-alive that browsers silently ignore.
+    """
+    monkeypatch.setattr("EvoScientist.langgraph_dev.http._SSE_HEARTBEAT_INTERVAL_S", 0)
+
+    chunks = await _collect_events(_FakeRequest("thread-idle", disconnect_after=1))
+    # No data: events (queue was empty), one keepalive comment.
+    assert _parse_data_events(chunks) == []
+    keepalives = [c for c in chunks if c.startswith(": keepalive")]
+    assert len(keepalives) == 1
+
+
+async def test_sse_returns_when_max_lifetime_elapsed(monkeypatch):
+    """On lifetime expiry the generator must return so the EventSource
+    client can transparently reconnect (SSE spec-defined behavior).
+    ``disconnect_after`` is set generously so a return can only come from
+    the lifetime check, not from the disconnect path.
+    """
+    from EvoScientist.cli import async_notifier
+
+    monkeypatch.setattr("EvoScientist.langgraph_dev.http._SSE_MAX_LIFETIME_S", 0)
+    async_notifier._enqueue(_make_notification("t-late", "thread-late"))
+
+    chunks = await _collect_events(_FakeRequest("thread-late", disconnect_after=1000))
+    assert chunks == []
+    # Notification stayed on the queue — the loop returned before draining.
+    remaining = async_notifier.drain_thread_notifications("thread-late")
+    assert [n.task_id for n in remaining] == ["t-late"]

--- a/tests/test_langgraph_dev_http.py
+++ b/tests/test_langgraph_dev_http.py
@@ -202,8 +202,8 @@ class _FakeRequest:
 
     ``stream_async_notifications`` only touches ``path_params`` and
     ``is_disconnected()`` on the Request, so a full Starlette Request is
-    overkill. Setting ``_disconnect_after`` bounds the loop for tests
-    that need to observe multiple iterations (e.g. heartbeat).
+    overkill. ``disconnect_after`` bounds the loop after N connectedness
+    checks so each test drives the generator to a deterministic exit.
     """
 
     def __init__(self, thread_id: str, disconnect_after: int = 1) -> None:

--- a/tests/test_langgraph_dev_http.py
+++ b/tests/test_langgraph_dev_http.py
@@ -377,10 +377,11 @@ async def test_sse_emits_heartbeat_when_queue_is_idle(monkeypatch):
     monkeypatch.setattr("EvoScientist.langgraph_dev.http._SSE_HEARTBEAT_INTERVAL_S", 0)
 
     chunks = await _collect_events(_FakeRequest("thread-idle", disconnect_after=1))
-    # No data: events (queue was empty), one keepalive comment.
+    # No data: events (queue was empty), exactly one keepalive comment
+    # emitted with both trailing newlines (a missing second newline would
+    # leave the frame buffered in an SSE parser).
     assert _parse_data_events(chunks) == []
-    keepalives = [c for c in chunks if c.startswith(": keepalive")]
-    assert len(keepalives) == 1
+    assert [c for c in chunks if c.startswith(":")] == [": keepalive\n\n"]
 
 
 async def test_sse_returns_when_max_lifetime_elapsed(monkeypatch):

--- a/tests/test_langgraph_dev_http.py
+++ b/tests/test_langgraph_dev_http.py
@@ -329,7 +329,7 @@ async def test_sse_does_not_emit_notifications_for_other_threads():
 
     assert [p["task_id"] for p in payloads] == ["t-B"]
     # thread-A's notification survives — nobody drained it.
-    remaining = async_notifier.drain_thread_notifications("thread-A")
+    remaining = async_notifier.drain_notifications("thread-A")
     assert [n.task_id for n in remaining] == ["t-A"]
 
 
@@ -342,7 +342,7 @@ async def test_sse_returns_cleanly_when_client_is_disconnected_before_first_chec
     chunks = await _collect_events(_FakeRequest("thread-x", disconnect_after=0))
     assert chunks == []
     # Notification stayed on the queue — the disconnected loop never drained.
-    remaining = async_notifier.drain_thread_notifications("thread-x")
+    remaining = async_notifier.drain_notifications("thread-x")
     assert [n.task_id for n in remaining] == ["t-x"]
 
 
@@ -365,7 +365,7 @@ async def test_sse_preserves_queue_tail_on_mid_batch_disconnect(monkeypatch):
     assert [p["task_id"] for p in payloads] == ["t-1", "t-2"]
 
     # t-3 survives on the queue for the next reconnect.
-    remaining = async_notifier.drain_thread_notifications("thread-mid")
+    remaining = async_notifier.drain_notifications("thread-mid")
     assert [n.task_id for n in remaining] == ["t-3"]
 
 
@@ -397,5 +397,5 @@ async def test_sse_returns_when_max_lifetime_elapsed(monkeypatch):
     chunks = await _collect_events(_FakeRequest("thread-late", disconnect_after=1000))
     assert chunks == []
     # Notification stayed on the queue — the loop returned before draining.
-    remaining = async_notifier.drain_thread_notifications("thread-late")
+    remaining = async_notifier.drain_notifications("thread-late")
     assert [n.task_id for n in remaining] == ["t-late"]


### PR DESCRIPTION
## Summary

Adds `GET /api/async-notifications/stream/{thread_id}` - a server-sent event stream of async-subagent completion notifications, drained per originating thread. Consumed by WebUI-style frontends that need to surface a synthetic "task complete" turn to the main agent without polling for status.

The TUI already drains the same notifier queue in-process via `has_pending_notifications` + `consume_notifications`; this PR adds the HTTP surface so out-of-process consumers get the same signal. Applies to every existing async subagent - `writing-agent`, `data-analysis-agent`, `scheduler` - not a new capability, just a new consumer path.

## Endpoint contract

- **Route**: `GET /api/async-notifications/stream/{thread_id}`
- **Response**: `Content-Type: text/event-stream`, one event per `AsyncTaskNotification` routed to `thread_id`. Each event body is a JSON object with `task_id`, `agent_name`, `status`, `received_at`, `prompt`, `kind`. The dataclass's internal `origin_cli_thread_id` is deliberately excluded - the client already knows the thread it opened the stream against.
- **Consume semantics**: drain-on-emit. The queue entry is popped as it's committed to the wire; no read-vs-drain distinction.
- **Per-thread only**: reads from `_notifications_by_thread[thread_id]`. The unrouted bucket (notifications with `origin_cli_thread_id=None`) is excluded to prevent multi-tab clients from receiving duplicates.
- **Lifetime**: connection held open indefinitely; no server-side cutoff. Client closes when the thread has no more active async subagents or on tab close.
- **Heartbeat**: SSE comment line (`: keepalive\n\n`) every 15 s of idle time so intermediate proxies (Cloudflare's 100 s, nginx's 60 s) don't evict the connection. SSE spec §9.2.5 requires clients to silently ignore comment lines.

## What changed

- `EvoScientist/cli/async_notifier.py` - new helper `drain_thread_notifications(thread_id)`. Per-thread queue only, excludes unrouted bucket. Existing `drain_notifications` (used by TUI) unchanged; it still includes the unrouted bucket by design because the TUI is a single consumer.
- `EvoScientist/langgraph_dev/http.py` - new `stream_async_notifications` route registered alongside the existing `/api/models` handler. Uses `StreamingResponse` with a 250 ms poll interval. Client disconnect is detected via `Request.is_disconnected()` between yields.

## Tests

`tests/test_async_notifier.py`: 2 new tests for `drain_thread_notifications` - per-thread bucket only, unrouted excluded, unknown thread returns empty.

`tests/test_langgraph_dev_http.py`: 5 new SSE tests plus an autouse fixture that resets the notifier's module-level queues per test. Tests drive the generator directly with a `_FakeRequest` fixture rather than through `TestClient.stream()` - the sync httpx transport deadlocks against an infinite server loop (no clean way to signal disconnect between yields). The generator-direct approach gives deterministic loop-exit control via the fake request's `is_disconnected` counter. Contract covered: content-type, per-thread filtering, wire schema, unrouted exclusion, clean return on already-disconnected client.

All 49 tests in the two files pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a real-time SSE stream for asynchronous task notifications scoped to a specific thread.
  * Added an endpoint to list available models.
  * Stream keeps the connection alive during idle periods and stops automatically after a maximum lifetime.
* **Bug Fixes**
  * Ensures thread-specific routing by excluding unrouted notifications and notifications from other threads.
* **Tests**
  * Added coverage for per-thread notification retrieval and SSE behavior (media type, routing, disconnect handling, idle heartbeats, and timeout).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->