### PR TITLE
fix(middleware): normalize blank tool_call_id before provider request

### DIFF
--- a/EvoScientist/middleware/tool_history_repair.py
+++ b/EvoScientist/middleware/tool_history_repair.py
@@ -33,7 +33,6 @@ tool-call id via a ``warned`` set owned by the middleware instance.
 from __future__ import annotations
 
 import logging
-import uuid
 from collections.abc import Awaitable, Callable, Sequence
 
 from langchain.agents.middleware.types import (
@@ -60,58 +59,54 @@ def _is_blank_tool_call_id(value: object) -> bool:
 
 def _normalize_blank_tool_call_ids(
     messages: Sequence[AnyMessage],
-    warned: set[str] | None = None,
 ) -> list[AnyMessage]:
-    """Replace blank tool_call_ids with fresh unique ids.
+    """Replace blank tool_call_ids with deterministic, positionally-stable ids.
 
-    Pairs each blank-id call (valid or invalid) on an ``AIMessage`` with the
-    next blank-id ``ToolMessage`` *in the same exchange* (FIFO) so existing
-    exchanges stay paired. The FIFO queue is closed at every
-    non-``ToolMessage`` boundary (new ``AIMessage``, ``HumanMessage``,
-    ``SystemMessage``, ...) so a later exchange's blank ``ToolMessage`` can
-    never steal an id from an earlier, already-interrupted exchange -- that
-    would mis-pair it and cause the main loop to drop the real tool result as
-    an orphan.
+    Each blank id is rewritten as ``_repair_{msg_idx}_{kind}{call_idx}`` (kind
+    is ``v`` for valid calls, ``i`` for invalid). The id is therefore stable
+    across model calls -- the middleware re-runs on every request but the
+    message thread is unchanged, so the same blank call gets the same repair
+    id every time. That lets the main loop's existing ``warned``-set dedup
+    suppress the synthesized-result warning on the second and later calls
+    without any pre-add hack, and it keeps the wire payload stable.
 
-    Both ``message.tool_calls`` and ``message.invalid_tool_calls`` are
-    normalized: langchain-openai's serializer puts ``tool_calls +
-    invalid_tool_calls`` on the wire (it does not consult ``additional_kwargs``
-    when either parsed list is non-empty), so a blank id on an invalid call
-    reaches the provider just as readily as one on a valid call. ``pending_slots``
-    is filled valid-first so a real ``ToolMessage`` for a valid blank call
-    never accidentally claims an invalid call's fresh id.
+    Pairs each blank-id call on an ``AIMessage`` with the next blank-id
+    ``ToolMessage`` *in the same exchange* (FIFO) so existing exchanges stay
+    paired. The FIFO queue is closed at every non-``ToolMessage`` boundary
+    (new ``AIMessage``, ``HumanMessage``, ``SystemMessage``, ...) so a later
+    exchange's blank ``ToolMessage`` can never steal an id from an earlier,
+    already-interrupted exchange.
 
-    Orphan blank ``ToolMessage``\\ s (no preceding blank call in their exchange
-    to claim) keep their blank id -- the main repair loop drops them as orphans.
+    Only valid ``tool_calls`` push their fresh ids into ``pending_slots``.
+    ``invalid_tool_calls`` get fresh ids too (langchain-openai's serializer
+    puts ``tool_calls + invalid_tool_calls`` on the wire when either parsed
+    list is non-empty, so a blank id on an invalid call reaches the provider
+    just as readily), but those ids are NOT pushed to ``pending_slots``:
+    invalid calls are never executed by LangGraph, so no real ToolMessage can
+    exist for them, and pushing the slot would let an orphan blank result
+    from some other call mis-pair with the invalid call.
+
+    Orphan blank ``ToolMessage``\\ s (no preceding blank valid call in their
+    exchange to claim) keep their blank id -- the main repair loop drops them
+    as orphans.
 
     The raw ``additional_kwargs["tool_calls"]`` form is dropped on any touched
     message so langchain-openai's serializer rebuilds the wire payload from
     the now-valid parsed form instead of consulting the raw form (which still
     carries the blank id).
-
-    Unmatched fresh ids are added to *warned* at every exchange boundary so the
-    main loop's synthesized interrupted-result for that id stays silent on
-    subsequent model calls -- the fresh ids are non-deterministic across calls,
-    so without this pre-add every model call on a thread with a blank id would
-    re-log the repair.
     """
     pending_slots: list[str] = []
     normalized: list[AnyMessage] = []
     saw_blank = False
 
-    def _close_unclaimed() -> None:
-        if warned is not None:
-            warned.update(pending_slots)
-        pending_slots.clear()
-
-    for message in messages:
+    for msg_idx, message in enumerate(messages):
         if isinstance(message, AIMessage):
-            _close_unclaimed()
+            pending_slots.clear()
             new_tool_calls: list[dict[str, object]] = []
             any_changed = False
-            for call in message.tool_calls:
+            for call_idx, call in enumerate(message.tool_calls):
                 if _is_blank_tool_call_id(call.get("id")):
-                    new_id = f"{_REPAIR_ID_PREFIX}{uuid.uuid4().hex}"
+                    new_id = f"{_REPAIR_ID_PREFIX}{msg_idx}_v{call_idx}"
                     pending_slots.append(new_id)
                     new_tool_calls.append({**call, "id": new_id})
                     any_changed = True
@@ -121,10 +116,11 @@ def _normalize_blank_tool_call_ids(
 
             new_invalid: list[dict[str, object]] = []
             invalid_changed = False
-            for call in getattr(message, "invalid_tool_calls", None) or []:
+            for call_idx, call in enumerate(
+                getattr(message, "invalid_tool_calls", None) or []
+            ):
                 if _is_blank_tool_call_id(call.get("id")):
-                    new_id = f"{_REPAIR_ID_PREFIX}{uuid.uuid4().hex}"
-                    pending_slots.append(new_id)
+                    new_id = f"{_REPAIR_ID_PREFIX}{msg_idx}_i{call_idx}"
                     new_invalid.append({**call, "id": new_id})
                     invalid_changed = True
                     saw_blank = True
@@ -149,10 +145,8 @@ def _normalize_blank_tool_call_ids(
                 message = message.model_copy(update={"tool_call_id": new_id})
                 saw_blank = True
         else:
-            _close_unclaimed()
+            pending_slots.clear()
         normalized.append(message)
-
-    _close_unclaimed()
 
     if saw_blank:
         logger.debug("Normalized blank tool_call_id(s) in message history")
@@ -170,7 +164,7 @@ def repair_tool_history(
     warning to once per unique interrupted/malformed call even though the
     middleware re-runs on every model call.
     """
-    messages = _normalize_blank_tool_call_ids(messages, warned=warned)
+    messages = _normalize_blank_tool_call_ids(messages)
 
     repaired: list[AnyMessage] = []
     pending: dict[str, str | None] = {}

--- a/EvoScientist/middleware/tool_history_repair.py
+++ b/EvoScientist/middleware/tool_history_repair.py
@@ -64,28 +64,49 @@ def _normalize_blank_tool_call_ids(
 ) -> list[AnyMessage]:
     """Replace blank tool_call_ids with fresh unique ids.
 
-    Pairs each blank-id call on an ``AIMessage`` with the next blank-id
-    ``ToolMessage`` in arrival order (FIFO) so existing exchanges stay paired.
-    Orphan blank ``ToolMessage``\\ s (no preceding blank call to claim) keep
-    their blank id -- the main repair loop drops them as orphans.
+    Pairs each blank-id call (valid or invalid) on an ``AIMessage`` with the
+    next blank-id ``ToolMessage`` *in the same exchange* (FIFO) so existing
+    exchanges stay paired. The FIFO queue is closed at every
+    non-``ToolMessage`` boundary (new ``AIMessage``, ``HumanMessage``,
+    ``SystemMessage``, ...) so a later exchange's blank ``ToolMessage`` can
+    never steal an id from an earlier, already-interrupted exchange -- that
+    would mis-pair it and cause the main loop to drop the real tool result as
+    an orphan.
 
-    The raw ``additional_kwargs["tool_calls"]`` form is dropped on any message
-    whose parsed ``tool_calls`` had a blank id, so langchain-openai's
-    serializer falls back to the now-valid parsed form instead of preferring
-    the raw form (which still carries the blank id and would be subset-filtered
-    by the main loop, losing the freshly-normalized entries).
+    Both ``message.tool_calls`` and ``message.invalid_tool_calls`` are
+    normalized: langchain-openai's serializer puts ``tool_calls +
+    invalid_tool_calls`` on the wire (it does not consult ``additional_kwargs``
+    when either parsed list is non-empty), so a blank id on an invalid call
+    reaches the provider just as readily as one on a valid call. ``pending_slots``
+    is filled valid-first so a real ``ToolMessage`` for a valid blank call
+    never accidentally claims an invalid call's fresh id.
 
-    Newly-assigned ids for unmatched blank calls are recorded in *warned* when
-    provided so the main loop doesn't log them again as a separate repair --
-    the fresh ids are non-deterministic across calls, so without this pre-add
-    every model call on a thread with a blank id would re-log the repair.
+    Orphan blank ``ToolMessage``\\ s (no preceding blank call in their exchange
+    to claim) keep their blank id -- the main repair loop drops them as orphans.
+
+    The raw ``additional_kwargs["tool_calls"]`` form is dropped on any touched
+    message so langchain-openai's serializer rebuilds the wire payload from
+    the now-valid parsed form instead of consulting the raw form (which still
+    carries the blank id).
+
+    Unmatched fresh ids are added to *warned* at every exchange boundary so the
+    main loop's synthesized interrupted-result for that id stays silent on
+    subsequent model calls -- the fresh ids are non-deterministic across calls,
+    so without this pre-add every model call on a thread with a blank id would
+    re-log the repair.
     """
     pending_slots: list[str] = []
     normalized: list[AnyMessage] = []
     saw_blank = False
 
+    def _close_unclaimed() -> None:
+        if warned is not None:
+            warned.update(pending_slots)
+        pending_slots.clear()
+
     for message in messages:
         if isinstance(message, AIMessage):
+            _close_unclaimed()
             new_tool_calls: list[dict[str, object]] = []
             any_changed = False
             for call in message.tool_calls:
@@ -99,15 +120,18 @@ def _normalize_blank_tool_call_ids(
                     new_tool_calls.append(dict(call))
 
             new_invalid: list[dict[str, object]] = []
+            invalid_changed = False
             for call in getattr(message, "invalid_tool_calls", None) or []:
                 if _is_blank_tool_call_id(call.get("id")):
                     new_id = f"{_REPAIR_ID_PREFIX}{uuid.uuid4().hex}"
+                    pending_slots.append(new_id)
                     new_invalid.append({**call, "id": new_id})
+                    invalid_changed = True
                     saw_blank = True
                 else:
                     new_invalid.append(dict(call))
 
-            if any_changed:
+            if any_changed or invalid_changed:
                 update: dict[str, object] = {"tool_calls": new_tool_calls}
                 if new_invalid:
                     update["invalid_tool_calls"] = new_invalid
@@ -124,18 +148,14 @@ def _normalize_blank_tool_call_ids(
                 new_id = pending_slots.pop(0)
                 message = message.model_copy(update={"tool_call_id": new_id})
                 saw_blank = True
+        else:
+            _close_unclaimed()
         normalized.append(message)
 
-    if saw_blank and warned is not None:
-        for slot in pending_slots:
-            warned.add(slot)
+    _close_unclaimed()
 
     if saw_blank:
-        logger.debug(
-            "Normalized blank tool_call_id(s) in message history; "
-            "%d unmatched blank call(s) will be synthesized or dropped",
-            len(pending_slots),
-        )
+        logger.debug("Normalized blank tool_call_id(s) in message history")
     return normalized
 
 

--- a/EvoScientist/middleware/tool_history_repair.py
+++ b/EvoScientist/middleware/tool_history_repair.py
@@ -17,6 +17,12 @@ It covers cases that deepagents' ``PatchToolCallsMiddleware`` does not:
 2. Mid-run coverage -- repair runs at the model boundary on every request
    (including malformed / ``invalid_tool_calls``), not only at agent start, so
    interruptions that happen partway through a run are healed too.
+3. Blank ``tool_call_id`` normalization -- some streaming providers (notably
+   Kimi and Zhipu on streamed tool calls) occasionally emit tool calls whose
+   id is an empty string, whitespace, or ``None``. Strict providers reject the
+   next turn with ``invalid tool_call_id`` (HTTP 400, code 3). Each blank id
+   is replaced with a fresh unique id, preserving the AIMessage↔ToolMessage
+   pairing by positional FIFO matching.
 
 Because the middleware only rewrites the request and cannot mutate thread
 state, the repaired synthetic results are recomputed on every model call. To
@@ -27,6 +33,7 @@ tool-call id via a ``warned`` set owned by the middleware instance.
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Awaitable, Callable, Sequence
 
 from langchain.agents.middleware.types import (
@@ -38,6 +45,98 @@ from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
 
 logger = logging.getLogger(__name__)
 _INTERRUPTED_RESULT = "Tool execution was interrupted before completion."
+_REPAIR_ID_PREFIX = "_repair_"
+
+
+def _is_blank_tool_call_id(value: object) -> bool:
+    """True for ids strict providers reject (None / empty / whitespace-only).
+
+    Non-string values (ints, lists, etc.) are left for the main loop's existing
+    strict-type filtering to handle -- only None and blank/whitespace strings
+    count as "blank" here.
+    """
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
+def _normalize_blank_tool_call_ids(
+    messages: Sequence[AnyMessage],
+    warned: set[str] | None = None,
+) -> list[AnyMessage]:
+    """Replace blank tool_call_ids with fresh unique ids.
+
+    Pairs each blank-id call on an ``AIMessage`` with the next blank-id
+    ``ToolMessage`` in arrival order (FIFO) so existing exchanges stay paired.
+    Orphan blank ``ToolMessage``\\ s (no preceding blank call to claim) keep
+    their blank id -- the main repair loop drops them as orphans.
+
+    The raw ``additional_kwargs["tool_calls"]`` form is dropped on any message
+    whose parsed ``tool_calls`` had a blank id, so langchain-openai's
+    serializer falls back to the now-valid parsed form instead of preferring
+    the raw form (which still carries the blank id and would be subset-filtered
+    by the main loop, losing the freshly-normalized entries).
+
+    Newly-assigned ids for unmatched blank calls are recorded in *warned* when
+    provided so the main loop doesn't log them again as a separate repair --
+    the fresh ids are non-deterministic across calls, so without this pre-add
+    every model call on a thread with a blank id would re-log the repair.
+    """
+    pending_slots: list[str] = []
+    normalized: list[AnyMessage] = []
+    saw_blank = False
+
+    for message in messages:
+        if isinstance(message, AIMessage):
+            new_tool_calls: list[dict[str, object]] = []
+            any_changed = False
+            for call in message.tool_calls:
+                if _is_blank_tool_call_id(call.get("id")):
+                    new_id = f"{_REPAIR_ID_PREFIX}{uuid.uuid4().hex}"
+                    pending_slots.append(new_id)
+                    new_tool_calls.append({**call, "id": new_id})
+                    any_changed = True
+                    saw_blank = True
+                else:
+                    new_tool_calls.append(dict(call))
+
+            new_invalid: list[dict[str, object]] = []
+            for call in getattr(message, "invalid_tool_calls", None) or []:
+                if _is_blank_tool_call_id(call.get("id")):
+                    new_id = f"{_REPAIR_ID_PREFIX}{uuid.uuid4().hex}"
+                    new_invalid.append({**call, "id": new_id})
+                    saw_blank = True
+                else:
+                    new_invalid.append(dict(call))
+
+            if any_changed:
+                update: dict[str, object] = {"tool_calls": new_tool_calls}
+                if new_invalid:
+                    update["invalid_tool_calls"] = new_invalid
+                additional_kwargs = message.additional_kwargs
+                if isinstance(additional_kwargs, dict) and isinstance(
+                    additional_kwargs.get("tool_calls"), list
+                ):
+                    new_additional = dict(additional_kwargs)
+                    new_additional.pop("tool_calls", None)
+                    update["additional_kwargs"] = new_additional
+                message = message.model_copy(update=update)
+        elif isinstance(message, ToolMessage):
+            if _is_blank_tool_call_id(message.tool_call_id) and pending_slots:
+                new_id = pending_slots.pop(0)
+                message = message.model_copy(update={"tool_call_id": new_id})
+                saw_blank = True
+        normalized.append(message)
+
+    if saw_blank and warned is not None:
+        for slot in pending_slots:
+            warned.add(slot)
+
+    if saw_blank:
+        logger.debug(
+            "Normalized blank tool_call_id(s) in message history; "
+            "%d unmatched blank call(s) will be synthesized or dropped",
+            len(pending_slots),
+        )
+    return normalized
 
 
 def repair_tool_history(
@@ -51,6 +150,8 @@ def repair_tool_history(
     warning to once per unique interrupted/malformed call even though the
     middleware re-runs on every model call.
     """
+    messages = _normalize_blank_tool_call_ids(messages, warned=warned)
+
     repaired: list[AnyMessage] = []
     pending: dict[str, str | None] = {}
     synthesized: list[str] = []

--- a/tests/test_tool_history_repair_middleware.py
+++ b/tests/test_tool_history_repair_middleware.py
@@ -352,3 +352,196 @@ def test_middleware_warns_once_per_thread(caplog):
         middleware.wrap_model_call(request, handler)
 
     assert len(caplog.records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #345: blank tool_call_id from streaming providers
+# (Kimi, Zhipu, etc.) was passed through to the next model call, where strict
+# providers rejected it as `invalid tool_call_id` (HTTP 400, code 3).
+# ---------------------------------------------------------------------------
+
+
+def _blank_tool_call():
+    return {"id": "", "name": "execute", "args": {"cmd": "ls"}}
+
+
+def test_normalizes_blank_tool_call_id_in_paired_exchange():
+    """AIMessage(blank id) + ToolMessage(blank id) → both get the same fresh id."""
+    messages = [
+        HumanMessage("run task"),
+        AIMessage(content="thinking", tool_calls=[_blank_tool_call()]),
+        ToolMessage(content="result", tool_call_id="", name="execute"),
+        HumanMessage("continue"),
+    ]
+
+    repaired = repair_tool_history(messages)
+
+    ai_msg = next(m for m in repaired if isinstance(m, AIMessage))
+    tool_msgs = [m for m in repaired if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 1, "paired ToolMessage must be preserved"
+
+    new_id = ai_msg.tool_calls[0]["id"]
+    assert isinstance(new_id, str)
+    assert new_id
+    assert new_id != ""
+    assert tool_msgs[0].tool_call_id == new_id, (
+        "ToolMessage must adopt the same fresh id as its AIMessage call"
+    )
+    assert tool_msgs[0].content == "result"
+
+
+def test_normalizes_none_tool_call_id_and_synthesizes_missing_result():
+    """AIMessage(None id) with no matching ToolMessage gets a fresh id plus a
+    synthesized interrupted-result ToolMessage."""
+    messages = [
+        HumanMessage("run task"),
+        AIMessage(
+            content="thinking",
+            tool_calls=[{"id": None, "name": "execute", "args": {}}],
+        ),
+        HumanMessage("continue"),
+    ]
+
+    repaired = repair_tool_history(messages)
+
+    assert [type(message) for message in repaired] == [
+        HumanMessage,
+        AIMessage,
+        ToolMessage,
+        HumanMessage,
+    ]
+    ai_msg = repaired[1]
+    tool_msg = repaired[2]
+    new_id = ai_msg.tool_calls[0]["id"]
+    assert isinstance(new_id, str)
+    assert new_id
+    assert tool_msg.tool_call_id == new_id
+    assert tool_msg.status == "error"
+
+
+def test_normalizes_multiple_blank_ids_positionally():
+    """Multiple blank-id calls in one AIMessage pair FIFO with subsequent
+    blank-id ToolMessages."""
+    messages = [
+        HumanMessage("run"),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "", "name": "first", "args": {}},
+                {"id": "   ", "name": "second", "args": {}},
+            ],
+        ),
+        ToolMessage(content="result-1", tool_call_id="", name="first"),
+        ToolMessage(content="result-2", tool_call_id="   ", name="second"),
+    ]
+
+    repaired = repair_tool_history(messages)
+
+    ai_msg = next(m for m in repaired if isinstance(m, AIMessage))
+    tool_msgs = [m for m in repaired if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 2
+
+    first_id = ai_msg.tool_calls[0]["id"]
+    second_id = ai_msg.tool_calls[1]["id"]
+    assert first_id
+    assert second_id
+    assert first_id != second_id
+    assert tool_msgs[0].tool_call_id == first_id
+    assert tool_msgs[1].tool_call_id == second_id
+    assert [m.content for m in tool_msgs] == ["result-1", "result-2"]
+
+
+def test_drops_orphan_blank_tool_message():
+    """A blank-id ToolMessage with no preceding blank-id AIMessage call is
+    still dropped (existing orphan behavior preserved)."""
+    messages = [
+        HumanMessage("old request"),
+        ToolMessage("late result", tool_call_id=""),
+        HumanMessage("continue"),
+    ]
+
+    repaired = repair_tool_history(messages)
+
+    assert [type(message) for message in repaired] == [HumanMessage, HumanMessage]
+    assert not any(isinstance(m, ToolMessage) for m in repaired)
+
+
+def test_blank_id_repair_yields_provider_serializable_payload():
+    """End-to-end: the repaired history, when serialized by langchain-openai,
+    must not put any blank tool_call_id on the wire."""
+    from langchain_openai.chat_models.base import _convert_message_to_dict
+
+    messages = [
+        HumanMessage(content="run task"),
+        AIMessage(
+            content="thinking",
+            tool_calls=[{"id": "", "name": "read_file", "args": {"path": "x"}}],
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "x"}',
+                        },
+                    }
+                ]
+            },
+        ),
+        ToolMessage(content="result", tool_call_id="", name="read_file"),
+        HumanMessage(content="continue"),
+    ]
+
+    repaired = repair_tool_history(messages)
+
+    wire_ids: list[str] = []
+    for message in repaired:
+        payload = _convert_message_to_dict(message)
+        if payload.get("role") == "assistant":
+            for call in payload.get("tool_calls", []):
+                wire_ids.append(call.get("id"))
+        elif payload.get("role") == "tool":
+            wire_ids.append(payload.get("tool_call_id"))
+
+    blanks = [cid for cid in wire_ids if not isinstance(cid, str) or not cid.strip()]
+    assert not blanks, f"blank tool_call_id reached the wire: {blanks!r}"
+    # pairing preserved: each assistant id has a matching tool result
+    assistant_ids = [
+        call.get("id")
+        for m in repaired
+        if isinstance(m, AIMessage)
+        for call in m.tool_calls
+    ]
+    tool_ids = [m.tool_call_id for m in repaired if isinstance(m, ToolMessage)]
+    assert sorted(assistant_ids) == sorted(tool_ids)
+
+
+def test_blank_id_repair_does_not_spam_warnings(caplog):
+    """Across repeated repair calls (as on every model call within one run),
+    blank-id normalization must not re-emit the synthesized/dropped warning.
+
+    The fresh ids assigned by the pre-pass are non-deterministic across calls,
+    so they are pre-added to ``warned`` to keep the warning silent -- otherwise
+    every model call on a thread with a blank id would re-log the repair.
+    """
+    messages = [
+        HumanMessage("run"),
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "", "name": "execute", "args": {}}],
+        ),
+        HumanMessage("continue"),
+    ]
+    warned: set[str] = set()
+
+    with caplog.at_level("WARNING"):
+        repair_tool_history(messages, warned=warned)
+        first_warnings = len(caplog.records)
+        repair_tool_history(messages, warned=warned)
+        second_warnings = len(caplog.records)
+
+    assert first_warnings == 0, (
+        "blank-id repair is silent (normalized before the warning path)"
+    )
+    assert second_warnings == 0

--- a/tests/test_tool_history_repair_middleware.py
+++ b/tests/test_tool_history_repair_middleware.py
@@ -626,9 +626,11 @@ def test_blank_id_repair_does_not_spam_warnings(caplog):
     """Across repeated repair calls (as on every model call within one run),
     blank-id normalization must not re-emit the synthesized/dropped warning.
 
-    The fresh ids assigned by the pre-pass are non-deterministic across calls,
-    so they are pre-added to ``warned`` to keep the warning silent -- otherwise
-    every model call on a thread with a blank id would re-log the repair.
+    Deterministic ids (``_repair_{msg_idx}_v{call_idx}``) make the same blank
+    call get the same id on every repair pass, so the main loop's existing
+    ``warned``-set dedup suppresses the warning from the second call on --
+    matching the behavior of ``test_warning_deduplicates_across_calls`` for
+    non-blank interrupted calls.
     """
     messages = [
         HumanMessage("run"),
@@ -646,7 +648,48 @@ def test_blank_id_repair_does_not_spam_warnings(caplog):
         repair_tool_history(messages, warned=warned)
         second_warnings = len(caplog.records)
 
-    assert first_warnings == 0, (
-        "blank-id repair is silent (normalized before the warning path)"
+    assert first_warnings == 1, (
+        "first call should warn once for the synthesized interrupted result"
     )
-    assert second_warnings == 0
+    assert second_warnings == 1, "second call must not repeat the warning"
+    assert warned == {"_repair_1_v0"}, "deterministic id should be stable across calls"
+
+
+def test_invalid_blank_id_not_pushed_to_pending_slots():
+    """Regression for din0s review on PR #399: an invalid_tool_call's fresh id
+    must NOT be pushed to ``pending_slots``, because invalid calls are never
+    executed -- pushing the slot would let an orphan blank ToolMessage from
+    some other call mis-pair with the invalid call's id."""
+    message = AIMessage(content="").model_copy(
+        update={
+            "invalid_tool_calls": [
+                {"id": "", "name": "broken_call", "args": "{bad", "error": "parse"}
+            ],
+        }
+    )
+    orphan_content = "orphan from somewhere else"
+    messages = [
+        HumanMessage("go"),
+        message,
+        ToolMessage(content=orphan_content, tool_call_id="", name="other"),
+        HumanMessage("stop"),
+    ]
+
+    repaired = repair_tool_history(messages)
+
+    tool_msgs = [m for m in repaired if isinstance(m, ToolMessage)]
+    # The orphan's content must NOT survive -- it must not have claimed the
+    # invalid call's fresh id and paired its content with broken_call.
+    assert all(orphan_content not in str(m.content) for m in tool_msgs), (
+        "orphan ToolMessage content leaked into a repaired tool result -- "
+        "its blank id was mis-paired with the invalid call's fresh id"
+    )
+    # The invalid call's fresh id is still synthesized as interrupted by the
+    # main loop (invalid calls with non-blank ids are added to pending), but
+    # that's the existing main-loop behavior and uses the interrupted-result
+    # string, never the orphan's content.
+    invalid_id = "_repair_1_i0"
+    synth = [m for m in tool_msgs if m.tool_call_id == invalid_id]
+    assert len(synth) == 1, "the invalid call should get a synthesized result"
+    assert synth[0].status == "error"
+    assert synth[0].name == "broken_call"

--- a/tests/test_tool_history_repair_middleware.py
+++ b/tests/test_tool_history_repair_middleware.py
@@ -466,6 +466,111 @@ def test_drops_orphan_blank_tool_message():
     assert not any(isinstance(m, ToolMessage) for m in repaired)
 
 
+def test_pending_slots_scoped_per_exchange_not_global_fifo():
+    """Regression for CodeRabbit review on PR #399: an interrupted blank call
+    in an earlier exchange must not leak its fresh id into a later exchange's
+    blank ToolMessage via the FIFO queue.
+
+    Sequence:
+        AIMessage1(blank A) -- interrupted, no ToolMessage
+        HumanMessage         -- boundary closes the queue
+        AIMessage2(blank B)
+        ToolMessage(blank)   -- must pair with B, not A
+
+    Before the fix, the FIFO queue still held A's id at the top, so the
+    ToolMessage was mis-tagged with A's id; the main loop then dropped the
+    real B result as an orphan and synthesized a fake interrupted result
+    for B.
+    """
+    messages = [
+        HumanMessage("turn 1"),
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "", "name": "interrupted_call", "args": {}}],
+        ),
+        HumanMessage("turn 2"),
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "", "name": "real_call", "args": {}}],
+        ),
+        ToolMessage(content="real result", tool_call_id="", name="real_call"),
+    ]
+
+    repaired = repair_tool_history(messages)
+
+    ai_msgs = [m for m in repaired if isinstance(m, AIMessage)]
+    tool_msgs = [m for m in repaired if isinstance(m, ToolMessage)]
+
+    # Two ToolMessages expected: one synthesized (interrupted_call, error)
+    # and one preserved (real_call, with its real content).
+    assert len(tool_msgs) == 2
+    real_results = [m for m in tool_msgs if m.content == "real result"]
+    synthesized = [m for m in tool_msgs if m.status == "error"]
+    assert len(real_results) == 1, "the real tool result must be preserved"
+    assert len(synthesized) == 1, "the interrupted call must be synthesized"
+
+    # Pairing integrity: each AIMessage's id has exactly one matching ToolMessage.
+    real_result = real_results[0]
+    owning_ai = next(
+        (
+            ai
+            for ai in ai_msgs
+            if any(c["id"] == real_result.tool_call_id for c in ai.tool_calls)
+        ),
+        None,
+    )
+    assert owning_ai is not None, "real result must match the second AIMessage's call"
+    assert any(c["name"] == "real_call" for c in owning_ai.tool_calls), (
+        "the real result must be paired with real_call, not interrupted_call"
+    )
+
+
+def test_normalizes_blank_id_in_invalid_tool_calls_only():
+    """Regression for CodeRabbit review on PR #399: a message with blank id
+    in ``invalid_tool_calls`` only (no valid ``tool_calls``) must also be
+    repaired.
+
+    langchain-openai's serializer puts ``tool_calls + invalid_tool_calls`` on
+    the wire (it does NOT skip invalid calls), so a blank id on an invalid
+    call reaches the provider just as readily. Before the fix the pre-pass
+    skipped this case entirely because ``any_changed`` was only set inside
+    the valid-call loop.
+    """
+    from langchain_openai.chat_models.base import _convert_message_to_dict
+
+    message = AIMessage(content="").model_copy(
+        update={
+            "invalid_tool_calls": [
+                {"id": "", "name": "broken_call", "args": "{bad", "error": "parse"}
+            ],
+            "additional_kwargs": {
+                "tool_calls": [
+                    {
+                        "id": "",
+                        "type": "function",
+                        "function": {"name": "broken_call", "arguments": "{bad"},
+                    }
+                ]
+            },
+        }
+    )
+    messages = [HumanMessage("hi"), message, HumanMessage("again")]
+
+    repaired = repair_tool_history(messages)
+
+    ai_msg = next(m for m in repaired if isinstance(m, AIMessage))
+    new_id = ai_msg.invalid_tool_calls[0]["id"]
+    assert isinstance(new_id, str)
+    assert new_id, "invalid_tool_call id must be non-blank after repair"
+
+    # Wire payload must not contain any blank id.
+    payload = _convert_message_to_dict(ai_msg)
+    wire_ids = [tc.get("id") for tc in payload.get("tool_calls", [])]
+    blanks = [i for i in wire_ids if not isinstance(i, str) or not i.strip()]
+    assert not blanks, f"blank tool_call_id reached the wire: {blanks!r}"
+    assert new_id in wire_ids, "fresh id must be the one on the wire"
+
+
 def test_blank_id_repair_yields_provider_serializable_payload():
     """End-to-end: the repaired history, when serialized by langchain-openai,
     must not put any blank tool_call_id on the wire."""


### PR DESCRIPTION
## Summary

Fixes #345.

`EvoScientist --output-format stream-json` was failing on the very first tool round with `Error code: 400 - {'error': {'message': 'invalid tool_call_id', 'type': 'invalid_request_error', 'code': '3'}}`. The reporter's logs show the model produced 243 / 97 / 135 output tokens of `usage_stats` and then the next model call 400'd on every retry.

### Root cause

Some streaming providers (notably **Kimi** and **Zhipu** on streamed tool calls) occasionally emit tool calls whose `id` is an empty string, whitespace, or `None`. The existing `repair_tool_history` logic skipped blank ids via a truthy check:

```python
for call in all_calls:
    if tool_call_id := call.get("id"):   # "" / None → falsy → skipped
        pending[tool_call_id] = call.get("name")
```

So an `AIMessage` carrying a blank id was passed through unchanged, while its paired `ToolMessage` was dropped as an orphan (its blank id matched nothing in `pending`). The next model call then 400'd because strict providers validate the call/result pairing and reject blank `tool_call_id`s outright.

This is a different failure mode than the one PR #393 just fixed (#360, "No tool output found"): the call/result pairing is intact, the id itself is invalid. #393 added a strict name+id filter for `additional_kwargs["tool_calls"]` but kept filtering the parsed `message.tool_calls` by name only, so blank ids still slipped through.

### The fix

Adds a pre-pass (`_normalize_blank_tool_call_ids`) before the main repair loop:

- Each blank-id tool call on an `AIMessage` gets a fresh `_repair_<uuid>` id.
- Subsequent blank-id `ToolMessage`s are paired in arrival order (FIFO) so existing exchanges stay paired.
- Unmatched blank calls fall through to the main loop, which synthesizes an interrupted-result `ToolMessage` with the fresh id.
- `additional_kwargs["tool_calls"]` is dropped on touched messages so `langchain-openai`'s serializer (`_convert_message_to_dict`) falls back to the now-valid parsed form instead of preferring the raw form (which still carries the blank id and would be subset-filtered by the main loop, losing the freshly-normalized entries).
- The fresh ids are pre-added to `warned` so repair stays silent on subsequent model calls (the fresh ids are non-deterministic across calls, so without this pre-add every model call on a thread with a blank id would re-log the repair).

### Verification

End-to-end via `langchain_openai.chat_models.base._convert_message_to_dict` (the exact serializer langchain-openai uses to build the HTTP request):

```
[1] assistant tool_calls:  id='_repair_9ca86c7363d346ffaba8beb8b673b7fe'  name='read_file'
[2] tool tool_call_id:     '_repair_9ca86c7363d346ffaba8beb8b673b7fe'

Blank ids on the wire: []  PASS
Pairing preserved:     PASS
```

Unit tests:
- `tests/test_tool_history_repair_middleware.py`: 18 existing + **6 new** regression tests for the blank-id scenarios (paired exchange, `None` id + synthesis, multiple positional blanks, orphan blank result, end-to-end serializer check, cross-call warning suppression).
- Full suite: **3068 passed, 13 skipped** (excluding 3 TUI widget visual tests unrelated to this change).
- `uv run ruff check .` and `uv run ruff format --check .` both clean.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing, blank, or whitespace-only tool-call IDs.
  * Ensured tool calls and results are paired consistently and assigned unique identifiers.
  * Removed conflicting or orphaned tool results and synthesized missing results when needed.
  * Prevented blank IDs from appearing in serialized tool history and reduced duplicate warnings.

* **Tests**
  * Added regression coverage for invalid IDs, missing results, positional pairing, orphan results, and repeated repairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->