### PR TITLE
feat: dispatch mid-session expert installs and edits without /new

### DIFF
--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -94,10 +94,11 @@ _MCP_TOOLS_CACHE_VALUE: dict[str, list] | None = None
 # spawning subprocesses at import time.
 _EvoScientist_agent = None
 # ``dispatchable_experts_token()`` at the time ``_EvoScientist_agent`` was
-# built. Compared on every access so a mid-session ``skill_manager install
-# <expert>`` rebuilds the agent instead of leaving an expert set frozen at
-# construction time. Written only inside ``_get_default_agent``'s build
-# block, so it cannot drift from the agent it describes.
+# built. Compared on every access so a mid-session change to the expert set
+# — an install, or an expert written straight onto the workspace skills
+# tier — rebuilds the agent instead of leaving it frozen at construction
+# time. Written only inside ``_get_default_agent``'s build block, so it
+# cannot drift from the agent it describes.
 _EvoScientist_agent_expert_token: str | None = None
 
 
@@ -1077,8 +1078,9 @@ def _get_default_agent():
 
     **Rebuilds when the expert registry changes.** ``task`` and
     ``start_async_task`` resolve ``subagent_type`` against dicts frozen
-    inside ``create_deep_agent``, so an expert installed after this agent
-    was built is unreachable until it is rebuilt. Comparing
+    inside ``create_deep_agent``, so an expert that appears — or whose
+    actor definition changes — after this agent was built is unreachable,
+    or reachable with a stale persona, until it is rebuilt. Comparing
     ``dispatchable_experts_token()`` against the value the cached agent was
     built at makes that rebuild happen on next access — the pull-side
     equivalent of the ``_replace_chat_model`` null-out, and the mechanism

--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -97,8 +97,12 @@ _EvoScientist_agent = None
 # built. Compared on every access so a mid-session change to the expert set
 # — an install, or an expert written straight onto the workspace skills
 # tier — rebuilds the agent instead of leaving it frozen at construction
-# time. Written only inside ``_get_default_agent``'s build block, so it
-# cannot drift from the agent it describes.
+# time. Written only by ``_get_default_agent``, and it means two different
+# things by outcome: on success, the registry the seated agent was built
+# from; on failure, the registry a build was already attempted and failed
+# at. The second reading is deliberate — it is what stops a broken expert
+# from being retried once per HTTP request — so after a failed rebuild this
+# describes the attempt, not the older agent still seated.
 _EvoScientist_agent_expert_token: str | None = None
 
 
@@ -1086,11 +1090,28 @@ def _get_default_agent():
     equivalent of the ``_replace_chat_model`` null-out, and the mechanism
     ``langgraph_dev.main_graph``'s graph factory relies on to serve a
     current agent per request.
+
+    **A failed rebuild keeps the previous agent.** Since the graph factory
+    calls this per request, raising would take a working deployment to a
+    permanent 500 — and the trigger is now agent-authored content, so a
+    half-written expert would be enough to do it. The degraded state is "the
+    new expert isn't reachable yet", never a dead deployment. A build with no
+    previous agent to fall back on (first access, or after
+    ``_replace_chat_model``) still raises.
     """
     global _EvoScientist_agent, _EvoScientist_agent_expert_token
-    from .subagents.expert_container import dispatchable_experts_token
+    from .subagents.expert_container import (
+        dispatchable_experts_token,
+        rollback_dispatchable_memo,
+    )
 
     expert_token = dispatchable_experts_token()
+    # Captured BEFORE the null-out below, which is what makes the failure
+    # path safe against ``_replace_chat_model``. That function nulls this
+    # global itself, so on a model switch ``previous`` is already None and a
+    # failed build re-raises rather than re-seating an agent still bound to
+    # the superseded chat model. Only the registry-change path can re-seat.
+    previous = _EvoScientist_agent
     if (
         _EvoScientist_agent is not None
         and _EvoScientist_agent_expert_token != expert_token
@@ -1104,27 +1125,56 @@ def _get_default_agent():
     if _EvoScientist_agent is None:
         from deepagents import create_deep_agent
 
-        cfg = _ensure_config()
-        be = _get_default_backend()
-        mw = _get_default_middleware()
+        try:
+            cfg = _ensure_config()
+            be = _get_default_backend()
+            mw = _get_default_middleware()
 
-        if os.environ.get("EVOSCIENTIST_DEPLOY_MODE", "").lower() == "stripped":
-            kwargs = _build_base_kwargs(
-                be,
-                mw,
-                workspace_dir=str(_paths_mod.WORKSPACE_ROOT),
-            )
-        else:
-            kwargs = load_mcp_and_build_kwargs(
-                be,
-                mw,
-                workspace_dir=str(_paths_mod.WORKSPACE_ROOT),
-            )
+            if os.environ.get("EVOSCIENTIST_DEPLOY_MODE", "").lower() == "stripped":
+                kwargs = _build_base_kwargs(
+                    be,
+                    mw,
+                    workspace_dir=str(_paths_mod.WORKSPACE_ROOT),
+                )
+            else:
+                kwargs = load_mcp_and_build_kwargs(
+                    be,
+                    mw,
+                    workspace_dir=str(_paths_mod.WORKSPACE_ROOT),
+                )
 
-        _EvoScientist_agent = create_deep_agent(
-            **kwargs,
-            interrupt_on=_build_hitl_interrupt_on(auto_approve=cfg.auto_approve),
-        ).with_config({"recursion_limit": cfg.recursion_limit})
+            agent = create_deep_agent(
+                **kwargs,
+                interrupt_on=_build_hitl_interrupt_on(auto_approve=cfg.auto_approve),
+            ).with_config({"recursion_limit": cfg.recursion_limit})
+        except Exception:
+            if previous is None:
+                raise
+            # A rebuild triggered by a registry change failed. The expert set
+            # is now agent-authored content, so a half-written expert must not
+            # take a working deployment down: the WebUI graph factory calls
+            # this per request, including for read-only state reads, so
+            # re-raising would 500 every one of them.
+            logging.getLogger(__name__).warning(
+                "Agent rebuild failed; continuing with the previously built "
+                "agent. The new experts will not be reachable until the "
+                "registry changes again.",
+                exc_info=True,
+            )
+            # Stamp the token we failed on, not the old one, so the failing
+            # build is not retried until the inputs move again — the same
+            # property ``BackgroundAgentLoader._reload`` gets for free from
+            # ``start``, and it matters more here because the retry would
+            # otherwise be paid per HTTP request.
+            _EvoScientist_agent = previous
+            _EvoScientist_agent_expert_token = expert_token
+            # The token read above already restamped the cue's memo with the
+            # set this build was going to provide. It didn't, so put back the
+            # set ``previous`` was actually built from.
+            rollback_dispatchable_memo()
+            return previous
+
+        _EvoScientist_agent = agent
         _EvoScientist_agent_expert_token = expert_token
     return _EvoScientist_agent
 

--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -93,6 +93,12 @@ _MCP_TOOLS_CACHE_VALUE: dict[str, list] | None = None
 # Lazily constructed on first access so MCP tools are included without
 # spawning subprocesses at import time.
 _EvoScientist_agent = None
+# ``dispatchable_experts_token()`` at the time ``_EvoScientist_agent`` was
+# built. Compared on every access so a mid-session ``skill_manager install
+# <expert>`` rebuilds the agent instead of leaving an expert set frozen at
+# construction time. Written only inside ``_get_default_agent``'s build
+# block, so it cannot drift from the agent it describes.
+_EvoScientist_agent_expert_token: str | None = None
 
 
 # =============================================================================
@@ -1068,8 +1074,31 @@ def _get_default_agent():
     Plain ``from EvoScientist import EvoScientist_agent`` (env var unset)
     loads MCP. Async sub-agents stay disabled in that case because there is
     no langgraph dev server to self-loop into.
+
+    **Rebuilds when the expert registry changes.** ``task`` and
+    ``start_async_task`` resolve ``subagent_type`` against dicts frozen
+    inside ``create_deep_agent``, so an expert installed after this agent
+    was built is unreachable until it is rebuilt. Comparing
+    ``dispatchable_experts_token()`` against the value the cached agent was
+    built at makes that rebuild happen on next access — the pull-side
+    equivalent of the ``_replace_chat_model`` null-out, and the mechanism
+    ``langgraph_dev.main_graph``'s graph factory relies on to serve a
+    current agent per request.
     """
-    global _EvoScientist_agent
+    global _EvoScientist_agent, _EvoScientist_agent_expert_token
+    from .subagents.expert_container import dispatchable_experts_token
+
+    expert_token = dispatchable_experts_token()
+    if (
+        _EvoScientist_agent is not None
+        and _EvoScientist_agent_expert_token != expert_token
+    ):
+        logging.getLogger(__name__).info(
+            "Expert registry changed; rebuilding the default agent so newly "
+            "installed experts are dispatchable."
+        )
+        _EvoScientist_agent = None
+
     if _EvoScientist_agent is None:
         from deepagents import create_deep_agent
 
@@ -1094,6 +1123,7 @@ def _get_default_agent():
             **kwargs,
             interrupt_on=_build_hitl_interrupt_on(auto_approve=cfg.auto_approve),
         ).with_config({"recursion_limit": cfg.recursion_limit})
+        _EvoScientist_agent_expert_token = expert_token
     return _EvoScientist_agent
 
 

--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -1093,16 +1093,19 @@ def _get_default_agent():
 
     **A failed rebuild keeps the previous agent.** Since the graph factory
     calls this per request, raising would take a working deployment to a
-    permanent 500 — and the trigger is now agent-authored content, so a
-    half-written expert would be enough to do it. The degraded state is "the
-    new expert isn't reachable yet", never a dead deployment. A build with no
-    previous agent to fall back on (first access, or after
-    ``_replace_chat_model``) still raises.
+    permanent 500. The expert content itself cannot cause that — every
+    malformed expert is skipped with a warning rather than raising — but the
+    stages a rebuild re-runs around it can: the backends are reconstructed
+    against live paths and the chat model is re-resolved, so a full disk, a
+    revoked credential or an unreachable provider all surface here. The
+    degraded state is "the new expert isn't reachable yet", never a dead
+    deployment. A build with no previous agent to fall back on (first
+    access, or after ``_replace_chat_model``) still raises.
     """
     global _EvoScientist_agent, _EvoScientist_agent_expert_token
     from .subagents.expert_container import (
         dispatchable_experts_token,
-        rollback_dispatchable_memo,
+        publish_dispatchable_experts,
     )
 
     expert_token = dispatchable_experts_token()
@@ -1150,11 +1153,12 @@ def _get_default_agent():
         except Exception:
             if previous is None:
                 raise
-            # A rebuild triggered by a registry change failed. The expert set
-            # is now agent-authored content, so a half-written expert must not
-            # take a working deployment down: the WebUI graph factory calls
-            # this per request, including for read-only state reads, so
-            # re-raising would 500 every one of them.
+            # A rebuild triggered by a registry change failed — on the backend
+            # or chat-model construction it re-runs, since expert content
+            # itself is skip-on-error. Either way it must not take a working
+            # deployment down: the WebUI graph factory calls this per request,
+            # including for read-only state reads, so re-raising would 500
+            # every one of them.
             logging.getLogger(__name__).warning(
                 "Agent rebuild failed; continuing with the previously built "
                 "agent. The new experts will not be reachable until the "
@@ -1168,14 +1172,16 @@ def _get_default_agent():
             # otherwise be paid per HTTP request.
             _EvoScientist_agent = previous
             _EvoScientist_agent_expert_token = expert_token
-            # The token read above already restamped the cue's memo with the
-            # set this build was going to provide. It didn't, so put back the
-            # set ``previous`` was actually built from.
-            rollback_dispatchable_memo()
+            # Nothing to undo: the token read above is side-effect-free and
+            # the cue's memo is only ever stamped below, past this branch.
             return previous
 
         _EvoScientist_agent = agent
         _EvoScientist_agent_expert_token = expert_token
+        # Reached only by a build that produced an agent, which is what makes
+        # the active-expert cue and the ``/expert`` popup describe something
+        # ``task()`` can actually route to.
+        publish_dispatchable_experts()
     return _EvoScientist_agent
 
 

--- a/EvoScientist/cli/_agent_loader.py
+++ b/EvoScientist/cli/_agent_loader.py
@@ -86,6 +86,11 @@ class BackgroundAgentLoader(Generic[AgentT]):
     threads inside it if needed.  ``on_success`` / ``on_failure`` fire
     on the event loop when the task completes.
 
+    ``on_failure`` means the session has no agent.  A failed *in-place*
+    rebuild is a different event — the previous agent keeps serving — and
+    reports through ``on_rebuild_failed`` instead, so a UI can say "couldn't
+    pick that up yet" rather than "the load died".
+
     ``build_token`` makes the seated agent self-invalidating: see
     :meth:`await_ready`.
     """
@@ -97,16 +102,24 @@ class BackgroundAgentLoader(Generic[AgentT]):
         on_progress: ProgressCallback | None = None,
         on_success: SuccessCallback | None = None,
         on_failure: FailureCallback | None = None,
+        on_rebuild_failed: FailureCallback | None = None,
         build_token: Callable[[], Any] | None = None,
     ) -> None:
         self._loader_fn = loader_fn
         self._on_progress = on_progress
         self._on_success = on_success
         self._on_failure = on_failure
+        self._on_rebuild_failed = on_rebuild_failed
         self._build_token = build_token
         self.agent: AgentT | None = None
         self._task: asyncio.Task[AgentT] | None = None
         self._load_id: int = 0
+        # True only while ``_reload`` is driving ``start`` + ``await_ready``.
+        # ``_on_done`` fires the fatal ``on_failure`` before ``_reload``'s
+        # ``except`` gets a chance to re-seat the previous agent, so without
+        # this flag every in-place rebuild failure is reported as a dead
+        # session.
+        self._reloading: bool = False
         # Kwargs of the most recent ``start``, replayed verbatim by the
         # stale-token reload in ``await_ready``. Everything session-scoped
         # (checkpointer, event sink, workspace, config object) lives in
@@ -188,15 +201,25 @@ class BackgroundAgentLoader(Generic[AgentT]):
         """Evaluate ``build_token``, treating any failure as "unknown".
 
         A token that can't be computed must not strand the session in a
-        rebuild loop, so it degrades to ``None`` — which compares equal to
-        the ``None`` used when no ``build_token`` was supplied.
+        rebuild loop, so it degrades to ``None``. That is not a no-op once a
+        real token has been read: ``None`` compares unequal to the hash
+        already in ``_agent_token``, so the first raise forces one rebuild,
+        after which ``start`` re-stamps ``None`` and it settles.
+
+        Logged at warning because this is the single failure that silently
+        turns mid-session expert pickup off entirely — at debug level nobody
+        would ever learn why installs stopped taking effect.
         """
         if self._build_token is None:
             return None
         try:
             return self._build_token()
         except Exception:
-            _logger.debug("build_token callback raised", exc_info=True)
+            _logger.warning(
+                "build_token callback raised; agent staleness checks are "
+                "disabled until it succeeds again.",
+                exc_info=True,
+            )
             return None
 
     async def await_ready(self) -> AgentT:
@@ -218,12 +241,13 @@ class BackgroundAgentLoader(Generic[AgentT]):
 
         A failed rebuild keeps the previous agent seated — a broken
         install must degrade to "the new thing isn't there yet", never to
-        a dead session.
+        a dead session — and reports through ``on_rebuild_failed`` rather
+        than the fatal ``on_failure``.
         """
         if self.agent is not None:
             token = self._read_build_token()
             if token != self._agent_token and self._last_kwargs is not None:
-                return await self._reload(token)
+                return await self._reload()
             return self.agent
         if self._task is None:
             raise RuntimeError(
@@ -234,19 +258,24 @@ class BackgroundAgentLoader(Generic[AgentT]):
             raise RuntimeError("BackgroundAgentLoader completed without an agent")
         return self.agent
 
-    async def _reload(self, token: Any) -> AgentT:
+    async def _reload(self) -> AgentT:
         """Rebuild the seated agent in place, falling back to the old one."""
         assert self._last_kwargs is not None
         previous = self.agent
-        _logger.info(
-            "Agent inputs changed (build token %r -> %r); rebuilding in place.",
-            self._agent_token,
-            token,
-        )
-        self.start(**self._last_kwargs)
+        stale_token = self._agent_token
+        self._reloading = True
         try:
+            # ``start`` re-reads the token itself, so it is not passed in —
+            # doing so would cost a second full skills-tree walk per rebuild
+            # for a value only ever used in this log line.
+            self.start(**self._last_kwargs)
+            _logger.info(
+                "Agent inputs changed (build token %r -> %r); rebuilding in place.",
+                stale_token,
+                self._agent_token,
+            )
             return await self.await_ready()
-        except Exception:
+        except Exception as exc:
             # Re-seat the old agent so the session keeps working. Its
             # token stays the failed one, so the rebuild is not retried
             # until the inputs change again — which is also the next
@@ -258,7 +287,11 @@ class BackgroundAgentLoader(Generic[AgentT]):
             )
             self.agent = previous
             self._task = None
+            if self._on_rebuild_failed is not None:
+                self._on_rebuild_failed(exc)
             return previous  # type: ignore[return-value]
+        finally:
+            self._reloading = False
 
     def _on_done(self, task: asyncio.Task[AgentT], load_id: int) -> None:
         if load_id != self._load_id:
@@ -271,7 +304,11 @@ class BackgroundAgentLoader(Generic[AgentT]):
             # Keep ``_task`` set so a later ``await_ready`` re-raises the
             # real exception instead of the "before start()" sentinel.
             self.agent = None
-            if self._on_failure is not None:
+            # During a reload the session is not dead — ``_reload``'s except
+            # branch is about to re-seat the previous agent and report via
+            # ``on_rebuild_failed``. Firing the fatal callback here would tell
+            # the user the load died a moment before the next turn runs fine.
+            if self._on_failure is not None and not self._reloading:
                 self._on_failure(exc)
             return
         if self._on_success is not None:

--- a/EvoScientist/cli/_agent_loader.py
+++ b/EvoScientist/cli/_agent_loader.py
@@ -92,7 +92,10 @@ class BackgroundAgentLoader(Generic[AgentT]):
     pick that up yet" rather than "the load died".
 
     ``build_token`` makes the seated agent self-invalidating: see
-    :meth:`await_ready`.
+    :meth:`await_ready`.  ``publish_build`` is its success-branch twin —
+    fired only once a build has produced an agent, so whatever it publishes
+    describes something that actually exists.  Both are injected rather than
+    imported so this module keeps knowing nothing about experts or skills.
     """
 
     def __init__(
@@ -105,6 +108,7 @@ class BackgroundAgentLoader(Generic[AgentT]):
         on_rebuild_started: Callable[[], None] | None = None,
         on_rebuild_failed: FailureCallback | None = None,
         build_token: Callable[[], Any] | None = None,
+        publish_build: Callable[[], None] | None = None,
     ) -> None:
         self._loader_fn = loader_fn
         self._on_progress = on_progress
@@ -113,6 +117,7 @@ class BackgroundAgentLoader(Generic[AgentT]):
         self._on_rebuild_started = on_rebuild_started
         self._on_rebuild_failed = on_rebuild_failed
         self._build_token = build_token
+        self._publish_build = publish_build
         self.agent: AgentT | None = None
         self._task: asyncio.Task[AgentT] | None = None
         self._load_id: int = 0
@@ -198,6 +203,27 @@ class BackgroundAgentLoader(Generic[AgentT]):
         # current inputs; without re-stamping, the next ``await_ready``
         # would rebuild it for a token change it already contains.
         self._agent_token = self._read_build_token()
+        self._publish_built_agent()
+
+    def _publish_built_agent(self) -> None:
+        """Announce a build that produced an agent.
+
+        Every call site is downstream of a successful construction, which is
+        the whole design: nothing publishes speculatively, so no caller has a
+        failure branch to undo. Swallows and logs rather than propagating —
+        the agent is already built and serving, and a failed publish costs a
+        stale side-cache, not a session.
+        """
+        if self._publish_build is None:
+            return
+        try:
+            self._publish_build()
+        except Exception:
+            _logger.warning(
+                "publish_build callback raised; caches derived from the agent's "
+                "inputs may report a stale set until the next build.",
+                exc_info=True,
+            )
 
     def _read_build_token(self) -> Any:
         """Evaluate ``build_token``, treating any failure as "unknown".
@@ -241,10 +267,12 @@ class BackgroundAgentLoader(Generic[AgentT]):
         inside a tool call) takes effect on the next turn without the
         user running ``/new`` and losing the conversation.
 
-        A failed rebuild keeps the previous agent seated — a broken
-        install must degrade to "the new thing isn't there yet", never to
-        a dead session — and reports through ``on_rebuild_failed`` rather
-        than the fatal ``on_failure``.
+        A failed rebuild keeps the previous agent seated — a rebuild that
+        raises must degrade to "the new thing isn't there yet", never to a
+        dead session — and reports through ``on_rebuild_failed`` rather than
+        the fatal ``on_failure``.  It also leaves ``publish_build`` unfired,
+        so anything derived from the agent's inputs still describes the
+        agent that is actually serving.
         """
         if self.agent is not None:
             token = self._read_build_token()
@@ -272,9 +300,11 @@ class BackgroundAgentLoader(Generic[AgentT]):
             self._on_rebuild_started()
         self._reloading = True
         try:
-            # ``start`` re-reads the token itself, so it is not passed in —
-            # doing so would cost a second full skills-tree walk per rebuild
-            # for a value only ever used in this log line.
+            # ``start`` re-reads the token rather than taking the one
+            # ``await_ready`` just read, so a rebuild turn walks the tree
+            # twice. Both reads are side-effect-free, so the cost is ~18 ms
+            # against a multi-second rebuild and nothing observable depends
+            # on which of the two won.
             self.start(**self._last_kwargs)
             _logger.info(
                 "Agent inputs changed (build token %r -> %r); rebuilding in place.",
@@ -318,5 +348,8 @@ class BackgroundAgentLoader(Generic[AgentT]):
             if self._on_failure is not None and not self._reloading:
                 self._on_failure(exc)
             return
+        # Before ``on_success`` so a UI callback that reads the published set
+        # while rendering sees the agent it is announcing, not the one before.
+        self._publish_built_agent()
         if self._on_success is not None:
             self._on_success(self.agent)

--- a/EvoScientist/cli/_agent_loader.py
+++ b/EvoScientist/cli/_agent_loader.py
@@ -85,6 +85,9 @@ class BackgroundAgentLoader(Generic[AgentT]):
     ``on_progress`` fires on the **worker thread**; UI callers hop
     threads inside it if needed.  ``on_success`` / ``on_failure`` fire
     on the event loop when the task completes.
+
+    ``build_token`` makes the seated agent self-invalidating: see
+    :meth:`await_ready`.
     """
 
     def __init__(
@@ -94,14 +97,23 @@ class BackgroundAgentLoader(Generic[AgentT]):
         on_progress: ProgressCallback | None = None,
         on_success: SuccessCallback | None = None,
         on_failure: FailureCallback | None = None,
+        build_token: Callable[[], Any] | None = None,
     ) -> None:
         self._loader_fn = loader_fn
         self._on_progress = on_progress
         self._on_success = on_success
         self._on_failure = on_failure
+        self._build_token = build_token
         self.agent: AgentT | None = None
         self._task: asyncio.Task[AgentT] | None = None
         self._load_id: int = 0
+        # Kwargs of the most recent ``start``, replayed verbatim by the
+        # stale-token reload in ``await_ready``. Everything session-scoped
+        # (checkpointer, event sink, workspace, config object) lives in
+        # here, so replaying them rebuilds the agent without disturbing
+        # the conversation — unlike ``/new``, which rotates the thread.
+        self._last_kwargs: dict[str, Any] | None = None
+        self._agent_token: Any = None
 
     @property
     def task(self) -> asyncio.Task[AgentT] | None:
@@ -127,6 +139,11 @@ class BackgroundAgentLoader(Generic[AgentT]):
         self._load_id += 1
         load_id = self._load_id
         self.agent = None
+        self._last_kwargs = dict(loader_kwargs)
+        # Stamped BEFORE the build, not after: a mutation landing mid-build
+        # may or may not be captured by it, so the pessimistic stamp costs
+        # at most one extra rebuild and never leaves a stale agent seated.
+        self._agent_token = self._read_build_token()
 
         def _gated_progress(event: str, server: str, detail: str) -> None:
             if load_id != self._load_id:
@@ -162,6 +179,25 @@ class BackgroundAgentLoader(Generic[AgentT]):
         self._load_id += 1
         self._task = None
         self.agent = agent
+        # The caller built this agent just now, so it already reflects the
+        # current inputs; without re-stamping, the next ``await_ready``
+        # would rebuild it for a token change it already contains.
+        self._agent_token = self._read_build_token()
+
+    def _read_build_token(self) -> Any:
+        """Evaluate ``build_token``, treating any failure as "unknown".
+
+        A token that can't be computed must not strand the session in a
+        rebuild loop, so it degrades to ``None`` — which compares equal to
+        the ``None`` used when no ``build_token`` was supplied.
+        """
+        if self._build_token is None:
+            return None
+        try:
+            return self._build_token()
+        except Exception:
+            _logger.debug("build_token callback raised", exc_info=True)
+            return None
 
     async def await_ready(self) -> AgentT:
         """Return the loaded agent; re-raises on load failure.
@@ -170,8 +206,24 @@ class BackgroundAgentLoader(Generic[AgentT]):
         ``on_success`` / ``on_failure``) are handled exclusively by
         :meth:`_on_done`, which fires before this ``await`` resumes
         (asyncio guarantees done-callbacks run in registration order).
+
+        When a ``build_token`` was supplied and its value has moved since
+        the seated agent was built, the agent is transparently rebuilt
+        here from the stored ``start`` kwargs.  Every pre-turn agent
+        access in both UIs funnels through this method, which is why the
+        check lives here rather than in each turn loop: an agent input
+        that changes mid-session (a ``skill_manager install`` firing from
+        inside a tool call) takes effect on the next turn without the
+        user running ``/new`` and losing the conversation.
+
+        A failed rebuild keeps the previous agent seated — a broken
+        install must degrade to "the new thing isn't there yet", never to
+        a dead session.
         """
         if self.agent is not None:
+            token = self._read_build_token()
+            if token != self._agent_token and self._last_kwargs is not None:
+                return await self._reload(token)
             return self.agent
         if self._task is None:
             raise RuntimeError(
@@ -181,6 +233,32 @@ class BackgroundAgentLoader(Generic[AgentT]):
         if self.agent is None:
             raise RuntimeError("BackgroundAgentLoader completed without an agent")
         return self.agent
+
+    async def _reload(self, token: Any) -> AgentT:
+        """Rebuild the seated agent in place, falling back to the old one."""
+        assert self._last_kwargs is not None
+        previous = self.agent
+        _logger.info(
+            "Agent inputs changed (build token %r -> %r); rebuilding in place.",
+            self._agent_token,
+            token,
+        )
+        self.start(**self._last_kwargs)
+        try:
+            return await self.await_ready()
+        except Exception:
+            # Re-seat the old agent so the session keeps working. Its
+            # token stays the failed one, so the rebuild is not retried
+            # until the inputs change again — which is also the next
+            # chance for the underlying problem to have been fixed.
+            _logger.warning(
+                "Agent rebuild failed; continuing with the previously loaded "
+                "agent. New inputs will not be visible until the next rebuild.",
+                exc_info=True,
+            )
+            self.agent = previous
+            self._task = None
+            return previous  # type: ignore[return-value]
 
     def _on_done(self, task: asyncio.Task[AgentT], load_id: int) -> None:
         if load_id != self._load_id:

--- a/EvoScientist/cli/_agent_loader.py
+++ b/EvoScientist/cli/_agent_loader.py
@@ -102,6 +102,7 @@ class BackgroundAgentLoader(Generic[AgentT]):
         on_progress: ProgressCallback | None = None,
         on_success: SuccessCallback | None = None,
         on_failure: FailureCallback | None = None,
+        on_rebuild_started: Callable[[], None] | None = None,
         on_rebuild_failed: FailureCallback | None = None,
         build_token: Callable[[], Any] | None = None,
     ) -> None:
@@ -109,6 +110,7 @@ class BackgroundAgentLoader(Generic[AgentT]):
         self._on_progress = on_progress
         self._on_success = on_success
         self._on_failure = on_failure
+        self._on_rebuild_started = on_rebuild_started
         self._on_rebuild_failed = on_rebuild_failed
         self._build_token = build_token
         self.agent: AgentT | None = None
@@ -263,6 +265,11 @@ class BackgroundAgentLoader(Generic[AgentT]):
         assert self._last_kwargs is not None
         previous = self.agent
         stale_token = self._agent_token
+        # Announced before the await, not after: the rebuild blocks the turn
+        # for seconds and the UI is otherwise silent for all of it, which
+        # reads as a hang rather than as work.
+        if self._on_rebuild_started is not None:
+            self._on_rebuild_started()
         self._reloading = True
         try:
             # ``start`` re-reads the token itself, so it is not passed in —

--- a/EvoScientist/cli/interactive.py
+++ b/EvoScientist/cli/interactive.py
@@ -45,6 +45,7 @@ from ..gateway import (
 from ..sessions import get_checkpointer, short_thread_id
 from ..stream.console import console
 from ..stream.display import _fix_markdown_heading_spacing
+from ..subagents.expert_container import dispatchable_experts_token
 from . import async_notifier
 from ._agent_loader import BackgroundAgentLoader, MCPProgressTracker
 from ._constants import (
@@ -505,9 +506,14 @@ def cmd_interactive(
                 f"[red]failed:[/red] {escape(detail)}"
             )
 
+    # ``build_token`` makes an expert installed mid-session dispatchable on
+    # the next turn: the loader rebuilds the agent in place (same thread,
+    # same checkpointer) when the expert registry changes, so ``task`` /
+    # ``start_async_task`` can reach the new expert without ``/new``.
     agent_loader = BackgroundAgentLoader(
         _load_agent,
         on_progress=_on_mcp_progress,
+        build_token=dispatchable_experts_token,
     )
 
     # One frontend event sink for the whole session — injected into the agent's

--- a/EvoScientist/cli/interactive.py
+++ b/EvoScientist/cli/interactive.py
@@ -530,9 +530,14 @@ def cmd_interactive(
             f"[/yellow]"
         )
 
+    def _on_agent_rebuild_started() -> None:
+        """Explain the pause before an in-place rebuild (it takes seconds)."""
+        console.print("[dim]Picking up new experts; this takes a few seconds.[/dim]")
+
     agent_loader = BackgroundAgentLoader(
         _load_agent,
         on_progress=_on_mcp_progress,
+        on_rebuild_started=_on_agent_rebuild_started,
         on_rebuild_failed=_on_agent_rebuild_failed,
         build_token=dispatchable_experts_token,
     )

--- a/EvoScientist/cli/interactive.py
+++ b/EvoScientist/cli/interactive.py
@@ -45,7 +45,10 @@ from ..gateway import (
 from ..sessions import get_checkpointer, short_thread_id
 from ..stream.console import console
 from ..stream.display import _fix_markdown_heading_spacing
-from ..subagents.expert_container import dispatchable_experts_token
+from ..subagents.expert_container import (
+    dispatchable_experts_token,
+    publish_dispatchable_experts,
+)
 from . import async_notifier
 from ._agent_loader import BackgroundAgentLoader, MCPProgressTracker
 from ._constants import (
@@ -515,15 +518,10 @@ def cmd_interactive(
 
         ``_reload`` swallows the exception and re-seats the previous agent,
         so without this the user gets no signal at all that the expert they
-        just installed didn't land.
+        just installed didn't land. Nothing to undo here — the cue's memo is
+        stamped from the build's success branch, which this rebuild never
+        reached.
         """
-        from ..subagents.expert_container import rollback_dispatchable_memo
-
-        # The staleness probe already restamped the cue's memo with the set
-        # this rebuild was going to provide. Put back the set the still-seated
-        # agent was built from, so neither the expert prompt nor ``/expert``
-        # offers something ``task`` can't route.
-        rollback_dispatchable_memo()
         console.print(
             f"[yellow]Couldn't pick up the new experts yet:[/yellow] "
             f"{escape(str(exc))}[yellow]. Continuing with the current agent."
@@ -540,6 +538,7 @@ def cmd_interactive(
         on_rebuild_started=_on_agent_rebuild_started,
         on_rebuild_failed=_on_agent_rebuild_failed,
         build_token=dispatchable_experts_token,
+        publish_build=publish_dispatchable_experts,
     )
 
     # One frontend event sink for the whole session — injected into the agent's

--- a/EvoScientist/cli/interactive.py
+++ b/EvoScientist/cli/interactive.py
@@ -510,9 +510,30 @@ def cmd_interactive(
     # the next turn: the loader rebuilds the agent in place (same thread,
     # same checkpointer) when the expert registry changes, so ``task`` /
     # ``start_async_task`` can reach the new expert without ``/new``.
+    def _on_agent_rebuild_failed(exc: BaseException) -> None:
+        """Report a failed in-place rebuild; the session keeps running.
+
+        ``_reload`` swallows the exception and re-seats the previous agent,
+        so without this the user gets no signal at all that the expert they
+        just installed didn't land.
+        """
+        from ..subagents.expert_container import rollback_dispatchable_memo
+
+        # The staleness probe already restamped the cue's memo with the set
+        # this rebuild was going to provide. Put back the set the still-seated
+        # agent was built from, so neither the expert prompt nor ``/expert``
+        # offers something ``task`` can't route.
+        rollback_dispatchable_memo()
+        console.print(
+            f"[yellow]Couldn't pick up the new experts yet:[/yellow] "
+            f"{escape(str(exc))}[yellow]. Continuing with the current agent."
+            f"[/yellow]"
+        )
+
     agent_loader = BackgroundAgentLoader(
         _load_agent,
         on_progress=_on_mcp_progress,
+        on_rebuild_failed=_on_agent_rebuild_failed,
         build_token=dispatchable_experts_token,
     )
 

--- a/EvoScientist/cli/tui_interactive.py
+++ b/EvoScientist/cli/tui_interactive.py
@@ -646,6 +646,7 @@ def run_textual_interactive(
                 on_progress=self._on_mcp_progress,
                 on_success=self._on_agent_load_success,
                 on_failure=self._on_agent_load_failure,
+                on_rebuild_started=self._on_agent_rebuild_started,
                 on_rebuild_failed=self._on_agent_rebuild_failed,
                 build_token=dispatchable_experts_token,
             )
@@ -732,6 +733,18 @@ def run_textual_interactive(
         def _on_agent_load_failure(self, exc: BaseException) -> None:
             self._append_system(f"Agent failed to load: {exc}", style="red")
             self._finish_loader_widget()
+
+        def _on_agent_rebuild_started(self) -> None:
+            """Explain the pause before an in-place rebuild.
+
+            The rebuild is awaited before the turn runs and takes seconds, with
+            no loader widget (``_reload`` drives ``start`` directly and never
+            mounts one). Without this the UI is silent for the whole wait.
+            """
+            self._append_system(
+                "Picking up new experts; this takes a few seconds.",
+                style="dim",
+            )
 
         def _on_agent_rebuild_failed(self, exc: BaseException) -> None:
             """Report a failed in-place rebuild without claiming the session died.

--- a/EvoScientist/cli/tui_interactive.py
+++ b/EvoScientist/cli/tui_interactive.py
@@ -35,7 +35,10 @@ from ..gateway import (
 from ..paths import DATA_DIR
 from ..sessions import get_checkpointer
 from ..stream.state import ResearchPhase, StreamState
-from ..subagents.expert_container import dispatchable_experts_token
+from ..subagents.expert_container import (
+    dispatchable_experts_token,
+    publish_dispatchable_experts,
+)
 from ._agent_loader import BackgroundAgentLoader, MCPProgressTracker
 from ._constants import (
     DANGEROUS_BANNER_LABEL,
@@ -649,6 +652,7 @@ def run_textual_interactive(
                 on_rebuild_started=self._on_agent_rebuild_started,
                 on_rebuild_failed=self._on_agent_rebuild_failed,
                 build_token=dispatchable_experts_token,
+                publish_build=publish_dispatchable_experts,
             )
             self._mcp_loader_widget: Any = None
             self._conversation_tid = thread_id_value
@@ -753,14 +757,11 @@ def run_textual_interactive(
             normally, so this is yellow rather than red and says what was
             actually lost. No loader widget to finish — ``_reload`` drives
             ``start`` directly and never mounts one.
-            """
-            from ..subagents.expert_container import rollback_dispatchable_memo
 
-            # The staleness probe already restamped the cue's memo with the
-            # set this rebuild was going to provide. Put back the set the
-            # still-seated agent was built from, so the expert prompt and the
-            # ``/expert`` popup don't offer something ``task`` can't route.
-            rollback_dispatchable_memo()
+            Nothing to undo here: the cue's memo and the ``/expert`` popup
+            are stamped from the build's success branch, which this rebuild
+            never reached, so both still describe the seated agent.
+            """
             self._append_system(
                 f"Couldn't pick up the new experts yet: {exc}. "
                 "Continuing with the current agent.",

--- a/EvoScientist/cli/tui_interactive.py
+++ b/EvoScientist/cli/tui_interactive.py
@@ -646,6 +646,7 @@ def run_textual_interactive(
                 on_progress=self._on_mcp_progress,
                 on_success=self._on_agent_load_success,
                 on_failure=self._on_agent_load_failure,
+                on_rebuild_failed=self._on_agent_rebuild_failed,
                 build_token=dispatchable_experts_token,
             )
             self._mcp_loader_widget: Any = None
@@ -731,6 +732,27 @@ def run_textual_interactive(
         def _on_agent_load_failure(self, exc: BaseException) -> None:
             self._append_system(f"Agent failed to load: {exc}", style="red")
             self._finish_loader_widget()
+
+        def _on_agent_rebuild_failed(self, exc: BaseException) -> None:
+            """Report a failed in-place rebuild without claiming the session died.
+
+            The previous agent is still seated and the next turn runs
+            normally, so this is yellow rather than red and says what was
+            actually lost. No loader widget to finish — ``_reload`` drives
+            ``start`` directly and never mounts one.
+            """
+            from ..subagents.expert_container import rollback_dispatchable_memo
+
+            # The staleness probe already restamped the cue's memo with the
+            # set this rebuild was going to provide. Put back the set the
+            # still-seated agent was built from, so the expert prompt and the
+            # ``/expert`` popup don't offer something ``task`` can't route.
+            rollback_dispatchable_memo()
+            self._append_system(
+                f"Couldn't pick up the new experts yet: {exc}. "
+                "Continuing with the current agent.",
+                style="yellow",
+            )
 
         def _start_background_agent_load(self, workspace: str | None) -> None:
             self._progress_tracker.prime()

--- a/EvoScientist/cli/tui_interactive.py
+++ b/EvoScientist/cli/tui_interactive.py
@@ -35,6 +35,7 @@ from ..gateway import (
 from ..paths import DATA_DIR
 from ..sessions import get_checkpointer
 from ..stream.state import ResearchPhase, StreamState
+from ..subagents.expert_container import dispatchable_experts_token
 from ._agent_loader import BackgroundAgentLoader, MCPProgressTracker
 from ._constants import (
     DANGEROUS_BANNER_LABEL,
@@ -635,11 +636,17 @@ def run_textual_interactive(
         ) -> None:
             super().__init__()
             self._progress_tracker = MCPProgressTracker()
+            # ``build_token`` makes an expert installed mid-session
+            # dispatchable on the next turn: the loader rebuilds the agent
+            # in place (same thread, same checkpointer) when the expert
+            # registry changes, so ``task`` / ``start_async_task`` can
+            # reach the new expert without ``/new``.
             self._agent_loader = BackgroundAgentLoader(
                 load_agent,
                 on_progress=self._on_mcp_progress,
                 on_success=self._on_agent_load_success,
                 on_failure=self._on_agent_load_failure,
+                build_token=dispatchable_experts_token,
             )
             self._mcp_loader_widget: Any = None
             self._conversation_tid = thread_id_value

--- a/EvoScientist/commands/implementation/experts.py
+++ b/EvoScientist/commands/implementation/experts.py
@@ -39,9 +39,12 @@ def _dispatchable_experts() -> list[SkillInfo]:
     the /expert popup and invite-accept path only ever surface names
     that will actually reach ``ActiveTeamMiddleware``'s cue.
 
-    ``list_dispatchable_experts`` memoises on ``skills_epoch()``, so the
-    popup stays responsive per keystroke and a freshly installed expert
-    appears without this module holding a second cache of its own.
+    ``list_dispatchable_experts`` is memoised, so the popup stays
+    responsive per keystroke without this module holding a second cache of
+    its own. The memo is restamped at every turn boundary by
+    ``dispatchable_experts_token``, so an expert that appeared mid-session
+    is offered here from the next turn on — whether it arrived by install
+    or was written straight onto the workspace skills tier.
     """
     try:
         from ...subagents.expert_container import list_dispatchable_experts

--- a/EvoScientist/commands/implementation/experts.py
+++ b/EvoScientist/commands/implementation/experts.py
@@ -41,10 +41,11 @@ def _dispatchable_experts() -> list[SkillInfo]:
 
     ``list_dispatchable_experts`` is memoised, so the popup stays
     responsive per keystroke without this module holding a second cache of
-    its own. The memo is restamped at every turn boundary by
-    ``dispatchable_experts_token``, so an expert that appeared mid-session
-    is offered here from the next turn on — whether it arrived by install
-    or was written straight onto the workspace skills tier.
+    its own. The memo is stamped by ``publish_dispatchable_experts`` once a
+    rebuild has produced an agent, so an expert that appeared mid-session is
+    offered here from the next turn on — whether it arrived by install or
+    was written straight onto the workspace skills tier — and a rebuild that
+    failed leaves the popup offering only what ``task`` can still reach.
     """
     try:
         from ...subagents.expert_container import list_dispatchable_experts

--- a/EvoScientist/commands/implementation/experts.py
+++ b/EvoScientist/commands/implementation/experts.py
@@ -29,56 +29,26 @@ from ..manager import manager
 if TYPE_CHECKING:
     from ...tools.skills_manager import SkillInfo
 
-_dispatchable_experts_cache: list[SkillInfo] | None = None
-
-
-def invalidate_experts_cache() -> None:
-    """Reset the /expert dispatchable-experts cache.
-
-    Called after ``install_skill`` / ``uninstall_skill`` mutations so a
-    freshly installed expert shows up in the /expert popup on the next
-    keystroke.
-    """
-    global _dispatchable_experts_cache
-    _dispatchable_experts_cache = None
-
-
-def _subscribe_cache_invalidation() -> None:
-    """Register with ``skills_manager`` so every install/uninstall path
-    (slash commands, agent ``skill_manager`` @tool, onboarding) busts
-    the /expert popup — no caller has to remember.
-    """
-    try:
-        from ...tools.skills_manager import register_skills_changed_callback
-
-        register_skills_changed_callback(invalidate_experts_cache)
-    except Exception:
-        # ``skills_manager`` not importable in some early-init contexts;
-        # cache staleness is a UX inconvenience, not a correctness bug.
-        pass
-
-
-_subscribe_cache_invalidation()
-
 
 def _dispatchable_experts() -> list[SkillInfo]:
-    """Cached list of experts that /expert can safely invite.
+    """Experts that /expert can safely invite.
 
     Filters ``list_expert_skills`` down to those that pass the same
     empty-body + name-collision guards ``build_expert_subagent_specs``
     and ``_fold_expert_subagents`` apply at agent-construction time, so
     the /expert popup and invite-accept path only ever surface names
     that will actually reach ``ActiveTeamMiddleware``'s cue.
-    """
-    global _dispatchable_experts_cache
-    if _dispatchable_experts_cache is None:
-        try:
-            from ...subagents.expert_container import list_dispatchable_experts
 
-            _dispatchable_experts_cache = list_dispatchable_experts(include_system=True)
-        except Exception:
-            return []
-    return _dispatchable_experts_cache
+    ``list_dispatchable_experts`` memoises on ``skills_epoch()``, so the
+    popup stays responsive per keystroke and a freshly installed expert
+    appears without this module holding a second cache of its own.
+    """
+    try:
+        from ...subagents.expert_container import list_dispatchable_experts
+
+        return list_dispatchable_experts(include_system=True)
+    except Exception:
+        return []
 
 
 class ExpertsCommand(Command):
@@ -224,12 +194,6 @@ class ExpertCommand(Command):
         else:
             runtime.active_teams = [*runtime.active_teams, target]
             ctx.ui.append_system(f"Invited expert: {target}", style="green")
-            # Case (c): expert was installed after agent construction, so it
-            # will not reach ``task()`` until the graph is rebuilt. Cheap
-            # always-print hint mirrors the /install-skill success message.
-            ctx.ui.append_system(
-                "If just installed, run /new to activate it.", style="dim"
-            )
         if runtime.active_teams:
             ctx.ui.append_system(
                 f"Active: {', '.join(runtime.active_teams)}", style="dim"

--- a/EvoScientist/langgraph_dev/__init__.py
+++ b/EvoScientist/langgraph_dev/__init__.py
@@ -5,7 +5,8 @@ Holds everything needed to run the EvoScientist agent ecosystem on a local
 
 - ``manager`` — subprocess lifecycle (auto-start, port management, cleanup).
 - ``langgraph.json`` — graph manifest consumed by ``langgraph dev --config``.
-- ``main_graph`` — re-export of the lazy-loaded ``EvoScientist_agent``.
+- ``main_graph`` — graph factory for the lazy-loaded ``EvoScientist_agent``,
+  rebuilt when the installed expert set changes.
 - ``graphs`` — module-level bindings for every yaml-flagged async sub-agent
   (``async: true`` in ``EvoScientist/subagents/<name>.yaml``).
 

--- a/EvoScientist/langgraph_dev/graphs.py
+++ b/EvoScientist/langgraph_dev/graphs.py
@@ -17,9 +17,10 @@ To add a new async sub-agent:
 
          "<name>": "EvoScientist.langgraph_dev.graphs:<snake_name>"
 
-The deployed main agent (``EvoScientist_agent``) lives in ``main_graph.py``
-because it follows a different mechanism (re-exporting a lazily-constructed
-attribute), not the yaml-driven factory.
+The deployed main agent lives in ``main_graph.py`` because it follows a
+different mechanism — a zero-arg graph factory (``make_EvoScientist_agent``)
+that langgraph-api invokes per request, so the agent can be rebuilt when the
+expert registry changes — not the yaml-driven factory below.
 """
 
 from EvoScientist.memory.agents import (

--- a/EvoScientist/langgraph_dev/http.py
+++ b/EvoScientist/langgraph_dev/http.py
@@ -23,6 +23,8 @@ memory.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -132,9 +134,29 @@ async def get_teams(_request: Request) -> JSONResponse:
     return JSONResponse({"teams": teams})
 
 
+@asynccontextmanager
+async def _lifespan(app: Starlette) -> AsyncIterator[None]:
+    """Custom-app lifespan, merged with langgraph-api's own.
+
+    ``langgraph_api.server`` combines this with its base lifespan, so it is the
+    supported place to own a background task for the deploy process. It must be
+    ``lifespan=`` and not ``on_startup`` — ``validate_router_lifespan_hooks``
+    refuses to merge a router that declares those.
+
+    Imported here rather than at module scope so importing this module (to
+    resolve the ``http`` entry in ``langgraph.json``) does not pull in the
+    agent-build machinery.
+    """
+    from .registry_refresh import expert_registry_refresher
+
+    async with expert_registry_refresher(app):
+        yield
+
+
 app = Starlette(
     routes=[
         Route("/api/models", get_models, methods=["GET"]),
         Route("/api/teams", get_teams, methods=["GET"]),
-    ]
+    ],
+    lifespan=_lifespan,
 )

--- a/EvoScientist/langgraph_dev/langgraph.json
+++ b/EvoScientist/langgraph_dev/langgraph.json
@@ -1,7 +1,7 @@
 {
     "dependencies": ["."],
     "graphs": {
-        "EvoScientist": "EvoScientist.langgraph_dev.main_graph:EvoScientist_agent",
+        "EvoScientist": "EvoScientist.langgraph_dev.main_graph:make_EvoScientist_agent",
         "writing-agent": "EvoScientist.langgraph_dev.graphs:writing_agent",
         "data-analysis-agent": "EvoScientist.langgraph_dev.graphs:data_analysis_agent",
         "scheduler": "EvoScientist.langgraph_dev.graphs:scheduler",

--- a/EvoScientist/langgraph_dev/main_graph.py
+++ b/EvoScientist/langgraph_dev/main_graph.py
@@ -1,12 +1,21 @@
 """Deployed graph entry for the main EvoScientist agent.
 
-The main ``EvoScientist_agent`` is exposed via ``__getattr__`` lazy loading
-in ``EvoScientist/EvoScientist.py`` so it doesn't construct on plain
-``import EvoScientist``. ``langgraph dev`` 's symbol resolver inspects
-module attributes directly and doesn't trigger ``__getattr__``, so we
-re-export here to make it visible.
+Registered in ``langgraph.json`` as ``make_EvoScientist_agent`` — a
+zero-arg **graph factory**, not a compiled graph. langgraph-api collects a
+compiled graph into its ``GRAPHS`` registry once at startup and never
+re-reads the source module, but it calls a factory on every request
+(``langgraph_api.graph.get_graph`` → ``invoke_factory``). Since the deploy
+subprocess is launched ``--no-reload``, the factory is the only way an
+expert installed mid-session becomes dispatchable there without restarting
+the server: see ``EvoScientist.EvoScientist._get_default_agent``, which
+rebuilds itself when the expert registry changes and which the factory
+simply forwards to.
 
-Before re-export we upgrade the compiled graph's class in place to
+The agent itself is exposed via ``__getattr__`` lazy loading in
+``EvoScientist/EvoScientist.py`` so it doesn't construct on plain ``import
+EvoScientist``; the factory triggers that load.
+
+Before handing the graph over we upgrade its class in place to
 ``_EvoFilteredGraph``, which strips ``PrivateStateAttr``-marked fields
 (currently just ``_quickjs_snapshot_payload``) from ``get_state`` /
 ``get_state_history`` responses. Upstream ``langchain_quickjs`` annotates
@@ -18,10 +27,13 @@ closes the gap without touching the middleware's write path, preserving
 cross-turn REPL persistence as ``langchain-ai/deepagents#3064`` shipped it.
 """
 
+import logging
+import time
+
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import PregelTask, StateSnapshot
 
-from EvoScientist.EvoScientist import EvoScientist_agent as _agent
+_logger = logging.getLogger(__name__)
 
 _PRIVATE_STATE_FIELDS = frozenset({"_quickjs_snapshot_payload"})
 
@@ -182,12 +194,45 @@ class _EvoFilteredGraph(CompiledStateGraph):
             yield _strip_private(snap)
 
 
-# In-place ``__class__`` swap: the subclass adds only methods (no new
-# instance attributes) so the memory layout is identical and the swap is
-# safe. Constructing a fresh ``_EvoFilteredGraph`` via ``.copy()`` would
-# require reproducing the deep-agent build pipeline; the swap avoids that.
-_agent.__class__ = _EvoFilteredGraph
-EvoScientist_agent = _agent
+def make_EvoScientist_agent() -> CompiledStateGraph:
+    """Graph factory for the ``EvoScientist`` entry in ``langgraph.json``.
+
+    Called by langgraph-api on every request that touches the graph
+    (``get_graph`` → ``invoke_factory``), so it must be cheap in the steady
+    state and it must not do its own caching: ``_get_default_agent`` already
+    returns the same compiled object until the expert registry changes, at
+    which point it rebuilds. Adding a second cache here would only be able
+    to go stale.
+
+    The rebuild runs synchronously on the event loop, so the one request
+    following a ``skill_manager install <expert>`` pays for it. That is the
+    price of the guarantee this factory exists to provide — returning the
+    stale graph and rebuilding in the background would mean the very next
+    turn still can't reach the new expert. It is logged with its elapsed
+    time so the cost is visible rather than inferred.
+
+    Zero-arg on purpose: ``langgraph_api._factory_utils._classify_factory``
+    reads the signature, and any parameter would make it inject a config or
+    a ``ServerRuntime`` we have no use for.
+    """
+    started = time.perf_counter()
+    from EvoScientist.EvoScientist import _get_default_agent
+
+    agent = _get_default_agent()
+    # In-place ``__class__`` swap: the subclass adds only methods (no new
+    # instance attributes) so the memory layout is identical and the swap
+    # is safe. Constructing a fresh ``_EvoFilteredGraph`` via ``.copy()``
+    # would require reproducing the deep-agent build pipeline; the swap
+    # avoids that. Idempotent, so re-running it on the cached graph costs
+    # one ``isinstance`` check.
+    if not isinstance(agent, _EvoFilteredGraph):
+        agent.__class__ = _EvoFilteredGraph
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        _logger.info(
+            "Built the main EvoScientist graph in %.0f ms.",
+            elapsed_ms,
+        )
+    return agent
 
 
 def _apply_filter_to_all_registered_graphs() -> None:
@@ -202,13 +247,16 @@ def _apply_filter_to_all_registered_graphs() -> None:
 
     Async subagents get their own ``thread_id`` and their ``/threads/{id}/state``
     endpoint is served by their own compiled graph. Without swapping the
-    class on those graphs, the filter we applied to ``EvoScientist_agent``
-    doesn't reach that endpoint and any real code_interpreter touch inside
-    a subagent leaks the anchor snapshot verbatim.
+    class on those graphs, the filter ``make_EvoScientist_agent`` applies to
+    the main agent doesn't reach that endpoint and any real code_interpreter
+    touch inside a subagent leaks the anchor snapshot verbatim.
 
     Reads the graph registry straight from ``langgraph.json`` so a new
     subagent added to the config picks up the swap automatically — no
-    hardcoded list to keep in sync.
+    hardcoded list to keep in sync. The main agent's own entry resolves to
+    a factory rather than a compiled graph, so the ``isinstance`` guard
+    below skips it; ``make_EvoScientist_agent`` swaps it instead, on every
+    graph it returns.
 
     Idempotent (skips graphs already swapped) and safe on graphs that don't
     use the middleware — ``_strip_private`` returns snapshots unchanged when
@@ -244,5 +292,13 @@ def _apply_filter_to_all_registered_graphs() -> None:
 
 _apply_filter_to_all_registered_graphs()
 
+# Build the main agent eagerly, at import. langgraph-api imports this module
+# from a worker thread during startup (``_graph_from_spec`` runs under
+# ``run_in_executor``), so paying the ~1 s construction here keeps it off the
+# event loop and off the first request — the same startup profile this module
+# had before it became a factory. Every later call is a cache hit unless the
+# expert registry moved.
+make_EvoScientist_agent()
 
-__all__ = ["EvoScientist_agent"]
+
+__all__ = ["make_EvoScientist_agent"]

--- a/EvoScientist/langgraph_dev/main_graph.py
+++ b/EvoScientist/langgraph_dev/main_graph.py
@@ -205,12 +205,23 @@ def make_EvoScientist_agent() -> CompiledStateGraph:
 
     Steady-state cost is one skills-tree walk per request — what
     ``dispatchable_experts_token`` charges to answer "did the expert set
-    change?". The walk cannot be replaced by a cheaper counter: an expert
-    can be authored or edited straight onto the writable workspace skills
-    tier without ever calling ``install_skill``, and that is a first-class
-    flow (the agent itself writes there when asked for a new expert), not a
-    corner case. Before this factory existed the equivalent walk ran on
-    every *model call*, so this remains a large net reduction.
+    change?". Measured at ~16 ms warm for 11 installed skills, scaling
+    roughly linearly with that count. The walk cannot be replaced by a
+    cheaper counter: an expert can be authored or edited straight onto the
+    writable workspace skills tier without ever calling ``install_skill``,
+    and that is a first-class flow (the agent itself writes there when asked
+    for a new expert), not a corner case. Before this factory existed the
+    equivalent walk ran on every *model call*, so this remains a large net
+    reduction.
+
+    Note which requests pay it, because it is wider than run creation:
+    ``get_graph`` is also entered for read-only ``GET /threads/{id}/state``
+    and history, so idle polling now costs a walk where it previously cost
+    nothing. Cutting that down needs a content fingerprint cheap enough to
+    check per request (mtime + size over each skill's SKILL.md / AGENTS.md)
+    so the parse only runs when something moved — deliberately not attempted
+    here, since same-second edits and coarse timestamp granularity make it a
+    change that needs its own measurement.
 
     A rebuild runs synchronously on the event loop, so the first request
     after the expert set changes pays for it. That is the price of the
@@ -289,7 +300,19 @@ def _apply_filter_to_all_registered_graphs() -> None:
         module_path, attr = path.rsplit(":", 1)
         try:
             module = import_module(module_path)
-        except ImportError:
+        except Exception:
+            # Broader than ImportError on purpose: these modules build their
+            # graphs at import (``graphs.py`` constructs every yaml sub-agent
+            # at module scope), so a missing API key or a malformed subagent
+            # surfaces here as a ValidationError, not an import error. Only
+            # ImportError was caught, which made the "best-effort" promise
+            # above false for the failure that actually happens.
+            _logger.debug(
+                "Could not import %r to apply the snapshot filter; leaving it "
+                "unfiltered.",
+                module_path,
+                exc_info=True,
+            )
             continue
         graph = getattr(module, attr, None)
         if isinstance(graph, CompiledStateGraph) and not isinstance(
@@ -306,7 +329,20 @@ _apply_filter_to_all_registered_graphs()
 # event loop and off the first request — the same startup profile this module
 # had before it became a factory. Every later call is a cache hit unless the
 # expert registry moved.
-make_EvoScientist_agent()
+#
+# Guarded because this is a warm-up, not the build of record. Letting it
+# propagate would turn any transient construction failure into a
+# ``GraphLoadError`` that stops the dev server outright, when the factory
+# would simply retry on the first request. It also keeps importing this
+# module — to check the ``langgraph.json`` contract, say — from requiring a
+# working model configuration.
+try:
+    make_EvoScientist_agent()
+except Exception:
+    _logger.exception(
+        "Eager main-agent build at import failed; deferring to the first "
+        "request through make_EvoScientist_agent()."
+    )
 
 
 __all__ = ["make_EvoScientist_agent"]

--- a/EvoScientist/langgraph_dev/main_graph.py
+++ b/EvoScientist/langgraph_dev/main_graph.py
@@ -198,18 +198,26 @@ def make_EvoScientist_agent() -> CompiledStateGraph:
     """Graph factory for the ``EvoScientist`` entry in ``langgraph.json``.
 
     Called by langgraph-api on every request that touches the graph
-    (``get_graph`` → ``invoke_factory``), so it must be cheap in the steady
-    state and it must not do its own caching: ``_get_default_agent`` already
-    returns the same compiled object until the expert registry changes, at
-    which point it rebuilds. Adding a second cache here would only be able
-    to go stale.
+    (``get_graph`` → ``invoke_factory``), and it must not do its own
+    caching: ``_get_default_agent`` already returns the same compiled
+    object until the expert registry changes, at which point it rebuilds.
+    Adding a second cache here would only be able to go stale.
 
-    The rebuild runs synchronously on the event loop, so the one request
-    following a ``skill_manager install <expert>`` pays for it. That is the
-    price of the guarantee this factory exists to provide — returning the
-    stale graph and rebuilding in the background would mean the very next
-    turn still can't reach the new expert. It is logged with its elapsed
-    time so the cost is visible rather than inferred.
+    Steady-state cost is one skills-tree walk per request — what
+    ``dispatchable_experts_token`` charges to answer "did the expert set
+    change?". The walk cannot be replaced by a cheaper counter: an expert
+    can be authored or edited straight onto the writable workspace skills
+    tier without ever calling ``install_skill``, and that is a first-class
+    flow (the agent itself writes there when asked for a new expert), not a
+    corner case. Before this factory existed the equivalent walk ran on
+    every *model call*, so this remains a large net reduction.
+
+    A rebuild runs synchronously on the event loop, so the first request
+    after the expert set changes pays for it. That is the price of the
+    guarantee this factory exists to provide — returning the stale graph
+    and rebuilding in the background would mean the very next turn still
+    can't reach the new expert. It is logged with its elapsed time so the
+    cost is visible rather than inferred.
 
     Zero-arg on purpose: ``langgraph_api._factory_utils._classify_factory``
     reads the signature, and any parameter would make it inject a config or

--- a/EvoScientist/langgraph_dev/main_graph.py
+++ b/EvoScientist/langgraph_dev/main_graph.py
@@ -35,6 +35,11 @@ from langgraph.types import PregelTask, StateSnapshot
 
 _logger = logging.getLogger(__name__)
 
+# The graph ``make_EvoScientist_agent`` hands langgraph-api. Written only by
+# ``refresh_main_graph`` — from the import-time warm-up and from the background
+# refresher — so the request path never has to decide whether it is current.
+_current_graph: CompiledStateGraph | None = None
+
 _PRIVATE_STATE_FIELDS = frozenset({"_quickjs_snapshot_payload"})
 
 # Sanity check on the LangGraph internals ``_strip_private`` scrubs. If any
@@ -197,43 +202,53 @@ class _EvoFilteredGraph(CompiledStateGraph):
 def make_EvoScientist_agent() -> CompiledStateGraph:
     """Graph factory for the ``EvoScientist`` entry in ``langgraph.json``.
 
-    Called by langgraph-api on every request that touches the graph
-    (``get_graph`` → ``invoke_factory``), and it must not do its own
-    caching: ``_get_default_agent`` already returns the same compiled
-    object until the expert registry changes, at which point it rebuilds.
-    Adding a second cache here would only be able to go stale.
+    Returns the graph most recently published by ``refresh_main_graph`` and
+    does nothing else. No token read, no filesystem access, no thread hop —
+    which is the whole point.
 
-    Steady-state cost is one skills-tree walk per request — what
-    ``dispatchable_experts_token`` charges to answer "did the expert set
-    change?". Measured at ~16 ms warm for 11 installed skills, scaling
-    roughly linearly with that count. The walk cannot be replaced by a
-    cheaper counter: an expert can be authored or edited straight onto the
-    writable workspace skills tier without ever calling ``install_skill``,
-    and that is a first-class flow (the agent itself writes there when asked
-    for a new expert), not a corner case. Before this factory existed the
-    equivalent walk ran on every *model call*, so this remains a large net
-    reduction.
+    langgraph-api calls this on **every** request that touches the graph
+    (``get_graph`` → ``invoke_factory``), and that is wider than run
+    creation: read-only ``GET /threads/{id}/state`` and history enter it
+    too. Any real work here is therefore paid per idle poll. Worse, it runs
+    on the event loop, where langgraph-dev's blockbuster guard turns a
+    filesystem call into a raised ``BlockingError`` rather than a slow
+    request — so a staleness check here does not merely cost time, it fails.
 
-    Note which requests pay it, because it is wider than run creation:
-    ``get_graph`` is also entered for read-only ``GET /threads/{id}/state``
-    and history, so idle polling now costs a walk where it previously cost
-    nothing. Cutting that down needs a content fingerprint cheap enough to
-    check per request (mtime + size over each skill's SKILL.md / AGENTS.md)
-    so the parse only runs when something moved — deliberately not attempted
-    here, since same-second edits and coarse timestamp granularity make it a
-    change that needs its own measurement.
-
-    A rebuild runs synchronously on the event loop, so the first request
-    after the expert set changes pays for it. That is the price of the
-    guarantee this factory exists to provide — returning the stale graph
-    and rebuilding in the background would mean the very next turn still
-    can't reach the new expert. It is logged with its elapsed time so the
-    cost is visible rather than inferred.
+    Keeping the graph current is instead the job of
+    ``registry_refresh.expert_registry_refresher``, a background task that
+    rebuilds off-request and publishes the result here. See that module for
+    why the check is both pushed and polled.
 
     Zero-arg on purpose: ``langgraph_api._factory_utils._classify_factory``
     reads the signature, and any parameter would make it inject a config or
     a ``ServerRuntime`` we have no use for.
     """
+    if _current_graph is None:
+        # The import-time warm-up below is guarded, so this is reachable when
+        # that build failed. Raising keeps the blocking build off the loop;
+        # the refresher's startup pass retries and the next request succeeds.
+        raise RuntimeError(
+            "The EvoScientist graph is not built yet. The import-time build "
+            "failed; the background refresher will retry shortly."
+        )
+    return _current_graph
+
+
+def refresh_main_graph() -> CompiledStateGraph:
+    """Rebuild if the expert registry moved, publish, and return the graph.
+
+    Blocking by nature — ``_get_default_agent`` walks the skills tree and may
+    construct a whole agent. Callers are the import-time warm-up (which
+    langgraph-api already runs in an executor thread) and the background
+    refresher (which hands it to ``asyncio.to_thread``). Never call it from
+    the request path.
+
+    Publishing last means a failed rebuild leaves the previous graph serving:
+    ``_get_default_agent`` re-seats its own previous agent and returns it, so
+    the assignment below is a no-op rather than a downgrade.
+    """
+    global _current_graph
+
     started = time.perf_counter()
     from EvoScientist.EvoScientist import _get_default_agent
 
@@ -251,6 +266,7 @@ def make_EvoScientist_agent() -> CompiledStateGraph:
             "Built the main EvoScientist graph in %.0f ms.",
             elapsed_ms,
         )
+    _current_graph = agent
     return agent
 
 
@@ -323,26 +339,25 @@ def _apply_filter_to_all_registered_graphs() -> None:
 
 _apply_filter_to_all_registered_graphs()
 
-# Build the main agent eagerly, at import. langgraph-api imports this module
-# from a worker thread during startup (``_graph_from_spec`` runs under
-# ``run_in_executor``), so paying the ~1 s construction here keeps it off the
-# event loop and off the first request — the same startup profile this module
-# had before it became a factory. Every later call is a cache hit unless the
-# expert registry moved.
+# Build and publish the main agent eagerly, at import. langgraph-api imports
+# this module from a worker thread during startup (``_graph_from_spec`` runs
+# under ``run_in_executor``), so the construction is off the event loop here
+# and off the first request. Without it the first request would find
+# ``_current_graph`` unset and fail until the refresher's startup pass landed.
 #
 # Guarded because this is a warm-up, not the build of record. Letting it
 # propagate would turn any transient construction failure into a
-# ``GraphLoadError`` that stops the dev server outright, when the factory
-# would simply retry on the first request. It also keeps importing this
+# ``GraphLoadError`` that stops the dev server outright, when the background
+# refresher's startup pass would simply retry. It also keeps importing this
 # module — to check the ``langgraph.json`` contract, say — from requiring a
 # working model configuration.
 try:
-    make_EvoScientist_agent()
+    refresh_main_graph()
 except Exception:
     _logger.exception(
-        "Eager main-agent build at import failed; deferring to the first "
-        "request through make_EvoScientist_agent()."
+        "Eager main-agent build at import failed; the background refresher "
+        "will retry on startup."
     )
 
 
-__all__ = ["make_EvoScientist_agent"]
+__all__ = ["make_EvoScientist_agent", "refresh_main_graph"]

--- a/EvoScientist/langgraph_dev/registry_refresh.py
+++ b/EvoScientist/langgraph_dev/registry_refresh.py
@@ -1,0 +1,156 @@
+"""Background refresh of the deployed main agent's expert registry.
+
+``task`` and ``start_async_task`` resolve ``subagent_type`` against dicts frozen
+inside ``create_deep_agent``, so an expert that appears after the agent was built
+is unreachable until it is rebuilt. In the CLI/TUI that rebuild happens at a turn
+boundary (``cli/_agent_loader.py``). The deployed graph has no turn boundary to
+hang it on, and the request path is the wrong place for it twice over: the work
+is blocking, which langgraph-dev's blockbuster guard turns into a raised
+``BlockingError`` rather than a slow request, and a rebuild takes seconds, which
+would stall an unrelated ``GET /threads/{id}/state``.
+
+So the check runs here instead, off-request, and publishes through
+``main_graph.refresh_main_graph``. The request path becomes a cached-object
+return.
+
+**Why both pushed and polled.** Only ``install_skill`` and ``uninstall_skill``
+publish through ``skills_manager._notify_skills_changed``. Every other way an
+expert can appear is silent:
+
+- the sandbox shell — ``CompositeBackend.execute`` is not path-routed, and
+  ``USER_SKILLS_DIR`` defaults to ``WORKSPACE_ROOT / "skills"``, so
+  ``mkdir skills/<name>`` is an ordinary in-workspace command no Python code sees;
+- autoskills proposal approval, which copies into ``USER_SKILLS_DIR`` directly;
+- ``write_file`` / ``edit_file`` onto the writable workspace tier, which
+  ``MergedSkillsBackend`` routes through three independent mutators with no shared
+  choke point;
+- anything edited by hand.
+
+Subscribing to the push hook alone would therefore catch skill *installs* and miss
+the agent authoring an expert, which is the case this feature exists to support.
+Polling alone would make every install wait out the interval. Together: installs
+take effect as soon as the rebuild finishes, and the silent paths within one poll.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+# How long to wait for a push before walking the tree anyway. Only bounds the
+# paths that emit no signal — install/uninstall wake the loop immediately. At
+# ~18 ms per walk this is well under 1% of one worker thread, and the walk runs
+# in a thread so it never touches the event loop.
+POLL_INTERVAL_SECONDS = 3.0
+
+
+def _is_deploy_mode() -> bool:
+    """True when this process serves the live main agent.
+
+    ``EvoSci deploy`` sets ``EVOSCIENTIST_DEPLOY_MODE=full``. Under ``EvoSci`` /
+    ``EvoSci serve`` it is ``stripped``: the agent lives in the parent CLI
+    process and the deployed main graph is dead code, so refreshing it would be
+    pure waste. Mirrors the gate in ``manager.py`` and ``EvoScientist.py``.
+    """
+    return os.environ.get("EVOSCIENTIST_DEPLOY_MODE", "").lower() == "full"
+
+
+async def _refresh_once(last_token: str | None) -> str | None:
+    """Detect a registry change and rebuild if there is one.
+
+    Returns the token to compare against next time. On failure returns
+    *last_token* unchanged, so the next pass retries rather than treating the
+    failed state as current.
+    """
+    from ..subagents.expert_container import dispatchable_experts_token
+
+    # ``restamp=False``: this is detection only. Restamping here would let the
+    # active-expert cue name the new expert for the whole rebuild, before
+    # ``task()`` can route to it. The rebuild restamps once it succeeds.
+    token = await asyncio.to_thread(dispatchable_experts_token, restamp=False)
+    if token == last_token:
+        return last_token
+
+    if last_token is not None:
+        _logger.info("Expert registry changed; rebuilding the deployed graph.")
+
+    from .main_graph import refresh_main_graph
+
+    await asyncio.to_thread(refresh_main_graph)
+    return token
+
+
+async def _refresh_loop(wake: asyncio.Event) -> None:
+    """Watch the expert registry until cancelled."""
+    last_token: str | None = None
+    while True:
+        try:
+            last_token = await _refresh_once(last_token)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Never let one bad pass end the watch — a half-written expert
+            # would otherwise disable refresh for the rest of the process.
+            # ``_get_default_agent`` keeps the previous agent seated, so the
+            # deployment stays usable; we simply try again next tick.
+            _logger.warning(
+                "Expert-registry refresh pass failed; keeping the current "
+                "graph and retrying.",
+                exc_info=True,
+            )
+        try:
+            await asyncio.wait_for(wake.wait(), timeout=POLL_INTERVAL_SECONDS)
+        except TimeoutError:
+            pass
+        wake.clear()
+
+
+@asynccontextmanager
+async def expert_registry_refresher(_app: Any = None) -> AsyncIterator[None]:
+    """Lifespan hook that keeps the deployed graph's expert set current.
+
+    Wired as ``Starlette(lifespan=...)`` on the custom app in ``http.py``.
+    langgraph-api merges that lifespan with its own; it must be a lifespan
+    context manager rather than ``on_startup``, which
+    ``langgraph_api.server.validate_router_lifespan_hooks`` rejects outright.
+    """
+    if not _is_deploy_mode():
+        yield
+        return
+
+    from ..tools.skills_manager import register_skills_changed_callback
+
+    loop = asyncio.get_running_loop()
+    wake = asyncio.Event()
+
+    def _on_skills_changed() -> None:
+        # Fires on a default-executor worker thread (the ``skill_manager``
+        # tool is a sync ``def``), where there is no running loop — so hop
+        # back rather than touching the Event directly.
+        loop.call_soon_threadsafe(wake.set)
+
+    # Process-scoped and never unregistered, which is fine: one refresher per
+    # process, and the callback only sets an Event.
+    register_skills_changed_callback(_on_skills_changed)
+
+    task = asyncio.create_task(
+        _refresh_loop(wake), name="evoscientist-expert-registry-refresh"
+    )
+    _logger.info(
+        "Watching the expert registry; polling every %.1fs plus immediate "
+        "wake-ups on skill install/uninstall.",
+        POLL_INTERVAL_SECONDS,
+    )
+    try:
+        yield
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/EvoScientist/langgraph_dev/registry_refresh.py
+++ b/EvoScientist/langgraph_dev/registry_refresh.py
@@ -71,10 +71,11 @@ async def _refresh_once(last_token: str | None) -> str | None:
     """
     from ..subagents.expert_container import dispatchable_experts_token
 
-    # ``restamp=False``: this is detection only. Restamping here would let the
-    # active-expert cue name the new expert for the whole rebuild, before
-    # ``task()`` can route to it. The rebuild restamps once it succeeds.
-    token = await asyncio.to_thread(dispatchable_experts_token, restamp=False)
+    # Detection only, and the token cannot stamp the cue's memo even if a
+    # caller wanted it to. ``refresh_main_graph`` -> ``_get_default_agent``
+    # stamps on its success branch, so the cue starts naming the new expert
+    # at the moment ``task()`` can route to it — not for the seconds before.
+    token = await asyncio.to_thread(dispatchable_experts_token)
     if token == last_token:
         return last_token
 
@@ -96,8 +97,9 @@ async def _refresh_loop(wake: asyncio.Event) -> None:
         except asyncio.CancelledError:
             raise
         except Exception:
-            # Never let one bad pass end the watch — a half-written expert
-            # would otherwise disable refresh for the rest of the process.
+            # Never let one bad pass end the watch — a transient failure in
+            # the surrounding build (backends against live paths, the chat
+            # model) would otherwise disable refresh for the whole process.
             # ``_get_default_agent`` keeps the previous agent seated, so the
             # deployment stays usable; we simply try again next tick.
             _logger.warning(

--- a/EvoScientist/middleware/active_team.py
+++ b/EvoScientist/middleware/active_team.py
@@ -102,19 +102,23 @@ def _dispatchable_names() -> set[str]:
     block the event loop.
 
     What makes the cue honest rather than merely current is that the memo
-    is restamped by ``expert_container.dispatchable_experts_token``, the
-    same read that decides whether to rebuild the agent (callers in
-    ``cli/_agent_loader.py`` / ``EvoScientist.py``). One skills-tree walk
-    feeds both, so by the time a turn reaches the model the running agent
-    was built from the very expert set this list reports. An expert
-    installed — or written straight onto the workspace skills tier —
+    is stamped by ``expert_container.publish_dispatchable_experts``, called
+    from the success branch of every agent build (``cli/_agent_loader.py``
+    and ``EvoScientist._get_default_agent``). So by the time a turn reaches
+    the model, the running agent was built from the very expert set this
+    list reports. An expert written straight onto the workspace skills tier
     mid-turn is named from the next turn on, the same turn it becomes
     dispatchable.
 
-    That holds on the failure branch too: a rebuild can fail after the
-    restamp, and the callers roll the memo back
-    (``expert_container.rollback_dispatchable_memo``) when it does, so this
-    never names an expert the still-seated agent cannot reach.
+    The failure branch needs no special handling: a rebuild that raises
+    never reaches the stamp, so this keeps reporting the set the seated
+    agent was built from rather than the one that failed to arrive.
+
+    One boundary: the memo's key is ``skills_epoch()``, which
+    ``install_skill`` advances. That invalidates the memo, so between an
+    install and the next build this reads through to a fresh walk and can
+    name the new expert a turn early. Tier writes never move the epoch, so
+    the agent-authors-an-expert path — the one this exists for — is exact.
 
     On import failure returns an empty set — the middleware then emits no
     cue, matching the outside-runnable-context no-op path.

--- a/EvoScientist/middleware/active_team.py
+++ b/EvoScientist/middleware/active_team.py
@@ -91,14 +91,23 @@ def _read_active_teams() -> list[str]:
 def _dispatchable_names() -> set[str]:
     """Return the names of experts the orchestrator can currently reach.
 
-    Fresh filesystem read every call so a ``skill_manager install <expert>``
-    is visible on the next turn without an agent rebuild. Cheap at current
-    scale (a handful of skills, cached bodies).
-
     Sourced from ``list_dispatchable_experts``, which drops empty-body
     experts and names colliding with reserved sub-agents. Keeps the cue
     honest: naming an expert the model cannot reach is worse than saying
     nothing.
+
+    That list is memoised on ``skills_epoch()``, so this is a dict lookup
+    on the steady-state model-call path rather than a skills-tree walk —
+    it runs inside ``awrap_model_call``, where synchronous filesystem and
+    YAML work would block the event loop.
+
+    The same epoch drives the agent rebuild (see
+    ``expert_container.dispatchable_experts_token`` and its callers in
+    ``cli/_agent_loader.py`` / ``EvoScientist.py``), which is what makes
+    the cue honest rather than merely current: by the time a turn reaches
+    the model, the running agent was built from the same expert set this
+    list reports. An expert installed mid-turn is named from the next turn
+    on — the turn where it also becomes dispatchable.
 
     On import failure returns an empty set — the middleware then emits no
     cue, matching the outside-runnable-context no-op path.

--- a/EvoScientist/middleware/active_team.py
+++ b/EvoScientist/middleware/active_team.py
@@ -105,11 +105,16 @@ def _dispatchable_names() -> set[str]:
     is restamped by ``expert_container.dispatchable_experts_token``, the
     same read that decides whether to rebuild the agent (callers in
     ``cli/_agent_loader.py`` / ``EvoScientist.py``). One skills-tree walk
-    per turn boundary feeds both, so by the time a turn reaches the model
-    the running agent was built from the very expert set this list
-    reports. An expert installed — or written straight onto the workspace
-    skills tier — mid-turn is named from the next turn on, the same turn
-    it becomes dispatchable.
+    feeds both, so by the time a turn reaches the model the running agent
+    was built from the very expert set this list reports. An expert
+    installed — or written straight onto the workspace skills tier —
+    mid-turn is named from the next turn on, the same turn it becomes
+    dispatchable.
+
+    That holds on the failure branch too: a rebuild can fail after the
+    restamp, and the callers roll the memo back
+    (``expert_container.rollback_dispatchable_memo``) when it does, so this
+    never names an expert the still-seated agent cannot reach.
 
     On import failure returns an empty set — the middleware then emits no
     cue, matching the outside-runnable-context no-op path.

--- a/EvoScientist/middleware/active_team.py
+++ b/EvoScientist/middleware/active_team.py
@@ -96,18 +96,20 @@ def _dispatchable_names() -> set[str]:
     honest: naming an expert the model cannot reach is worse than saying
     nothing.
 
-    That list is memoised on ``skills_epoch()``, so this is a dict lookup
-    on the steady-state model-call path rather than a skills-tree walk —
-    it runs inside ``awrap_model_call``, where synchronous filesystem and
-    YAML work would block the event loop.
+    That list is memoised, so this is a dict lookup on the steady-state
+    model-call path rather than a skills-tree walk — it runs inside
+    ``awrap_model_call``, where synchronous filesystem and YAML work would
+    block the event loop.
 
-    The same epoch drives the agent rebuild (see
-    ``expert_container.dispatchable_experts_token`` and its callers in
-    ``cli/_agent_loader.py`` / ``EvoScientist.py``), which is what makes
-    the cue honest rather than merely current: by the time a turn reaches
-    the model, the running agent was built from the same expert set this
-    list reports. An expert installed mid-turn is named from the next turn
-    on — the turn where it also becomes dispatchable.
+    What makes the cue honest rather than merely current is that the memo
+    is restamped by ``expert_container.dispatchable_experts_token``, the
+    same read that decides whether to rebuild the agent (callers in
+    ``cli/_agent_loader.py`` / ``EvoScientist.py``). One skills-tree walk
+    per turn boundary feeds both, so by the time a turn reaches the model
+    the running agent was built from the very expert set this list
+    reports. An expert installed — or written straight onto the workspace
+    skills tier — mid-turn is named from the next turn on, the same turn
+    it becomes dispatchable.
 
     On import failure returns an empty set — the middleware then emits no
     cue, matching the outside-runnable-context no-op path.

--- a/EvoScientist/subagents/expert_container.py
+++ b/EvoScientist/subagents/expert_container.py
@@ -264,7 +264,9 @@ def rollback_dispatchable_memo() -> None:
     _dispatchable_cache_key, _dispatchable_cache_value = _dispatchable_memo_prev
 
 
-def _read_dispatchable_fresh(include_system: bool) -> list[SkillInfo]:
+def _read_dispatchable_fresh(
+    include_system: bool, *, restamp: bool = True
+) -> list[SkillInfo]:
     """Walk the skills tree, apply the dispatchability filters, restamp the memo.
 
     The single place the memo is written, so "which epoch is this list
@@ -279,6 +281,11 @@ def _read_dispatchable_fresh(include_system: bool) -> list[SkillInfo]:
     The displaced entry is kept in ``_dispatchable_memo_prev`` so a caller
     that walked in order to decide on a rebuild can undo this restamp if the
     rebuild fails; see ``rollback_dispatchable_memo``.
+
+    ``restamp=False`` walks without touching the memo at all. For a caller
+    that only wants to *detect* a change and will rebuild separately, that
+    is the difference between the cue naming a new expert immediately and
+    naming it once the agent can actually reach it.
     """
     global _dispatchable_cache_key, _dispatchable_cache_value
     global _dispatchable_memo_prev
@@ -296,6 +303,9 @@ def _read_dispatchable_fresh(include_system: bool) -> list[SkillInfo]:
         if info.name in reserved:
             continue
         dispatchable.append(info)
+
+    if not restamp:
+        return dispatchable
 
     _dispatchable_memo_prev = (_dispatchable_cache_key, _dispatchable_cache_value)
     # Value before key. A reader interleaving between these two writes then
@@ -347,7 +357,9 @@ def list_dispatchable_experts(
     return list(_read_dispatchable_fresh(include_system))
 
 
-def dispatchable_experts_token(*, include_system: bool = True) -> str:
+def dispatchable_experts_token(
+    *, include_system: bool = True, restamp: bool = True
+) -> str:
     """Fingerprint of the expert registry an agent would be built from.
 
     Answers one question for every cache of a *constructed* agent: would
@@ -387,17 +399,26 @@ def dispatchable_experts_token(*, include_system: bool = True) -> str:
     Without the walk, "write me an expert" would produce one the
     orchestrator could not dispatch to until ``/new``.
 
-    Costs one skills-tree walk per call, measured at ~16 ms warm for 11
-    installed skills and scaling roughly linearly with that count. Callers
-    are turn boundaries (CLI/TUI) and the WebUI graph factory, which pays it
-    per HTTP request including read-only state polls — never
-    ``awrap_model_call``, whose cue reads the memo this restamps.
+    Costs one skills-tree walk per call, measured at ~18 ms warm for 5
+    dispatchable experts and scaling roughly linearly with the installed
+    skill count. Callers are turn boundaries (CLI/TUI) and the WebUI's
+    background refresher — never ``awrap_model_call``, whose cue reads the
+    memo this restamps, and never the WebUI request path.
+
+    Blocking by nature (``iterdir`` plus SKILL.md / AGENTS.md parsing), so
+    every caller must keep it off an event loop. langgraph-dev installs a
+    blockbuster guard that turns a filesystem call on the loop into a raised
+    ``BlockingError``, not merely a slow request.
 
     Restamping the memo is a side effect, not incidental: it is what keeps
-    the cue reporting the same set the rebuild decision was made on. A
+    the cue reporting the same set the rebuild decision was made on, and a
     caller whose rebuild then fails must call ``rollback_dispatchable_memo``.
+    Pass ``restamp=False`` when only *detecting* a change: the rebuild that
+    follows is what makes the new expert reachable and can take seconds,
+    during which a restamped memo would have the cue naming an expert
+    ``task()`` cannot route to. The rebuild path restamps on its own.
     """
-    experts = _read_dispatchable_fresh(include_system)
+    experts = _read_dispatchable_fresh(include_system, restamp=restamp)
 
     digest = hashlib.sha256()
     # Sorted so filesystem iteration order can't produce a spurious change.

--- a/EvoScientist/subagents/expert_container.py
+++ b/EvoScientist/subagents/expert_container.py
@@ -199,18 +199,23 @@ def _reserved_subagent_names() -> frozenset[str]:
     return _reserved_subagent_names_cache
 
 
-# Epoch-keyed memo for ``list_dispatchable_experts`` and the token derived
-# from it. Keyed on ``(skills_epoch(), include_system)``: an entry stays
-# valid until a skill is installed or uninstalled, which is the only way
-# the dispatchable set can change through a supported path.
+# Epoch-keyed memo for ``list_dispatchable_experts``. Keyed on
+# ``(skills_epoch(), include_system)``, so an entry survives until a skill
+# is installed or uninstalled.
 #
-# The cache exists because the active-expert cue reads this list on EVERY
-# model call, including inside ``awrap_model_call``. Uncached, that is a
-# full ``iterdir`` + SKILL.md parse of the skills tree on the async
-# model-call path.
+# The memo exists for one reader: the active-expert cue calls
+# ``list_dispatchable_experts`` on EVERY model call, including inside
+# ``awrap_model_call``. Uncached, that is a full ``iterdir`` + SKILL.md
+# parse of the skills tree on the async model-call path.
+#
+# It is deliberately NOT the source for ``dispatchable_experts_token`` —
+# the epoch only moves on install/uninstall, and an expert can also be
+# authored or edited straight onto the writable workspace skills tier
+# (``MergedSkillsBackend`` routes the agent's own ``write``/``edit`` there).
+# The token walks the tree itself so those edits are seen; see
+# ``_read_dispatchable_fresh``.
 _dispatchable_cache_key: tuple[int, bool] | None = None
 _dispatchable_cache_value: list[SkillInfo] | None = None
-_dispatchable_cache_token: str | None = None
 
 
 def _reset_dispatchable_experts_cache() -> None:
@@ -222,10 +227,41 @@ def _reset_dispatchable_experts_cache() -> None:
     fixture in ``tests/conftest.py``).
     """
     global _dispatchable_cache_key, _dispatchable_cache_value
-    global _dispatchable_cache_token
     _dispatchable_cache_key = None
     _dispatchable_cache_value = None
-    _dispatchable_cache_token = None
+
+
+def _read_dispatchable_fresh(include_system: bool) -> list[SkillInfo]:
+    """Walk the skills tree, apply the dispatchability filters, restamp the memo.
+
+    The single place the memo is written, so "which epoch is this list
+    from" is decided once rather than at each caller. Returns the live
+    list; callers that hand it out copy it first.
+
+    The epoch is read *before* the walk on purpose. An install landing
+    mid-walk then leaves the memo stamped with the superseded epoch, so
+    the next reader misses and re-walks — rather than a half-updated view
+    being served under the new key.
+    """
+    global _dispatchable_cache_key, _dispatchable_cache_value
+
+    from ..tools.skills_manager import list_expert_skills, skills_epoch
+
+    epoch = skills_epoch()
+    reserved = _reserved_subagent_names()
+    dispatchable: list[SkillInfo] = []
+    for info in list_expert_skills(include_system=include_system):
+        # Nothing to prompt the expert with.
+        if not expert_prompt_body(info).strip():
+            continue
+        # Would shadow a yaml sub-agent or ``general-purpose`` at fold time.
+        if info.name in reserved:
+            continue
+        dispatchable.append(info)
+
+    _dispatchable_cache_key = (epoch, include_system)
+    _dispatchable_cache_value = dispatchable
+    return dispatchable
 
 
 def list_dispatchable_experts(
@@ -248,35 +284,22 @@ def list_dispatchable_experts(
     returned list is a fresh copy so a caller sorting or filtering it in
     place can't corrupt the next reader's view.
 
+    The memo is also restamped by ``dispatchable_experts_token``, which
+    runs at every turn boundary, so a mid-run edit reaches this reader on
+    the next turn even though it never advanced the epoch.
+
     ``cfg`` is accepted and ignored; kept so callers that thread config
     through don't have to special-case this one. Read-only filter —
     construction-time warnings for empty-body / colliding experts are
     emitted by ``build_expert_subagent_specs`` and
     ``_fold_expert_subagents`` respectively, so nothing is logged here.
     """
-    global _dispatchable_cache_key, _dispatchable_cache_value
-    global _dispatchable_cache_token
-
-    from ..tools.skills_manager import list_expert_skills, skills_epoch
+    from ..tools.skills_manager import skills_epoch
 
     key = (skills_epoch(), include_system)
     if key == _dispatchable_cache_key and _dispatchable_cache_value is not None:
         return list(_dispatchable_cache_value)
-
-    reserved = _reserved_subagent_names()
-    dispatchable: list[SkillInfo] = []
-    for info in list_expert_skills(include_system=include_system):
-        if not expert_prompt_body(info).strip():
-            continue
-        if info.name in reserved:
-            continue
-        dispatchable.append(info)
-
-    _dispatchable_cache_key = key
-    _dispatchable_cache_value = dispatchable
-    # Recomputed lazily by ``dispatchable_experts_token`` under the new key.
-    _dispatchable_cache_token = None
-    return list(dispatchable)
+    return list(_read_dispatchable_fresh(include_system))
 
 
 def dispatchable_experts_token(*, include_system: bool = True) -> str:
@@ -298,15 +321,20 @@ def dispatchable_experts_token(*, include_system: bool = True) -> str:
     a skills-tree walk rather than a full agent rebuild. Utility skills
     are already live through the ``/skills/`` mount and need no rebuild.
 
-    Memoised on the same epoch key as ``list_dispatchable_experts``, whose
-    cached ``SkillInfo`` bodies it reads — so a steady-state call does no
-    disk I/O.
-    """
-    global _dispatchable_cache_token
+    Deliberately *wider* than the epoch in the other direction: this walks
+    the skills tree rather than reading the epoch-keyed memo, so it also
+    sees an expert authored or edited straight onto the workspace skills
+    tier. That tier is writable precisely so the agent can author there
+    (``backends.MergedSkillsBackend`` routes ``write``/``edit`` to it), and
+    such a change never calls ``install_skill``, so the epoch never moves.
+    Without the walk, "write me an expert" would produce one the
+    orchestrator could not dispatch to until ``/new``.
 
-    experts = list_dispatchable_experts(include_system=include_system)
-    if _dispatchable_cache_token is not None:
-        return _dispatchable_cache_token
+    Costs one skills-tree walk per call. Callers are turn boundaries and
+    the WebUI graph factory — never ``awrap_model_call``, whose cue reads
+    the memo this restamps.
+    """
+    experts = _read_dispatchable_fresh(include_system)
 
     digest = hashlib.sha256()
     # Sorted so filesystem iteration order can't produce a spurious change.
@@ -315,8 +343,7 @@ def dispatchable_experts_token(*, include_system: bool = True) -> str:
         digest.update(b"\0")
         digest.update(expert_prompt_body(info).encode("utf-8"))
         digest.update(b"\0")
-    _dispatchable_cache_token = digest.hexdigest()
-    return _dispatchable_cache_token
+    return digest.hexdigest()
 
 
 def build_expert_subagent_specs(

--- a/EvoScientist/subagents/expert_container.py
+++ b/EvoScientist/subagents/expert_container.py
@@ -22,6 +22,7 @@ rather than a per-expert YAML.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import Any
 
@@ -198,6 +199,35 @@ def _reserved_subagent_names() -> frozenset[str]:
     return _reserved_subagent_names_cache
 
 
+# Epoch-keyed memo for ``list_dispatchable_experts`` and the token derived
+# from it. Keyed on ``(skills_epoch(), include_system)``: an entry stays
+# valid until a skill is installed or uninstalled, which is the only way
+# the dispatchable set can change through a supported path.
+#
+# The cache exists because the active-expert cue reads this list on EVERY
+# model call, including inside ``awrap_model_call``. Uncached, that is a
+# full ``iterdir`` + SKILL.md parse of the skills tree on the async
+# model-call path.
+_dispatchable_cache_key: tuple[int, bool] | None = None
+_dispatchable_cache_value: list[SkillInfo] | None = None
+_dispatchable_cache_token: str | None = None
+
+
+def _reset_dispatchable_experts_cache() -> None:
+    """Test hook: drop the epoch-keyed dispatchable-experts memo.
+
+    Production code never needs this — the epoch key invalidates itself.
+    Tests that patch ``list_expert_skills`` mutate the skill set without
+    touching the epoch, so they must reset explicitly (see the autouse
+    fixture in ``tests/conftest.py``).
+    """
+    global _dispatchable_cache_key, _dispatchable_cache_value
+    global _dispatchable_cache_token
+    _dispatchable_cache_key = None
+    _dispatchable_cache_value = None
+    _dispatchable_cache_token = None
+
+
 def list_dispatchable_experts(
     *, include_system: bool = True, cfg: Any | None = None
 ) -> list[SkillInfo]:
@@ -214,13 +244,24 @@ def list_dispatchable_experts(
     failure mode that made installed experts vanish whenever langgraph
     dev was unhealthy.
 
+    Memoised on ``skills_epoch()`` — see ``_dispatchable_cache_key``. The
+    returned list is a fresh copy so a caller sorting or filtering it in
+    place can't corrupt the next reader's view.
+
     ``cfg`` is accepted and ignored; kept so callers that thread config
     through don't have to special-case this one. Read-only filter —
     construction-time warnings for empty-body / colliding experts are
     emitted by ``build_expert_subagent_specs`` and
     ``_fold_expert_subagents`` respectively, so nothing is logged here.
     """
-    from ..tools.skills_manager import list_expert_skills
+    global _dispatchable_cache_key, _dispatchable_cache_value
+    global _dispatchable_cache_token
+
+    from ..tools.skills_manager import list_expert_skills, skills_epoch
+
+    key = (skills_epoch(), include_system)
+    if key == _dispatchable_cache_key and _dispatchable_cache_value is not None:
+        return list(_dispatchable_cache_value)
 
     reserved = _reserved_subagent_names()
     dispatchable: list[SkillInfo] = []
@@ -230,7 +271,52 @@ def list_dispatchable_experts(
         if info.name in reserved:
             continue
         dispatchable.append(info)
-    return dispatchable
+
+    _dispatchable_cache_key = key
+    _dispatchable_cache_value = dispatchable
+    # Recomputed lazily by ``dispatchable_experts_token`` under the new key.
+    _dispatchable_cache_token = None
+    return list(dispatchable)
+
+
+def dispatchable_experts_token(*, include_system: bool = True) -> str:
+    """Fingerprint of the expert registry an agent would be built from.
+
+    Answers one question for every cache of a *constructed* agent: would
+    rebuilding right now change which experts ``task`` / ``start_async_task``
+    can reach, or what any of them is prompted with? Callers hold the
+    previous value and rebuild when it differs.
+
+    Covers name and actor definition, because both are baked into the
+    frozen in-turn spec at ``create_deep_agent`` time
+    (``build_expert_subagent_spec`` bakes ``system_prompt``). Hashing the
+    body — not just the name set — is what makes a reinstall that only
+    edits an expert's AGENTS.md refresh the stale sync spec.
+
+    Deliberately narrower than ``skills_epoch()``: installing a utility
+    skill advances the epoch but leaves this token unchanged, so it costs
+    a skills-tree walk rather than a full agent rebuild. Utility skills
+    are already live through the ``/skills/`` mount and need no rebuild.
+
+    Memoised on the same epoch key as ``list_dispatchable_experts``, whose
+    cached ``SkillInfo`` bodies it reads — so a steady-state call does no
+    disk I/O.
+    """
+    global _dispatchable_cache_token
+
+    experts = list_dispatchable_experts(include_system=include_system)
+    if _dispatchable_cache_token is not None:
+        return _dispatchable_cache_token
+
+    digest = hashlib.sha256()
+    # Sorted so filesystem iteration order can't produce a spurious change.
+    for info in sorted(experts, key=lambda s: s.name):
+        digest.update(info.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(expert_prompt_body(info).encode("utf-8"))
+        digest.update(b"\0")
+    _dispatchable_cache_token = digest.hexdigest()
+    return _dispatchable_cache_token
 
 
 def build_expert_subagent_specs(

--- a/EvoScientist/subagents/expert_container.py
+++ b/EvoScientist/subagents/expert_container.py
@@ -199,16 +199,19 @@ def _reserved_subagent_names() -> frozenset[str]:
     return _reserved_subagent_names_cache
 
 
-# Epoch-keyed memo for ``list_dispatchable_experts``. Keyed on
-# ``(skills_epoch(), include_system)``, so an entry survives until a skill
-# is installed or uninstalled.
+# Memo for ``list_dispatchable_experts``, keyed on
+# ``(skills_epoch(), include_system)``. The epoch invalidates it on
+# install/uninstall; ``dispatchable_experts_token`` overwrites it outright on
+# every call, regardless of epoch, which is what lets an edit that never
+# touched the install path reach the readers below.
 #
-# The memo exists for one reader: the active-expert cue calls
-# ``list_dispatchable_experts`` on EVERY model call, including inside
-# ``awrap_model_call``. Uncached, that is a full ``iterdir`` + SKILL.md
-# parse of the skills tree on the async model-call path.
+# Two readers, both of which would otherwise walk the skills tree:
+# the active-expert cue (``middleware/active_team.py``) on EVERY model call,
+# including inside ``awrap_model_call``, and the ``/expert`` popup
+# (``commands/implementation/experts.py``) per keystroke. Uncached, the first
+# of those is a full ``iterdir`` + SKILL.md parse on the async model-call path.
 #
-# It is deliberately NOT the source for ``dispatchable_experts_token`` —
+# The memo is deliberately NOT the source for ``dispatchable_experts_token``:
 # the epoch only moves on install/uninstall, and an expert can also be
 # authored or edited straight onto the writable workspace skills tier
 # (``MergedSkillsBackend`` routes the agent's own ``write``/``edit`` there).
@@ -217,18 +220,48 @@ def _reserved_subagent_names() -> frozenset[str]:
 _dispatchable_cache_key: tuple[int, bool] | None = None
 _dispatchable_cache_value: list[SkillInfo] | None = None
 
+# The memo entry displaced by the most recent ``_read_dispatchable_fresh``.
+# Exists so a caller that walked the tree in order to DECIDE on a rebuild can
+# undo the restamp when that rebuild fails — see ``rollback_dispatchable_memo``.
+_dispatchable_memo_prev: tuple[tuple[int, bool] | None, list[SkillInfo] | None] = (
+    None,
+    None,
+)
+
 
 def _reset_dispatchable_experts_cache() -> None:
-    """Test hook: drop the epoch-keyed dispatchable-experts memo.
+    """Test hook: drop the dispatchable-experts memo and its rollback slot.
 
-    Production code never needs this — the epoch key invalidates itself.
-    Tests that patch ``list_expert_skills`` mutate the skill set without
-    touching the epoch, so they must reset explicitly (see the autouse
-    fixture in ``tests/conftest.py``).
+    Production code never needs this — the epoch key invalidates itself and
+    the token overwrites it. Tests that patch ``list_expert_skills`` mutate
+    the skill set without touching the epoch, so they must reset explicitly
+    (see the autouse fixture in ``tests/conftest.py``).
     """
     global _dispatchable_cache_key, _dispatchable_cache_value
+    global _dispatchable_memo_prev
     _dispatchable_cache_key = None
     _dispatchable_cache_value = None
+    _dispatchable_memo_prev = (None, None)
+
+
+def rollback_dispatchable_memo() -> None:
+    """Undo the most recent memo restamp.
+
+    ``dispatchable_experts_token`` restamps the memo at the moment a caller
+    decides *whether* to rebuild, which is necessarily before it knows the
+    rebuild succeeded. When it did not, the readers above would otherwise
+    advertise an expert the still-seated agent cannot dispatch to — the exact
+    advertise-versus-provide divergence this module exists to close, just on
+    the failure branch.
+
+    Callers on a rebuild-failure path call this to restore the set the seated
+    agent was actually built from. Idempotent in the sense that rolling back
+    twice restores the same entry; the displaced value is not itself stacked,
+    so only one level of undo is available. That is enough: every caller
+    walks, decides, and rebuilds without yielding in between.
+    """
+    global _dispatchable_cache_key, _dispatchable_cache_value
+    _dispatchable_cache_key, _dispatchable_cache_value = _dispatchable_memo_prev
 
 
 def _read_dispatchable_fresh(include_system: bool) -> list[SkillInfo]:
@@ -242,8 +275,13 @@ def _read_dispatchable_fresh(include_system: bool) -> list[SkillInfo]:
     mid-walk then leaves the memo stamped with the superseded epoch, so
     the next reader misses and re-walks — rather than a half-updated view
     being served under the new key.
+
+    The displaced entry is kept in ``_dispatchable_memo_prev`` so a caller
+    that walked in order to decide on a rebuild can undo this restamp if the
+    rebuild fails; see ``rollback_dispatchable_memo``.
     """
     global _dispatchable_cache_key, _dispatchable_cache_value
+    global _dispatchable_memo_prev
 
     from ..tools.skills_manager import list_expert_skills, skills_epoch
 
@@ -259,8 +297,12 @@ def _read_dispatchable_fresh(include_system: bool) -> list[SkillInfo]:
             continue
         dispatchable.append(info)
 
-    _dispatchable_cache_key = (epoch, include_system)
+    _dispatchable_memo_prev = (_dispatchable_cache_key, _dispatchable_cache_value)
+    # Value before key. A reader interleaving between these two writes then
+    # either misses (old key, cheap re-walk) or matches the old key and gets
+    # the fresher list — never the new key paired with the stale value.
     _dispatchable_cache_value = dispatchable
+    _dispatchable_cache_key = (epoch, include_system)
     return dispatchable
 
 
@@ -284,9 +326,12 @@ def list_dispatchable_experts(
     returned list is a fresh copy so a caller sorting or filtering it in
     place can't corrupt the next reader's view.
 
-    The memo is also restamped by ``dispatchable_experts_token``, which
-    runs at every turn boundary, so a mid-run edit reaches this reader on
-    the next turn even though it never advanced the epoch.
+    The memo is also restamped by ``dispatchable_experts_token`` — once per
+    turn boundary in the CLI/TUI, once per HTTP request in the WebUI — so a
+    mid-run edit reaches this reader without ever advancing the epoch. When
+    the rebuild that restamp was taken for fails, the caller rolls it back
+    (``rollback_dispatchable_memo``), so this never reports an expert the
+    seated agent cannot dispatch to.
 
     ``cfg`` is accepted and ignored; kept so callers that thread config
     through don't have to special-case this one. Read-only filter —
@@ -310,11 +355,23 @@ def dispatchable_experts_token(*, include_system: bool = True) -> str:
     can reach, or what any of them is prompted with? Callers hold the
     previous value and rebuild when it differs.
 
-    Covers name and actor definition, because both are baked into the
-    frozen in-turn spec at ``create_deep_agent`` time
-    (``build_expert_subagent_spec`` bakes ``system_prompt``). Hashing the
-    body — not just the name set — is what makes a reinstall that only
-    edits an expert's AGENTS.md refresh the stale sync spec.
+    Covers exactly the ``SkillInfo`` surface that gets frozen at
+    ``create_deep_agent`` time, which is three fields:
+
+    - ``name`` — the key in deepagents' ``subagent_graphs`` dict.
+    - ``description`` — baked into BOTH dispatch tools' schemas: deepagents
+      builds the ``task`` description from it, and
+      ``middleware/expert_async_subagent.py`` builds ``start_async_task``'s
+      the same way. An edited ``description:`` therefore leaves the model
+      reading a stale blurb on both reaches until a rebuild.
+    - the composed system prompt — ``_compose_system_prompt`` over the actor
+      body, which folds in ``role``. Composing rather than hashing the raw
+      body is what catches a ``role:`` edit on a legacy frontmatter expert.
+
+    Nothing else on ``SkillInfo`` reaches a frozen construct: ``byline``,
+    ``capability_tags``, ``avatar_hint``, ``tags`` and ``source`` are
+    WebUI/filter-only, and the async persona is re-resolved per model call by
+    ``expert_container_async.ExpertSkillLoaderMiddleware`` rather than baked.
 
     Deliberately narrower than ``skills_epoch()``: installing a utility
     skill advances the epoch but leaves this token unchanged, so it costs
@@ -330,9 +387,15 @@ def dispatchable_experts_token(*, include_system: bool = True) -> str:
     Without the walk, "write me an expert" would produce one the
     orchestrator could not dispatch to until ``/new``.
 
-    Costs one skills-tree walk per call. Callers are turn boundaries and
-    the WebUI graph factory — never ``awrap_model_call``, whose cue reads
-    the memo this restamps.
+    Costs one skills-tree walk per call, measured at ~16 ms warm for 11
+    installed skills and scaling roughly linearly with that count. Callers
+    are turn boundaries (CLI/TUI) and the WebUI graph factory, which pays it
+    per HTTP request including read-only state polls — never
+    ``awrap_model_call``, whose cue reads the memo this restamps.
+
+    Restamping the memo is a side effect, not incidental: it is what keeps
+    the cue reporting the same set the rebuild decision was made on. A
+    caller whose rebuild then fails must call ``rollback_dispatchable_memo``.
     """
     experts = _read_dispatchable_fresh(include_system)
 
@@ -341,7 +404,11 @@ def dispatchable_experts_token(*, include_system: bool = True) -> str:
     for info in sorted(experts, key=lambda s: s.name):
         digest.update(info.name.encode("utf-8"))
         digest.update(b"\0")
-        digest.update(expert_prompt_body(info).encode("utf-8"))
+        digest.update((info.description or "").encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(
+            _compose_system_prompt(info, expert_prompt_body(info)).encode("utf-8")
+        )
         digest.update(b"\0")
     return digest.hexdigest()
 

--- a/EvoScientist/subagents/expert_container.py
+++ b/EvoScientist/subagents/expert_container.py
@@ -201,9 +201,9 @@ def _reserved_subagent_names() -> frozenset[str]:
 
 # Memo for ``list_dispatchable_experts``, keyed on
 # ``(skills_epoch(), include_system)``. The epoch invalidates it on
-# install/uninstall; ``dispatchable_experts_token`` overwrites it outright on
-# every call, regardless of epoch, which is what lets an edit that never
-# touched the install path reach the readers below.
+# install/uninstall; ``publish_dispatchable_experts`` overwrites it outright,
+# regardless of epoch, which is what lets an edit that never touched the
+# install path reach the readers below.
 #
 # Two readers, both of which would otherwise walk the skills tree:
 # the active-expert cue (``middleware/active_team.py``) on EVERY model call,
@@ -220,48 +220,36 @@ def _reserved_subagent_names() -> frozenset[str]:
 _dispatchable_cache_key: tuple[int, bool] | None = None
 _dispatchable_cache_value: list[SkillInfo] | None = None
 
-# The memo entry displaced by the most recent ``_read_dispatchable_fresh``.
-# Exists so a caller that walked the tree in order to DECIDE on a rebuild can
-# undo the restamp when that rebuild fails — see ``rollback_dispatchable_memo``.
-_dispatchable_memo_prev: tuple[tuple[int, bool] | None, list[SkillInfo] | None] = (
-    None,
-    None,
-)
-
 
 def _reset_dispatchable_experts_cache() -> None:
-    """Test hook: drop the dispatchable-experts memo and its rollback slot.
+    """Test hook: drop the dispatchable-experts memo.
 
     Production code never needs this — the epoch key invalidates itself and
-    the token overwrites it. Tests that patch ``list_expert_skills`` mutate
-    the skill set without touching the epoch, so they must reset explicitly
-    (see the autouse fixture in ``tests/conftest.py``).
+    a successful build overwrites it. Tests that patch ``list_expert_skills``
+    mutate the skill set without touching the epoch, so they must reset
+    explicitly (see the autouse fixture in ``tests/conftest.py``).
     """
     global _dispatchable_cache_key, _dispatchable_cache_value
-    global _dispatchable_memo_prev
     _dispatchable_cache_key = None
     _dispatchable_cache_value = None
-    _dispatchable_memo_prev = (None, None)
 
 
-def rollback_dispatchable_memo() -> None:
-    """Undo the most recent memo restamp.
+def publish_dispatchable_experts(*, include_system: bool = True) -> None:
+    """Stamp the memo with the expert set a just-built agent can dispatch to.
 
-    ``dispatchable_experts_token`` restamps the memo at the moment a caller
-    decides *whether* to rebuild, which is necessarily before it knows the
-    rebuild succeeded. When it did not, the readers above would otherwise
-    advertise an expert the still-seated agent cannot dispatch to — the exact
-    advertise-versus-provide divergence this module exists to close, just on
-    the failure branch.
+    Called from the success branch of every agent build — the CLI/TUI loader
+    (``cli/_agent_loader.py``), and ``EvoScientist._get_default_agent`` for the
+    deployed graph. Nowhere else writes the memo on behalf of a build, so a
+    build that raises leaves the readers reporting the set the still-seated
+    agent was actually constructed from. There is no failure branch to get
+    right because a failed build simply never reaches this call.
 
-    Callers on a rebuild-failure path call this to restore the set the seated
-    agent was actually built from. Idempotent in the sense that rolling back
-    twice restores the same entry; the displaced value is not itself stacked,
-    so only one level of undo is available. That is enough: every caller
-    walks, decides, and rebuilds without yielding in between.
+    Costs one skills-tree walk (~18 ms for a dozen skills) against a rebuild
+    measured at 15-25 s, so it is not worth threading the decision walk's list
+    through the build to avoid it — and re-walking here is the more honest
+    read anyway, since the build did its own walk.
     """
-    global _dispatchable_cache_key, _dispatchable_cache_value
-    _dispatchable_cache_key, _dispatchable_cache_value = _dispatchable_memo_prev
+    _read_dispatchable_fresh(include_system, restamp=True)
 
 
 def _read_dispatchable_fresh(
@@ -278,17 +266,13 @@ def _read_dispatchable_fresh(
     the next reader misses and re-walks — rather than a half-updated view
     being served under the new key.
 
-    The displaced entry is kept in ``_dispatchable_memo_prev`` so a caller
-    that walked in order to decide on a rebuild can undo this restamp if the
-    rebuild fails; see ``rollback_dispatchable_memo``.
-
-    ``restamp=False`` walks without touching the memo at all. For a caller
-    that only wants to *detect* a change and will rebuild separately, that
-    is the difference between the cue naming a new expert immediately and
-    naming it once the agent can actually reach it.
+    ``restamp=False`` walks without touching the memo at all, which is how
+    ``dispatchable_experts_token`` reads: a caller deciding *whether* to
+    rebuild must not advertise the result before the rebuild has happened.
+    Only ``publish_dispatchable_experts`` and this function's own memo-miss
+    path pass ``restamp=True``.
     """
     global _dispatchable_cache_key, _dispatchable_cache_value
-    global _dispatchable_memo_prev
 
     from ..tools.skills_manager import list_expert_skills, skills_epoch
 
@@ -307,7 +291,6 @@ def _read_dispatchable_fresh(
     if not restamp:
         return dispatchable
 
-    _dispatchable_memo_prev = (_dispatchable_cache_key, _dispatchable_cache_value)
     # Value before key. A reader interleaving between these two writes then
     # either misses (old key, cheap re-walk) or matches the old key and gets
     # the fresher list — never the new key paired with the stale value.
@@ -336,12 +319,18 @@ def list_dispatchable_experts(
     returned list is a fresh copy so a caller sorting or filtering it in
     place can't corrupt the next reader's view.
 
-    The memo is also restamped by ``dispatchable_experts_token`` — once per
-    turn boundary in the CLI/TUI, once per HTTP request in the WebUI — so a
-    mid-run edit reaches this reader without ever advancing the epoch. When
-    the rebuild that restamp was taken for fails, the caller rolls it back
-    (``rollback_dispatchable_memo``), so this never reports an expert the
-    seated agent cannot dispatch to.
+    The memo is also stamped by ``publish_dispatchable_experts`` on the
+    success branch of every agent build, so a mid-run edit reaches this
+    reader without ever advancing the epoch. A build that fails stamps
+    nothing, which is what keeps this from reporting an expert the seated
+    agent cannot dispatch to.
+
+    That guarantee is a turn-boundary one, not an absolute one. The key
+    above is the epoch, so an ``install_skill`` landing mid-turn invalidates
+    the memo and the next read here walks fresh — naming the new expert
+    before the rebuild that makes it dispatchable. The window closes at the
+    next build; edits written straight to the workspace skills tier never
+    move the epoch and so never open it at all.
 
     ``cfg`` is accepted and ignored; kept so callers that thread config
     through don't have to special-case this one. Read-only filter —
@@ -357,9 +346,7 @@ def list_dispatchable_experts(
     return list(_read_dispatchable_fresh(include_system))
 
 
-def dispatchable_experts_token(
-    *, include_system: bool = True, restamp: bool = True
-) -> str:
+def dispatchable_experts_token(*, include_system: bool = True) -> str:
     """Fingerprint of the expert registry an agent would be built from.
 
     Answers one question for every cache of a *constructed* agent: would
@@ -403,22 +390,21 @@ def dispatchable_experts_token(
     dispatchable experts and scaling roughly linearly with the installed
     skill count. Callers are turn boundaries (CLI/TUI) and the WebUI's
     background refresher — never ``awrap_model_call``, whose cue reads the
-    memo this restamps, and never the WebUI request path.
+    memo, and never the WebUI request path.
 
     Blocking by nature (``iterdir`` plus SKILL.md / AGENTS.md parsing), so
     every caller must keep it off an event loop. langgraph-dev installs a
     blockbuster guard that turns a filesystem call on the loop into a raised
     ``BlockingError``, not merely a slow request.
 
-    Restamping the memo is a side effect, not incidental: it is what keeps
-    the cue reporting the same set the rebuild decision was made on, and a
-    caller whose rebuild then fails must call ``rollback_dispatchable_memo``.
-    Pass ``restamp=False`` when only *detecting* a change: the rebuild that
-    follows is what makes the new expert reachable and can take seconds,
-    during which a restamped memo would have the cue naming an expert
-    ``task()`` cannot route to. The rebuild path restamps on its own.
+    Reads without writing, and takes no argument that would let a caller
+    change that. This is a *detection* read: the rebuild it triggers is what
+    makes the new expert reachable and takes seconds, so stamping the memo
+    here would have the cue naming an expert ``task()`` cannot route to for
+    that whole window — and for good, if the rebuild then failed. Stamping
+    belongs to ``publish_dispatchable_experts`` on the success branch.
     """
-    experts = _read_dispatchable_fresh(include_system, restamp=restamp)
+    experts = _read_dispatchable_fresh(include_system, restamp=False)
 
     digest = hashlib.sha256()
     # Sorted so filesystem iteration order can't produce a spurious change.

--- a/EvoScientist/tools/skills_manager.py
+++ b/EvoScientist/tools/skills_manager.py
@@ -69,11 +69,10 @@ _logger = logging.getLogger(__name__)
 #   decision belongs to ``expert_container.dispatchable_experts_token``,
 #   which walks the tree rather than reading a counter.
 # - ``register_skills_changed_callback`` — push, for a consumer that must
-#   act at mutation time rather than at next read. No in-tree subscriber
-#   currently needs that; the hook is kept because it is the documented
-#   extension point and removing it would leave the next such consumer
-#   re-deriving it at a caller site, which is the pattern this block exists
-#   to prevent.
+#   act at mutation time rather than at next read. ``langgraph_dev/
+#   registry_refresh.py`` subscribes: it wakes its poll loop immediately on
+#   install/uninstall instead of waiting out the interval. It still polls,
+#   because the silent paths above never reach this publish point.
 #
 # Both are driven by ``_notify_skills_changed`` below, so a caller that
 # forgets to publish breaks them identically — one thing to get right.

--- a/EvoScientist/tools/skills_manager.py
+++ b/EvoScientist/tools/skills_manager.py
@@ -53,16 +53,49 @@ _logger = logging.getLogger(__name__)
 #
 # ``install_skill`` and ``uninstall_skill`` are called from six places today:
 # three slash commands, two paths in the agent's ``skill_manager`` @tool, and
-# the onboarding step. Consumers that cache skill data (currently the
-# /expert completion popup) need to invalidate on every mutation, and wiring
-# that at each caller site was the "vibes and hope" pattern reviewers rightly
-# called out on PR #371 — the next caller silently reintroduces staleness.
+# the onboarding step. Consumers that cache skill data need to invalidate on
+# every mutation, and wiring that at each caller site was the "vibes and hope"
+# pattern reviewers rightly called out on PR #371 — the next caller silently
+# reintroduces staleness.
 #
-# The invariant lives here instead: any subscriber registered via
-# ``register_skills_changed_callback`` is fired after every install / uninstall
-# call, so no caller has to remember.
+# The invariant lives here instead, in two shapes over one publish point:
+#
+# - ``skills_epoch()`` — pull. What every in-tree consumer uses: the
+#   dispatchable-expert memo, the agent build token, and through it the
+#   TUI/CLI in-place agent rebuild and the deployed graph factory. A
+#   consumer with no natural place to subscribe from just compares it.
+# - ``register_skills_changed_callback`` — push, for a consumer that must
+#   act at mutation time rather than at next read. No in-tree subscriber
+#   currently needs that; the hook is kept because it is the documented
+#   extension point and removing it would leave the next such consumer
+#   re-deriving it at a caller site, which is the pattern this block exists
+#   to prevent.
+#
+# Both are driven by ``_notify_skills_changed`` below, so a caller that
+# forgets to publish breaks them identically — one thing to get right.
 
 _skills_changed_callbacks: list[Callable[[], None]] = []
+
+# Monotonic counter advanced by every ``_notify_skills_changed`` call. The
+# pull-side counterpart to the callback list above: consumers that cache
+# derived skill data but have no natural place to subscribe from (module
+# globals rebuilt lazily, per-request graph factories) compare this value
+# against the one their cache was built at instead of registering a
+# callback. Same invariant, same single publish point — a caller that
+# forgets to notify breaks both mechanisms identically, so there is only
+# one thing to get right.
+_skills_epoch = 0
+
+
+def skills_epoch() -> int:
+    """Return the current skills-mutation counter.
+
+    Advances on every ``install_skill`` / ``uninstall_skill`` call. Callers
+    treat it as an opaque cache key: equal value means no skill was
+    installed or uninstalled since, so anything derived from the skill set
+    is still valid.
+    """
+    return _skills_epoch
 
 
 def register_skills_changed_callback(callback: Callable[[], None]) -> None:
@@ -85,11 +118,16 @@ def _reset_skills_changed_callbacks() -> None:
 
 
 def _notify_skills_changed() -> None:
-    """Fire every registered callback.
+    """Advance ``skills_epoch`` and fire every registered callback.
+
+    The epoch is bumped first so a callback that reads it during the
+    notification already sees the post-mutation value.
 
     Exceptions are logged but swallowed so a misbehaving subscriber can't
     break the install/uninstall return path.
     """
+    global _skills_epoch
+    _skills_epoch += 1
     for cb in _skills_changed_callbacks:
         try:
             cb()

--- a/EvoScientist/tools/skills_manager.py
+++ b/EvoScientist/tools/skills_manager.py
@@ -60,10 +60,14 @@ _logger = logging.getLogger(__name__)
 #
 # The invariant lives here instead, in two shapes over one publish point:
 #
-# - ``skills_epoch()`` — pull. What every in-tree consumer uses: the
-#   dispatchable-expert memo, the agent build token, and through it the
-#   TUI/CLI in-place agent rebuild and the deployed graph factory. A
-#   consumer with no natural place to subscribe from just compares it.
+# - ``skills_epoch()`` — pull. Compared by the dispatchable-expert memo,
+#   whose job is keeping a skills-tree walk off the model-call path. It
+#   counts install/uninstall calls, which makes it the right key for that
+#   memo and the wrong one for deciding whether a *built agent* is stale:
+#   an expert can also be authored or edited straight onto the writable
+#   workspace skills tier, which never reaches this publish point. That
+#   decision belongs to ``expert_container.dispatchable_experts_token``,
+#   which walks the tree rather than reading a counter.
 # - ``register_skills_changed_callback`` — push, for a consumer that must
 #   act at mutation time rather than at next read. No in-tree subscriber
 #   currently needs that; the hook is kept because it is the documented
@@ -77,11 +81,10 @@ _logger = logging.getLogger(__name__)
 _skills_changed_callbacks: list[Callable[[], None]] = []
 
 # Monotonic counter advanced by every ``_notify_skills_changed`` call. The
-# pull-side counterpart to the callback list above: consumers that cache
-# derived skill data but have no natural place to subscribe from (module
-# globals rebuilt lazily, per-request graph factories) compare this value
-# against the one their cache was built at instead of registering a
-# callback. Same invariant, same single publish point — a caller that
+# pull-side counterpart to the callback list above: a consumer that caches
+# derived skill data but has no natural place to subscribe from compares
+# this value against the one its cache was built at instead of registering
+# a callback. Same invariant, same single publish point — a caller that
 # forgets to notify breaks both mechanisms identically, so there is only
 # one thing to get right.
 _skills_epoch = 0
@@ -91,9 +94,12 @@ def skills_epoch() -> int:
     """Return the current skills-mutation counter.
 
     Advances on every ``install_skill`` / ``uninstall_skill`` call. Callers
-    treat it as an opaque cache key: equal value means no skill was
-    installed or uninstalled since, so anything derived from the skill set
-    is still valid.
+    treat it as an opaque cache key, and an equal value means exactly what
+    it says — no skill was installed or uninstalled since — which is not
+    the same as "the skill set is unchanged". Edits written straight to the
+    writable workspace skills tier bypass both entry points and leave this
+    counter still. A cache that must survive those needs a content read,
+    not this counter; see ``expert_container.dispatchable_experts_token``.
     """
     return _skills_epoch
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,3 +169,26 @@ def _isolate_dotenv(monkeypatch):
         "EvoScientist.config.settings.find_dotenv",
         lambda *args, **kwargs: _NONEXISTENT_DOTENV,
     )
+
+
+@pytest.fixture(autouse=True)
+def _reset_dispatchable_experts_cache():
+    """Drop the epoch-keyed dispatchable-experts memo around every test.
+
+    ``expert_container.list_dispatchable_experts`` invalidates on
+    ``skills_manager.skills_epoch()``, which only advances on a real
+    install / uninstall. Tests instead patch ``list_expert_skills`` or
+    write skill directories straight to a tmpdir, neither of which moves
+    the epoch — so without this the second test to run sees the first
+    test's fakes. Autouse rather than opt-in because the memo is read
+    transitively (the ``/expert`` popup, the active-expert cue, the agent
+    build token), so an opt-in fixture would have to be remembered by
+    tests that never mention the cache.
+    """
+    from EvoScientist.subagents import expert_container
+
+    expert_container._reset_dispatchable_experts_cache()
+    try:
+        yield
+    finally:
+        expert_container._reset_dispatchable_experts_cache()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,7 @@ def _reset_dispatchable_experts_cache():
     the epoch — so without this the second test to run sees the first
     test's fakes. Autouse rather than opt-in because the memo is reached
     transitively: the ``/expert`` popup and the active-expert cue read it,
-    and ``dispatchable_experts_token`` restamps it on every agent build.
+    and ``publish_dispatchable_experts`` stamps it after every agent build.
     An opt-in fixture would have to be remembered by tests that never
     mention the cache.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,10 +180,11 @@ def _reset_dispatchable_experts_cache():
     install / uninstall. Tests instead patch ``list_expert_skills`` or
     write skill directories straight to a tmpdir, neither of which moves
     the epoch — so without this the second test to run sees the first
-    test's fakes. Autouse rather than opt-in because the memo is read
-    transitively (the ``/expert`` popup, the active-expert cue, the agent
-    build token), so an opt-in fixture would have to be remembered by
-    tests that never mention the cache.
+    test's fakes. Autouse rather than opt-in because the memo is reached
+    transitively: the ``/expert`` popup and the active-expert cue read it,
+    and ``dispatchable_experts_token`` restamps it on every agent build.
+    An opt-in fixture would have to be remembered by tests that never
+    mention the cache.
     """
     from EvoScientist.subagents import expert_container
 

--- a/tests/test_active_team_middleware.py
+++ b/tests/test_active_team_middleware.py
@@ -298,9 +298,9 @@ def test_cue_does_not_walk_the_skills_tree_per_model_call(mock_get_config):
     ``modify_request`` runs inside ``awrap_model_call``; a ``list_skills``
     ``iterdir`` + SKILL.md parse there is synchronous I/O on the event
     loop. The memo makes repeat turns a dict lookup — and, because
-    ``dispatchable_experts_token`` restamps that memo with the same walk
-    that decides whether to rebuild, it reports the expert set the running
-    agent was actually built from.
+    ``publish_dispatchable_experts`` stamps it from the success branch of
+    every agent build, it reports the expert set the running agent was
+    actually built from.
     """
     mock_get_config.return_value = {
         "configurable": {"active_teams": ["idea-brainstorm"]},

--- a/tests/test_active_team_middleware.py
+++ b/tests/test_active_team_middleware.py
@@ -285,3 +285,83 @@ def test_default_middleware_excludes_active_team_for_async_subagent(
 
 def test_factory_returns_middleware_instance():
     assert isinstance(create_active_team_middleware(), ActiveTeamMiddleware)
+
+
+# ---- registry reads on the model-call path --------------------------------
+
+
+@patch("langgraph.config.get_config")
+def test_cue_does_not_walk_the_skills_tree_per_model_call(mock_get_config):
+    """The cue renders from the epoch-keyed registry memo, not a fresh
+    filesystem read.
+
+    ``modify_request`` runs inside ``awrap_model_call``; a ``list_skills``
+    ``iterdir`` + SKILL.md parse there is synchronous I/O on the event
+    loop. The memo makes repeat turns a dict lookup — and, because the
+    same epoch drives the agent rebuild, it reports the expert set the
+    running agent was actually built from.
+    """
+    mock_get_config.return_value = {
+        "configurable": {"active_teams": ["idea-brainstorm"]},
+    }
+    expert = SimpleNamespace(
+        name="idea-brainstorm",
+        description="d",
+        path=None,
+        source="builtin",
+        type="expert",
+        role="",
+        body="persona\n",
+        expert_source="",
+        agents_body="",
+    )
+    middleware = ActiveTeamMiddleware()
+    with patch(
+        "EvoScientist.tools.skills_manager.list_expert_skills",
+        return_value=[expert],
+    ) as listing:
+        for _ in range(3):
+            text = _system_text(middleware.modify_request(_request()))
+            assert "`idea-brainstorm`" in text
+    assert listing.call_count == 1
+
+
+@patch("langgraph.config.get_config")
+def test_cue_picks_up_a_newly_installed_expert(mock_get_config):
+    """An install advances ``skills_epoch``, which drops the memo — the same
+    signal that rebuilds the agent, so the cue and the reachable set move
+    together.
+    """
+    from EvoScientist.tools import skills_manager
+
+    mock_get_config.return_value = {
+        "configurable": {"active_teams": ["fresh-expert"]},
+    }
+
+    def _expert(name):
+        return SimpleNamespace(
+            name=name,
+            description="d",
+            path=None,
+            source="builtin",
+            type="expert",
+            role="",
+            body="persona\n",
+            expert_source="",
+            agents_body="",
+        )
+
+    middleware = ActiveTeamMiddleware()
+    with patch("EvoScientist.tools.skills_manager.list_expert_skills", return_value=[]):
+        text = _system_text(middleware.modify_request(_request()))
+    # The concept still injects; only the invite block waits on the install.
+    assert "## Experts" in text
+    assert "The user has invited" not in text
+
+    skills_manager._notify_skills_changed()
+    with patch(
+        "EvoScientist.tools.skills_manager.list_expert_skills",
+        return_value=[_expert("fresh-expert")],
+    ):
+        text = _system_text(middleware.modify_request(_request()))
+    assert "`fresh-expert`" in text

--- a/tests/test_active_team_middleware.py
+++ b/tests/test_active_team_middleware.py
@@ -297,9 +297,10 @@ def test_cue_does_not_walk_the_skills_tree_per_model_call(mock_get_config):
 
     ``modify_request`` runs inside ``awrap_model_call``; a ``list_skills``
     ``iterdir`` + SKILL.md parse there is synchronous I/O on the event
-    loop. The memo makes repeat turns a dict lookup — and, because the
-    same epoch drives the agent rebuild, it reports the expert set the
-    running agent was actually built from.
+    loop. The memo makes repeat turns a dict lookup — and, because
+    ``dispatchable_experts_token`` restamps that memo with the same walk
+    that decides whether to rebuild, it reports the expert set the running
+    agent was actually built from.
     """
     mock_get_config.return_value = {
         "configurable": {"active_teams": ["idea-brainstorm"]},
@@ -328,9 +329,13 @@ def test_cue_does_not_walk_the_skills_tree_per_model_call(mock_get_config):
 
 @patch("langgraph.config.get_config")
 def test_cue_picks_up_a_newly_installed_expert(mock_get_config):
-    """An install advances ``skills_epoch``, which drops the memo — the same
-    signal that rebuilds the agent, so the cue and the reachable set move
-    together.
+    """An install advances ``skills_epoch``, which drops the memo the cue
+    reads.
+
+    This pins the install path specifically. The agent rebuild is driven
+    by ``dispatchable_experts_token``, not by the epoch, which is what
+    also covers experts that appear without an install — see
+    ``TestDispatchableExpertsTokenSeesMidRunEdits``.
     """
     from EvoScientist.tools import skills_manager
 

--- a/tests/test_agent_loader.py
+++ b/tests/test_agent_loader.py
@@ -440,23 +440,60 @@ class TestBackgroundAgentLoaderBuildToken:
         token["value"] = "t2"
         assert await loader.await_ready() == "RECOVERED"
 
-    async def test_adopt_restamps_the_token(self):
+    async def test_adopt_restamps_the_token_and_publishes(self):
         """``/model`` builds its replacement agent from current inputs, so
-        the next ``await_ready`` must not rebuild it again.
+        the next ``await_ready`` must not rebuild it again — and anything
+        derived from those inputs has to describe the adopted agent, not
+        the one it displaced.
         """
         calls: list[dict] = []
+        published: list[int] = []
         token = {"value": "t0"}
         loader = BackgroundAgentLoader(
-            self._counting_loader(calls), build_token=lambda: token["value"]
+            self._counting_loader(calls),
+            build_token=lambda: token["value"],
+            publish_build=lambda: published.append(1),
         )
 
         loader.start()
         await loader.await_ready()
+        assert len(published) == 1  # the initial load
         token["value"] = "t1"
         loader.adopt("FROM_MODEL")
 
         assert await loader.await_ready() == "FROM_MODEL"
         assert len(calls) == 1
+        assert len(published) == 2
+
+    async def test_a_failed_build_publishes_nothing(self):
+        """The whole point of publishing from the success branch."""
+        published: list[int] = []
+
+        def _fail(**_kwargs):
+            raise RuntimeError("build boom")
+
+        loader = BackgroundAgentLoader(_fail, publish_build=lambda: published.append(1))
+
+        loader.start()
+        with pytest.raises(RuntimeError):
+            await loader.await_ready()
+        assert published == []
+
+    async def test_a_raising_publish_does_not_break_the_load(self):
+        """The agent is already built and serving; a stale side-cache is the
+        lesser failure."""
+        calls: list[dict] = []
+
+        def _boom() -> None:
+            raise RuntimeError("publish boom")
+
+        loader = BackgroundAgentLoader(
+            self._counting_loader(calls), publish_build=_boom
+        )
+
+        loader.start()
+        await loader.await_ready()
+        assert loader.agent is not None
 
     async def test_no_build_token_never_rebuilds(self):
         """Loaders constructed without the hook keep the old behaviour."""

--- a/tests/test_agent_loader.py
+++ b/tests/test_agent_loader.py
@@ -481,3 +481,75 @@ class TestBackgroundAgentLoaderBuildToken:
         assert await loader.await_ready() == "AGENT1"
         assert await loader.await_ready() == "AGENT1"
         assert len(calls) == 1
+
+    async def test_a_token_that_starts_raising_settles_after_one_rebuild(self):
+        """The interesting transition: a token that worked, then breaks.
+
+        The always-raising case above passes trivially — ``start`` stamps
+        ``None`` too, so both sides of the comparison are ``None``. Here the
+        seated agent carries a real hash, so the first ``None`` reads as a
+        change and forces one rebuild; after that ``start`` has re-stamped
+        ``None`` and it must settle rather than rebuild every turn.
+        """
+        calls: list[dict] = []
+        reads = {"n": 0}
+
+        def _breaks_after_first():
+            reads["n"] += 1
+            if reads["n"] == 1:
+                return "t0"
+            raise RuntimeError("registry unreadable")
+
+        loader = BackgroundAgentLoader(
+            self._counting_loader(calls), build_token=_breaks_after_first
+        )
+
+        loader.start()
+        assert await loader.await_ready() == "AGENT1"
+        assert await loader.await_ready() == "AGENT2"  # one rebuild, not a loop
+        assert await loader.await_ready() == "AGENT2"
+        assert await loader.await_ready() == "AGENT2"
+        assert len(calls) == 2
+
+    async def test_failed_rebuild_reports_as_a_refresh_not_a_dead_session(self):
+        """``_reload`` reuses ``start``, so ``_on_done`` fires before the
+        previous agent is re-seated. Without the guard the user is told the
+        load died a moment before the next turn runs normally.
+        """
+        token = {"value": "t0"}
+        fatal: list[BaseException] = []
+        refresh: list[BaseException] = []
+        loader = BackgroundAgentLoader(
+            _make_loader_fn("GOOD"),
+            on_failure=fatal.append,
+            on_rebuild_failed=refresh.append,
+            build_token=lambda: token["value"],
+        )
+
+        loader.start()
+        await loader.await_ready()
+
+        loader._loader_fn = _make_loader_fn(fail_with=RuntimeError("bad skill"))
+        token["value"] = "t1"
+        assert await loader.await_ready() == "GOOD"
+
+        assert fatal == []
+        assert [str(e) for e in refresh] == ["bad skill"]
+
+    async def test_failed_initial_load_still_reports_as_fatal(self):
+        """The guard must not swallow the case where there is no agent."""
+        fatal: list[BaseException] = []
+        refresh: list[BaseException] = []
+        loader = BackgroundAgentLoader(
+            _make_loader_fn(fail_with=RuntimeError("no agent")),
+            on_failure=fatal.append,
+            on_rebuild_failed=refresh.append,
+            build_token=lambda: "t0",
+        )
+
+        loader.start()
+        with pytest.raises(RuntimeError, match="no agent"):
+            await loader.await_ready()
+
+        assert [str(e) for e in fatal] == ["no agent"]
+        assert refresh == []

--- a/tests/test_agent_loader.py
+++ b/tests/test_agent_loader.py
@@ -335,3 +335,149 @@ class TestBackgroundAgentLoaderIsPending:
         wait_loader.release.set()
         await loader.await_ready()
         assert not loader.is_pending
+
+
+class TestBackgroundAgentLoaderBuildToken:
+    """``build_token`` is what makes a mid-session ``skill_manager install
+    <expert>`` reach ``task()`` on the next turn: every pre-turn agent
+    access in both UIs goes through ``await_ready``, so the staleness check
+    lives there instead of in each turn loop.
+    """
+
+    def _counting_loader(self, calls: list[dict]):
+        def _loader(*, on_mcp_progress=None, **kwargs):
+            calls.append(kwargs)
+            return f"AGENT{len(calls)}"
+
+        return _loader
+
+    async def test_no_rebuild_while_the_token_is_unchanged(self):
+        calls: list[dict] = []
+        loader = BackgroundAgentLoader(
+            self._counting_loader(calls), build_token=lambda: "t0"
+        )
+
+        loader.start(workspace_dir="/ws")
+        assert await loader.await_ready() == "AGENT1"
+        assert await loader.await_ready() == "AGENT1"
+        assert len(calls) == 1
+
+    async def test_rebuild_replays_the_original_kwargs(self):
+        """The rebuild must reuse the session's checkpointer, workspace and
+        event sink — that is what keeps the conversation intact, unlike
+        ``/new``, which rotates the thread.
+        """
+        calls: list[dict] = []
+        token = {"value": "t0"}
+        loader = BackgroundAgentLoader(
+            self._counting_loader(calls), build_token=lambda: token["value"]
+        )
+
+        loader.start(workspace_dir="/ws", checkpointer="CK", events="SINK")
+        assert await loader.await_ready() == "AGENT1"
+
+        token["value"] = "t1"
+        assert await loader.await_ready() == "AGENT2"
+        assert calls == [
+            {"workspace_dir": "/ws", "checkpointer": "CK", "events": "SINK"},
+            {"workspace_dir": "/ws", "checkpointer": "CK", "events": "SINK"},
+        ]
+
+    async def test_rebuild_happens_once_per_token_change(self):
+        calls: list[dict] = []
+        token = {"value": "t0"}
+        loader = BackgroundAgentLoader(
+            self._counting_loader(calls), build_token=lambda: token["value"]
+        )
+
+        loader.start()
+        await loader.await_ready()
+        token["value"] = "t1"
+        await loader.await_ready()
+        await loader.await_ready()
+        assert len(calls) == 2
+
+    async def test_failed_rebuild_keeps_serving_the_previous_agent(self, caplog):
+        """A broken install must degrade to "the new expert isn't there yet",
+        never to a dead session.
+        """
+        token = {"value": "t0"}
+        loader = BackgroundAgentLoader(
+            _make_loader_fn("GOOD"), build_token=lambda: token["value"]
+        )
+
+        loader.start()
+        assert await loader.await_ready() == "GOOD"
+
+        loader._loader_fn = _make_loader_fn(fail_with=RuntimeError("bad skill"))
+        token["value"] = "t1"
+        assert await loader.await_ready() == "GOOD"
+        assert loader.agent == "GOOD"
+        assert any("Agent rebuild failed" in r.message for r in caplog.records)
+
+    async def test_failed_rebuild_is_not_retried_until_inputs_change_again(self):
+        """Otherwise every turn pays for a rebuild that is known to fail."""
+        token = {"value": "t0"}
+        loader = BackgroundAgentLoader(
+            _make_loader_fn("GOOD"), build_token=lambda: token["value"]
+        )
+        loader.start()
+        await loader.await_ready()
+
+        attempts: list[int] = []
+
+        def _failing(*, on_mcp_progress=None, **kwargs):
+            attempts.append(1)
+            raise RuntimeError("bad skill")
+
+        loader._loader_fn = _failing
+        token["value"] = "t1"
+        await loader.await_ready()
+        await loader.await_ready()
+        assert len(attempts) == 1
+
+        loader._loader_fn = _make_loader_fn("RECOVERED")
+        token["value"] = "t2"
+        assert await loader.await_ready() == "RECOVERED"
+
+    async def test_adopt_restamps_the_token(self):
+        """``/model`` builds its replacement agent from current inputs, so
+        the next ``await_ready`` must not rebuild it again.
+        """
+        calls: list[dict] = []
+        token = {"value": "t0"}
+        loader = BackgroundAgentLoader(
+            self._counting_loader(calls), build_token=lambda: token["value"]
+        )
+
+        loader.start()
+        await loader.await_ready()
+        token["value"] = "t1"
+        loader.adopt("FROM_MODEL")
+
+        assert await loader.await_ready() == "FROM_MODEL"
+        assert len(calls) == 1
+
+    async def test_no_build_token_never_rebuilds(self):
+        """Loaders constructed without the hook keep the old behaviour."""
+        calls: list[dict] = []
+        loader = BackgroundAgentLoader(self._counting_loader(calls))
+
+        loader.start()
+        await loader.await_ready()
+        await loader.await_ready()
+        assert len(calls) == 1
+
+    async def test_a_raising_token_does_not_strand_the_session(self):
+        """An unreadable token degrades to "unknown", not to a rebuild loop."""
+        calls: list[dict] = []
+
+        def _boom():
+            raise RuntimeError("registry unreadable")
+
+        loader = BackgroundAgentLoader(self._counting_loader(calls), build_token=_boom)
+
+        loader.start()
+        assert await loader.await_ready() == "AGENT1"
+        assert await loader.await_ready() == "AGENT1"
+        assert len(calls) == 1

--- a/tests/test_code_interpreter_middleware.py
+++ b/tests/test_code_interpreter_middleware.py
@@ -255,16 +255,16 @@ def test_agent_uses_filtered_graph_class():
     ``Pregel.copy(update=...)`` — the call langgraph-api makes in
     ``get_graph`` before yielding the graph to endpoint handlers.
 
-    The swap lives inside the factory rather than at module level because
-    the factory rebuilds the agent when the expert registry changes; a
+    The swap lives inside ``refresh_main_graph`` rather than at module level
+    because the graph is rebuilt whenever the expert registry changes; a
     one-shot swap at import would leave every rebuilt graph unfiltered.
     """
     from EvoScientist.langgraph_dev.main_graph import (
         _EvoFilteredGraph,
-        make_EvoScientist_agent,
+        refresh_main_graph,
     )
 
-    agent = make_EvoScientist_agent()
+    agent = refresh_main_graph()
     assert isinstance(agent, _EvoFilteredGraph)
     assert isinstance(agent.copy(update={}), _EvoFilteredGraph)
 
@@ -277,6 +277,11 @@ def test_main_graph_entry_is_a_zero_arg_factory():
 
     Zero-arg specifically: ``_classify_factory`` injects a config or a
     ``ServerRuntime`` for any declared parameter.
+
+    Synchronous specifically: ``invoke_factory`` calls it on the event loop,
+    so it must stay a plain function doing no blocking work. An ``async def``
+    would resolve (``as_asynccontextmanager`` awaits coroutines) but would put
+    the whole per-request path through a thread hop for no reason.
     """
     import inspect
     import json
@@ -294,34 +299,48 @@ def test_main_graph_entry_is_a_zero_arg_factory():
     factory = getattr(main_graph, attr)
 
     assert callable(factory)
+    assert not inspect.iscoroutinefunction(factory)
     assert list(inspect.signature(factory).parameters) == []
     # ``{}`` (not ``None``) is what ``is_factory`` keys on for the 0-arg case.
     assert _classify_factory(factory) == {}
 
 
-def test_factory_returns_the_cached_graph_until_experts_change():
-    """A factory is called on every request, so the steady state must be a
-    cache hit — and a changed expert registry must produce a new graph.
+def test_factory_does_no_work_per_request(monkeypatch):
+    """The factory runs on the event loop for every request that touches the
+    graph, including read-only state polls. Any filesystem access there is not
+    merely slow — langgraph-dev's blockbuster guard raises ``BlockingError`` on
+    it. So the factory must return the published graph and nothing else;
+    keeping it current is the background refresher's job.
     """
     from EvoScientist.langgraph_dev.main_graph import (
-        _EvoFilteredGraph,
         make_EvoScientist_agent,
+        refresh_main_graph,
     )
 
-    first = make_EvoScientist_agent()
+    first = refresh_main_graph()
+
+    def _explode(*_args, **_kwargs):
+        raise AssertionError("the factory must not read the skills tree")
+
+    monkeypatch.setattr(
+        "EvoScientist.tools.skills_manager.list_expert_skills", _explode
+    )
+    monkeypatch.setattr("EvoScientist.tools.skills_manager.list_skills", _explode)
+
+    assert make_EvoScientist_agent() is first
     assert make_EvoScientist_agent() is first
 
-    import EvoScientist.EvoScientist as evo_mod
 
-    original_token = evo_mod._EvoScientist_agent_expert_token
-    try:
-        evo_mod._EvoScientist_agent_expert_token = "stale-token"
-        rebuilt = make_EvoScientist_agent()
-        assert rebuilt is not first
-        assert isinstance(rebuilt, _EvoFilteredGraph)
-    finally:
-        evo_mod._EvoScientist_agent_expert_token = original_token
-        evo_mod._EvoScientist_agent = first
+def test_factory_reports_clearly_when_nothing_is_published(monkeypatch):
+    """If the guarded import-time build failed, the factory must say so rather
+    than build inline — an inline build is exactly the blocking-on-the-loop
+    call this design exists to avoid. The refresher's startup pass retries.
+    """
+    from EvoScientist.langgraph_dev import main_graph
+
+    monkeypatch.setattr(main_graph, "_current_graph", None)
+    with pytest.raises(RuntimeError, match="not built yet"):
+        main_graph.make_EvoScientist_agent()
 
 
 def test_all_registered_graphs_use_filtered_graph_class():
@@ -345,7 +364,15 @@ def test_all_registered_graphs_use_filtered_graph_class():
 
     # Import triggers ``main_graph``'s swap loop.
     from EvoScientist.langgraph_dev import main_graph
-    from EvoScientist.langgraph_dev.main_graph import _EvoFilteredGraph
+    from EvoScientist.langgraph_dev.main_graph import (
+        _EvoFilteredGraph,
+        refresh_main_graph,
+    )
+
+    # The factory only ever returns what the refresher published, so publish
+    # once here — otherwise this asserts against an unbuilt module rather than
+    # against the graph that reaches the endpoints.
+    refresh_main_graph()
 
     config_path = Path(main_graph.__file__).parent / "langgraph.json"
     config = json.loads(config_path.read_text())

--- a/tests/test_code_interpreter_middleware.py
+++ b/tests/test_code_interpreter_middleware.py
@@ -250,18 +250,78 @@ def test_agent_uses_filtered_graph_class():
     that makes ``_strip_private`` reach the langgraph-api endpoints.
     ``_strip_private`` and ``_EvoFilteredGraph`` in isolation don't prove the
     swap ran; every other test in this file passes even if someone drops the
-    swap line. This asserts the compiled agent is actually the filtered
-    subclass at module-load time, and that the subclass survives
+    swap line. This asserts the graph the factory hands langgraph-api is
+    actually the filtered subclass, and that the subclass survives
     ``Pregel.copy(update=...)`` — the call langgraph-api makes in
     ``get_graph`` before yielding the graph to endpoint handlers.
+
+    The swap lives inside the factory rather than at module level because
+    the factory rebuilds the agent when the expert registry changes; a
+    one-shot swap at import would leave every rebuilt graph unfiltered.
     """
     from EvoScientist.langgraph_dev.main_graph import (
-        EvoScientist_agent,
         _EvoFilteredGraph,
+        make_EvoScientist_agent,
     )
 
-    assert isinstance(EvoScientist_agent, _EvoFilteredGraph)
-    assert isinstance(EvoScientist_agent.copy(update={}), _EvoFilteredGraph)
+    agent = make_EvoScientist_agent()
+    assert isinstance(agent, _EvoFilteredGraph)
+    assert isinstance(agent.copy(update={}), _EvoFilteredGraph)
+
+
+def test_main_graph_entry_is_a_zero_arg_factory():
+    """``langgraph.json``'s ``EvoScientist`` entry must resolve to a callable
+    langgraph-api classifies as a factory, otherwise the graph is collected
+    into ``GRAPHS`` once at startup and an expert installed mid-session stays
+    unreachable in the WebUI until the dev subprocess restarts.
+
+    Zero-arg specifically: ``_classify_factory`` injects a config or a
+    ``ServerRuntime`` for any declared parameter.
+    """
+    import inspect
+    import json
+    from pathlib import Path
+
+    from langgraph_api._factory_utils import _classify_factory
+
+    from EvoScientist.langgraph_dev import main_graph
+
+    config = json.loads(
+        (Path(main_graph.__file__).parent / "langgraph.json").read_text()
+    )
+    module_path, attr = config["graphs"]["EvoScientist"].rsplit(":", 1)
+    assert module_path == main_graph.__name__
+    factory = getattr(main_graph, attr)
+
+    assert callable(factory)
+    assert list(inspect.signature(factory).parameters) == []
+    # ``{}`` (not ``None``) is what ``is_factory`` keys on for the 0-arg case.
+    assert _classify_factory(factory) == {}
+
+
+def test_factory_returns_the_cached_graph_until_experts_change():
+    """A factory is called on every request, so the steady state must be a
+    cache hit — and a changed expert registry must produce a new graph.
+    """
+    from EvoScientist.langgraph_dev.main_graph import (
+        _EvoFilteredGraph,
+        make_EvoScientist_agent,
+    )
+
+    first = make_EvoScientist_agent()
+    assert make_EvoScientist_agent() is first
+
+    import EvoScientist.EvoScientist as evo_mod
+
+    original_token = evo_mod._EvoScientist_agent_expert_token
+    try:
+        evo_mod._EvoScientist_agent_expert_token = "stale-token"
+        rebuilt = make_EvoScientist_agent()
+        assert rebuilt is not first
+        assert isinstance(rebuilt, _EvoFilteredGraph)
+    finally:
+        evo_mod._EvoScientist_agent_expert_token = original_token
+        evo_mod._EvoScientist_agent = first
 
 
 def test_all_registered_graphs_use_filtered_graph_class():
@@ -292,6 +352,11 @@ def test_all_registered_graphs_use_filtered_graph_class():
     for name, path in config["graphs"].items():
         module_path, attr = path.rsplit(":", 1)
         graph = getattr(import_module(module_path), attr)
+        # Factory entries (the main agent) are resolved the same way
+        # langgraph-api resolves them — by calling them — so the assertion
+        # covers the graph that actually reaches the endpoints.
+        if callable(graph):
+            graph = graph()
         assert isinstance(graph, _EvoFilteredGraph), (
             f"graph {name!r} ({path}) did not receive the class swap"
         )

--- a/tests/test_default_agent_rebuild.py
+++ b/tests/test_default_agent_rebuild.py
@@ -9,10 +9,28 @@ deployment down.
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 import EvoScientist.EvoScientist as agent_module
 from EvoScientist.subagents import expert_container
+from EvoScientist.tools.skills_manager import SkillInfo
+
+_SKILLS = "EvoScientist.tools.skills_manager.list_expert_skills"
+
+
+def _expert(name: str) -> SkillInfo:
+    return SkillInfo(
+        name=name,
+        description=f"{name} description",
+        path=Path("/tmp/nope") / name,
+        source="builtin",
+        type="expert",
+        role=f"{name} role",
+        body="persona body\n",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -48,14 +66,17 @@ def build(monkeypatch):
     configuration before the interesting failure — these tests stay runnable
     without credentials, unlike the factory tests that construct a real agent.
 
-    Failing at the kwargs step is also where a malformed expert actually bites:
-    ``_fold_expert_subagents`` runs inside ``_build_base_kwargs``.
+    The failure is injected rather than provoked with a malformed expert,
+    because expert content cannot fail a build: empty bodies, colliding names
+    and unresolved tools are each skipped with a warning. What can fail is the
+    surrounding construction a rebuild re-runs — backends against live paths,
+    and the chat model — which is what this stands in for.
     """
     calls: list[int] = []
 
     def _fail(*_args, **_kwargs):
         calls.append(1)
-        raise RuntimeError("bad expert spec")
+        raise RuntimeError("backend construction failed")
 
     monkeypatch.setattr(agent_module, "_ensure_config", lambda: _StubConfig())
     monkeypatch.setattr(agent_module, "_get_default_backend", lambda: object())
@@ -104,35 +125,25 @@ class TestFailedRebuildKeepsTheSeatedAgent:
 
         assert len(build) == 1
 
-    def test_a_failed_rebuild_rolls_the_cue_back(self, build, monkeypatch):
-        """The staleness probe restamps the memo before the build is tried.
+    def test_a_failed_rebuild_leaves_the_cue_on_the_seated_set(self, build):
+        """The expert prompt and the ``/expert`` popup must not offer an
+        expert ``task()`` cannot route to.
 
-        If the build then fails, the expert prompt and the ``/expert`` popup
-        must not go on offering an expert ``task()`` cannot route.
+        Drives the real ``dispatchable_experts_token`` and the real memo,
+        patching only the skills listing underneath them — a stand-in for
+        either would let a scheme that writes the memo before the build and
+        undoes it afterwards pass while failing in production.
         """
-        monkeypatch.setattr(
-            expert_container, "_reset_dispatchable_experts_cache", lambda: None
-        )
-        expert_container._dispatchable_cache_key = (0, True)
-        expert_container._dispatchable_cache_value = ["seated-set"]
-        expert_container._dispatchable_memo_prev = ((0, True), ["seated-set"])
+        seated = object()
+        with patch(_SKILLS, return_value=[_expert("alpha")]):
+            # The set the seated agent was built from.
+            expert_container.list_dispatchable_experts()
+            _seat(seated, expert_container.dispatchable_experts_token())
 
-        def _token_that_restamps(**_kwargs):
-            expert_container._dispatchable_memo_prev = (
-                expert_container._dispatchable_cache_key,
-                expert_container._dispatchable_cache_value,
-            )
-            expert_container._dispatchable_cache_value = ["seated-set", "not-built"]
-            return "new"
-
-        monkeypatch.setattr(
-            expert_container, "dispatchable_experts_token", _token_that_restamps
-        )
-        _seat(object(), "old")
-
-        agent_module._get_default_agent()
-
-        assert expert_container._dispatchable_cache_value == ["seated-set"]
+        with patch(_SKILLS, return_value=[_expert("alpha"), _expert("beta")]):
+            assert agent_module._get_default_agent() is seated
+            names = [s.name for s in expert_container.list_dispatchable_experts()]
+            assert names == ["alpha"]
 
     def test_a_failed_first_build_still_raises(self, build, monkeypatch):
         """With no previous agent there is nothing to degrade to.
@@ -146,7 +157,7 @@ class TestFailedRebuildKeepsTheSeatedAgent:
         )
         agent_module._EvoScientist_agent = None
 
-        with pytest.raises(RuntimeError, match="bad expert spec"):
+        with pytest.raises(RuntimeError, match="backend construction failed"):
             agent_module._get_default_agent()
 
     def test_a_failed_rebuild_warns(self, build, monkeypatch, caplog):

--- a/tests/test_default_agent_rebuild.py
+++ b/tests/test_default_agent_rebuild.py
@@ -1,0 +1,175 @@
+"""Tests for the expert-registry rebuild in ``_get_default_agent``.
+
+The module-level agent is rebuilt when ``dispatchable_experts_token`` moves,
+so an expert installed mid-session becomes dispatchable without ``/new``. The
+WebUI graph factory calls this per HTTP request, which is what makes the
+failure branch load-bearing: a build that raises must not take a working
+deployment down.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import EvoScientist.EvoScientist as agent_module
+from EvoScientist.subagents import expert_container
+
+
+@pytest.fixture(autouse=True)
+def _isolate_agent_globals():
+    """Snapshot and restore the module globals this suite mutates."""
+    saved = (
+        agent_module._EvoScientist_agent,
+        agent_module._EvoScientist_agent_expert_token,
+    )
+    agent_module._EvoScientist_agent = None
+    agent_module._EvoScientist_agent_expert_token = None
+    try:
+        yield
+    finally:
+        (
+            agent_module._EvoScientist_agent,
+            agent_module._EvoScientist_agent_expert_token,
+        ) = saved
+
+
+def _seat(agent: object, token: str) -> None:
+    """Put a pre-built agent in the module cache, as a successful build would."""
+    agent_module._EvoScientist_agent = agent
+    agent_module._EvoScientist_agent_expert_token = token
+
+
+@pytest.fixture
+def build(monkeypatch):
+    """Make the build fail at the kwargs step, counting attempts.
+
+    The three calls ahead of it are stubbed because ``_get_default_middleware``
+    reaches ``_ensure_chat_model`` and would raise on the missing model
+    configuration before the interesting failure — these tests stay runnable
+    without credentials, unlike the factory tests that construct a real agent.
+
+    Failing at the kwargs step is also where a malformed expert actually bites:
+    ``_fold_expert_subagents`` runs inside ``_build_base_kwargs``.
+    """
+    calls: list[int] = []
+
+    def _fail(*_args, **_kwargs):
+        calls.append(1)
+        raise RuntimeError("bad expert spec")
+
+    monkeypatch.setattr(agent_module, "_ensure_config", lambda: _StubConfig())
+    monkeypatch.setattr(agent_module, "_get_default_backend", lambda: object())
+    monkeypatch.setattr(agent_module, "_get_default_middleware", lambda: [])
+    monkeypatch.setattr(agent_module, "load_mcp_and_build_kwargs", _fail)
+    monkeypatch.setattr(agent_module, "_build_base_kwargs", _fail)
+    return calls
+
+
+class _StubConfig:
+    auto_approve = False
+    recursion_limit = 100
+
+
+class TestFailedRebuildKeepsTheSeatedAgent:
+    """A build that raises must degrade, not kill the deployment.
+
+    The rebuild trigger is agent-authored content — the workspace skills tier
+    is writable so the agent can be asked to write an expert — so a
+    half-written file reaches this path in normal use.
+    """
+
+    def test_a_failed_rebuild_returns_the_previous_agent(self, build, monkeypatch):
+        monkeypatch.setattr(
+            expert_container, "dispatchable_experts_token", lambda **_k: "new"
+        )
+        seated = object()
+        _seat(seated, "old")
+
+        assert agent_module._get_default_agent() is seated
+        assert agent_module._EvoScientist_agent is seated
+
+    def test_a_failed_rebuild_is_not_retried_on_every_call(self, build, monkeypatch):
+        """The token of the *attempt* is stamped, not the old one.
+
+        Without that, the WebUI would re-enter the failing build once per
+        HTTP request — including for read-only state polls.
+        """
+        monkeypatch.setattr(
+            expert_container, "dispatchable_experts_token", lambda **_k: "new"
+        )
+        _seat(object(), "old")
+
+        for _ in range(3):
+            agent_module._get_default_agent()
+
+        assert len(build) == 1
+
+    def test_a_failed_rebuild_rolls_the_cue_back(self, build, monkeypatch):
+        """The staleness probe restamps the memo before the build is tried.
+
+        If the build then fails, the expert prompt and the ``/expert`` popup
+        must not go on offering an expert ``task()`` cannot route.
+        """
+        monkeypatch.setattr(
+            expert_container, "_reset_dispatchable_experts_cache", lambda: None
+        )
+        expert_container._dispatchable_cache_key = (0, True)
+        expert_container._dispatchable_cache_value = ["seated-set"]
+        expert_container._dispatchable_memo_prev = ((0, True), ["seated-set"])
+
+        def _token_that_restamps(**_kwargs):
+            expert_container._dispatchable_memo_prev = (
+                expert_container._dispatchable_cache_key,
+                expert_container._dispatchable_cache_value,
+            )
+            expert_container._dispatchable_cache_value = ["seated-set", "not-built"]
+            return "new"
+
+        monkeypatch.setattr(
+            expert_container, "dispatchable_experts_token", _token_that_restamps
+        )
+        _seat(object(), "old")
+
+        agent_module._get_default_agent()
+
+        assert expert_container._dispatchable_cache_value == ["seated-set"]
+
+    def test_a_failed_first_build_still_raises(self, build, monkeypatch):
+        """With no previous agent there is nothing to degrade to.
+
+        Also the ``_replace_chat_model`` path: it nulls the agent global
+        itself, so ``previous`` is ``None`` and a failed rebuild cannot
+        re-seat an agent still bound to the superseded chat model.
+        """
+        monkeypatch.setattr(
+            expert_container, "dispatchable_experts_token", lambda **_k: "new"
+        )
+        agent_module._EvoScientist_agent = None
+
+        with pytest.raises(RuntimeError, match="bad expert spec"):
+            agent_module._get_default_agent()
+
+    def test_a_failed_rebuild_warns(self, build, monkeypatch, caplog):
+        """A silent fallback would leave nobody able to tell it is still in effect."""
+        monkeypatch.setattr(
+            expert_container, "dispatchable_experts_token", lambda **_k: "new"
+        )
+        _seat(object(), "old")
+
+        with caplog.at_level("WARNING"):
+            agent_module._get_default_agent()
+
+        assert any("Agent rebuild failed" in r.message for r in caplog.records)
+
+
+class TestUnchangedRegistryDoesNotRebuild:
+    def test_a_matching_token_returns_the_cached_agent(self, monkeypatch):
+        monkeypatch.setattr(
+            expert_container, "dispatchable_experts_token", lambda **_k: "same"
+        )
+        seated = object()
+        _seat(seated, "same")
+
+        # No build stub needed: reaching the build at all would raise on the
+        # missing model configuration, so returning cleanly is the assertion.
+        assert agent_module._get_default_agent() is seated

--- a/tests/test_expert_container.py
+++ b/tests/test_expert_container.py
@@ -929,6 +929,33 @@ class TestRollbackDispatchableMemo:
             rollback_dispatchable_memo()
             assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
 
+    def test_restamp_false_leaves_the_memo_untouched(self):
+        """Detection must not advertise ahead of the rebuild.
+
+        The background refresher reads the token to decide whether to rebuild,
+        and the rebuild takes seconds. Restamping at detection time would have
+        the active-expert cue naming the new expert for that whole window,
+        while ``task()`` still cannot route to it.
+        """
+        _reset_dispatchable_experts_cache()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha")],
+        ):
+            list_dispatchable_experts()  # the set the seated agent was built from
+            alpha_only = dispatchable_experts_token(restamp=False)
+
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha"), _expert("beta")],
+        ):
+            with_beta = dispatchable_experts_token(restamp=False)
+            # The cue still reports only what the seated agent can reach...
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
+
+        # ...while the token is still a real change signal.
+        assert with_beta != alpha_only
+
     def test_rollback_is_safe_before_any_walk(self):
         """Nothing has been displaced yet; rolling back must not crash."""
         _reset_dispatchable_experts_cache()

--- a/tests/test_expert_container.py
+++ b/tests/test_expert_container.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 
 from EvoScientist.subagents.expert_container import (
     _compose_system_prompt,
+    _reset_dispatchable_experts_cache,
     build_expert_subagent_spec,
     build_expert_subagent_specs,
+    dispatchable_experts_token,
     expert_prompt_body,
     list_dispatchable_experts,
 )
@@ -638,3 +640,144 @@ class TestListDispatchableExpertsSurvivesAsyncOutage:
         ):
             result = list_dispatchable_experts(cfg=cfg)
         assert [s.name for s in result] == ["idea-brainstorm"]
+
+
+# =============================================================================
+# epoch-keyed cache + registry token
+# =============================================================================
+
+
+def _expert(name: str, body: str = "persona body\n") -> SkillInfo:
+    return SkillInfo(
+        name=name,
+        description=f"{name} description",
+        path=Path("/tmp/nope") / name,
+        source="builtin",
+        type="expert",
+        role=f"{name} role",
+        body=body,
+    )
+
+
+class TestDispatchableExpertsCache:
+    """``list_dispatchable_experts`` runs on the async model-call path via
+    the active-expert cue, so it is memoised on ``skills_epoch()`` rather
+    than walking the skills tree per call.
+    """
+
+    def test_second_call_at_same_epoch_does_not_re_read(self):
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha")],
+        ) as listing:
+            first = list_dispatchable_experts()
+            second = list_dispatchable_experts()
+        assert [s.name for s in first] == ["alpha"]
+        assert [s.name for s in second] == ["alpha"]
+        assert listing.call_count == 1
+
+    def test_epoch_bump_re_reads(self):
+        from EvoScientist.tools import skills_manager
+
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha")],
+        ):
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
+        skills_manager._notify_skills_changed()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha"), _expert("beta")],
+        ):
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha", "beta"]
+
+    def test_include_system_is_part_of_the_key(self):
+        """Two callers asking different questions must not share an answer."""
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            side_effect=lambda include_system=True: (
+                [_expert("alpha"), _expert("beta")]
+                if include_system
+                else [_expert("alpha")]
+            ),
+        ):
+            with_system = list_dispatchable_experts(include_system=True)
+            without_system = list_dispatchable_experts(include_system=False)
+        assert [s.name for s in with_system] == ["alpha", "beta"]
+        assert [s.name for s in without_system] == ["alpha"]
+
+    def test_returned_list_is_a_copy(self):
+        """A caller sorting or popping the result can't corrupt the memo."""
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha"), _expert("beta")],
+        ):
+            first = list_dispatchable_experts()
+            first.clear()
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha", "beta"]
+
+
+class TestDispatchableExpertsToken:
+    """The token decides whether a *constructed* agent is stale.
+
+    It must move when — and only when — rebuilding would change which
+    experts ``task`` / ``start_async_task`` reach, or what they are
+    prompted with.
+    """
+
+    def _token_for(self, skills: list[SkillInfo]) -> str:
+        _reset_dispatchable_experts_cache()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=skills,
+        ):
+            return dispatchable_experts_token()
+
+    def test_stable_for_an_unchanged_registry(self):
+        skills = [_expert("alpha"), _expert("beta")]
+        assert self._token_for(skills) == self._token_for(skills)
+
+    def test_changes_when_an_expert_is_added(self):
+        before = self._token_for([_expert("alpha")])
+        after = self._token_for([_expert("alpha"), _expert("beta")])
+        assert before != after
+
+    def test_changes_when_an_expert_is_removed(self):
+        before = self._token_for([_expert("alpha"), _expert("beta")])
+        after = self._token_for([_expert("alpha")])
+        assert before != after
+
+    def test_changes_when_an_actor_definition_is_edited(self):
+        """The in-turn spec bakes the prompt at ``create_deep_agent`` time.
+
+        Without hashing the body, a reinstall that only rewrites an
+        expert's AGENTS.md would leave ``task()`` serving the old persona
+        while the background reach — which resolves the skill at
+        model-call time — served the new one.
+        """
+        before = self._token_for([_expert("alpha", body="original persona\n")])
+        after = self._token_for([_expert("alpha", body="rewritten persona\n")])
+        assert before != after
+
+    def test_ignores_filesystem_ordering(self):
+        alpha, beta = _expert("alpha"), _expert("beta")
+        assert self._token_for([alpha, beta]) == self._token_for([beta, alpha])
+
+    def test_unchanged_by_a_non_expert_skill_install(self):
+        """A utility skill bumps the epoch but must not force a rebuild.
+
+        Utility skills are already live through the ``/skills/`` mount, so
+        charging an agent rebuild for one would be pure cost.
+        """
+        from EvoScientist.tools import skills_manager
+
+        experts = [_expert("alpha")]
+        before = self._token_for(experts)
+        skills_manager._notify_skills_changed()
+        assert self._token_for(experts) == before
+
+    def test_ignores_experts_that_are_not_dispatchable(self):
+        """The token describes the registry, not the skills directory."""
+        with_blank = self._token_for([_expert("alpha"), _expert("blank", body="  \n")])
+        without = self._token_for([_expert("alpha")])
+        assert with_blank == without

--- a/tests/test_expert_container.py
+++ b/tests/test_expert_container.py
@@ -781,3 +781,88 @@ class TestDispatchableExpertsToken:
         with_blank = self._token_for([_expert("alpha"), _expert("blank", body="  \n")])
         without = self._token_for([_expert("alpha")])
         assert with_blank == without
+
+
+class TestDispatchableExpertsTokenSeesMidRunEdits:
+    """The token must not be gated on ``skills_epoch()``.
+
+    The workspace skills tier is writable by the agent itself —
+    ``backends.MergedSkillsBackend`` routes ``write``/``edit`` there — so a
+    user can ask the agent to author or rewrite an expert mid-session. That
+    path never calls ``install_skill``, so the epoch never moves and the
+    epoch-keyed memo never expires. These tests pin the walk that makes
+    such changes visible; none of them bumps the epoch or resets the memo
+    between the two states.
+    """
+
+    def test_an_edited_actor_definition_moves_the_token(self):
+        _reset_dispatchable_experts_cache()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha", body="original persona\n")],
+        ):
+            before = dispatchable_experts_token()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha", body="rewritten persona\n")],
+        ):
+            after = dispatchable_experts_token()
+        assert before != after
+
+    def test_an_expert_authored_without_an_install_moves_the_token(self):
+        """An expert the agent was asked to write must be dispatchable."""
+        _reset_dispatchable_experts_cache()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha")],
+        ):
+            before = dispatchable_experts_token()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha"), _expert("authored-in-session")],
+        ):
+            after = dispatchable_experts_token()
+        assert before != after
+
+    def test_the_walk_restamps_the_memo_the_cue_reads(self):
+        """Otherwise the cue would under-report what ``task()`` can reach.
+
+        ``_dispatchable_names`` reads the epoch-keyed memo on every model
+        call. At an unchanged epoch it would keep serving the pre-edit list
+        while the rebuilt agent could already dispatch to the new expert.
+        The token's walk restamps the memo so one tree read serves both.
+        """
+        _reset_dispatchable_experts_cache()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha")],
+        ):
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha"), _expert("authored-in-session")],
+        ) as listing:
+            dispatchable_experts_token()
+            assert [s.name for s in list_dispatchable_experts()] == [
+                "alpha",
+                "authored-in-session",
+            ]
+            # One walk, not two: the cue reuses what the token just read.
+            assert listing.call_count == 1
+
+    def test_a_stale_memo_never_shadows_the_token(self):
+        """The memo is a hot-path optimisation, never the token's source."""
+        _reset_dispatchable_experts_cache()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha")],
+        ):
+            # Seed the memo at this epoch, so a memo-reading token would be
+            # pinned to the pre-edit view for the rest of the epoch.
+            list_dispatchable_experts()
+            before = dispatchable_experts_token()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha", body="rewritten persona\n")],
+        ):
+            assert dispatchable_experts_token() != before

--- a/tests/test_expert_container.py
+++ b/tests/test_expert_container.py
@@ -14,7 +14,7 @@ from EvoScientist.subagents.expert_container import (
     dispatchable_experts_token,
     expert_prompt_body,
     list_dispatchable_experts,
-    rollback_dispatchable_memo,
+    publish_dispatchable_experts,
 )
 from EvoScientist.tools.skills_manager import SkillInfo
 
@@ -855,13 +855,13 @@ class TestDispatchableExpertsTokenSeesMidRunEdits:
             after = dispatchable_experts_token()
         assert before != after
 
-    def test_the_walk_restamps_the_memo_the_cue_reads(self):
-        """Otherwise the cue would under-report what ``task()`` can reach.
+    def test_the_cue_follows_the_rebuild_rather_than_the_edit(self):
+        """Otherwise the cue would mis-report what ``task()`` can reach.
 
         ``_dispatchable_names`` reads the epoch-keyed memo on every model
-        call. At an unchanged epoch it would keep serving the pre-edit list
-        while the rebuilt agent could already dispatch to the new expert.
-        The token's walk restamps the memo so one tree read serves both.
+        call, and an in-session edit never moves the epoch. So the memo has
+        to be written by something — and it matters that the something is
+        the finished rebuild, not the walk that decided to start one.
         """
         _reset_dispatchable_experts_cache()
         with patch(
@@ -872,14 +872,17 @@ class TestDispatchableExpertsTokenSeesMidRunEdits:
         with patch(
             "EvoScientist.tools.skills_manager.list_expert_skills",
             return_value=[_expert("alpha"), _expert("authored-in-session")],
-        ) as listing:
+        ):
+            # Detection: the agent is still the one built from ``alpha``.
             dispatchable_experts_token()
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
+
+            # The rebuild finished, so now the cue may name the new expert.
+            publish_dispatchable_experts()
             assert [s.name for s in list_dispatchable_experts()] == [
                 "alpha",
                 "authored-in-session",
             ]
-            # One walk, not two: the cue reuses what the token just read.
-            assert listing.call_count == 1
 
     def test_a_stale_memo_never_shadows_the_token(self):
         """The memo is a hot-path optimisation, never the token's source."""
@@ -899,69 +902,50 @@ class TestDispatchableExpertsTokenSeesMidRunEdits:
             assert dispatchable_experts_token() != before
 
 
-class TestRollbackDispatchableMemo:
-    """The token restamps the memo before anyone knows the rebuild worked.
+class TestOnlyASuccessfulBuildStampsTheMemo:
+    """Detection must not advertise ahead of the rebuild it triggers.
 
-    When it didn't, the cue and the ``/expert`` popup would go on naming an
-    expert the still-seated agent cannot route to — the same
-    advertise-versus-provide gap this module exists to close, moved onto the
-    failure branch.
+    Deciding whether to rebuild and announcing the result are separate
+    events with seconds between them, and the rebuild can fail in between.
+    Only the second one may write the memo the cue and the ``/expert``
+    popup read.
     """
 
-    def test_rollback_restores_the_pre_probe_list(self):
-        _reset_dispatchable_experts_cache()
-        with patch(
-            "EvoScientist.tools.skills_manager.list_expert_skills",
-            return_value=[_expert("alpha")],
-        ):
-            # The set the seated agent was built from.
-            list_dispatchable_experts()
-
-        with patch(
-            "EvoScientist.tools.skills_manager.list_expert_skills",
-            return_value=[_expert("alpha"), _expert("beta")],
-        ):
-            # A staleness probe: walks, restamps, decides a rebuild is due.
-            dispatchable_experts_token()
-            assert [s.name for s in list_dispatchable_experts()] == ["alpha", "beta"]
-
-            # The rebuild failed, so the new expert is not reachable.
-            rollback_dispatchable_memo()
-            assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
-
-    def test_restamp_false_leaves_the_memo_untouched(self):
-        """Detection must not advertise ahead of the rebuild.
-
-        The background refresher reads the token to decide whether to rebuild,
-        and the rebuild takes seconds. Restamping at detection time would have
-        the active-expert cue naming the new expert for that whole window,
-        while ``task()`` still cannot route to it.
-        """
+    def test_the_token_never_stamps_the_memo(self):
         _reset_dispatchable_experts_cache()
         with patch(
             "EvoScientist.tools.skills_manager.list_expert_skills",
             return_value=[_expert("alpha")],
         ):
             list_dispatchable_experts()  # the set the seated agent was built from
-            alpha_only = dispatchable_experts_token(restamp=False)
+            alpha_only = dispatchable_experts_token()
 
         with patch(
             "EvoScientist.tools.skills_manager.list_expert_skills",
             return_value=[_expert("alpha"), _expert("beta")],
         ):
-            with_beta = dispatchable_experts_token(restamp=False)
-            # The cue still reports only what the seated agent can reach...
+            # Reading it repeatedly must stay side-effect-free: the CLI walks
+            # twice per rebuild turn (``await_ready`` then ``start``).
+            with_beta = dispatchable_experts_token()
+            assert dispatchable_experts_token() == with_beta
+            # The cue still reports only what the seated agent can reach.
             assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
 
         # ...while the token is still a real change signal.
         assert with_beta != alpha_only
 
-    def test_rollback_is_safe_before_any_walk(self):
-        """Nothing has been displaced yet; rolling back must not crash."""
+    def test_publish_stamps_the_memo_without_advancing_the_epoch(self):
+        """What a finished rebuild calls, and the only thing that writes."""
         _reset_dispatchable_experts_cache()
-        rollback_dispatchable_memo()
         with patch(
             "EvoScientist.tools.skills_manager.list_expert_skills",
             return_value=[_expert("alpha")],
         ):
-            assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
+            list_dispatchable_experts()
+
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha"), _expert("beta")],
+        ):
+            publish_dispatchable_experts()
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha", "beta"]

--- a/tests/test_expert_container.py
+++ b/tests/test_expert_container.py
@@ -14,6 +14,7 @@ from EvoScientist.subagents.expert_container import (
     dispatchable_experts_token,
     expert_prompt_body,
     list_dispatchable_experts,
+    rollback_dispatchable_memo,
 )
 from EvoScientist.tools.skills_manager import SkillInfo
 
@@ -647,14 +648,19 @@ class TestListDispatchableExpertsSurvivesAsyncOutage:
 # =============================================================================
 
 
-def _expert(name: str, body: str = "persona body\n") -> SkillInfo:
+def _expert(
+    name: str,
+    body: str = "persona body\n",
+    description: str | None = None,
+    role: str | None = None,
+) -> SkillInfo:
     return SkillInfo(
         name=name,
-        description=f"{name} description",
+        description=f"{name} description" if description is None else description,
         path=Path("/tmp/nope") / name,
         source="builtin",
         type="expert",
-        role=f"{name} role",
+        role=f"{name} role" if role is None else role,
         body=body,
     )
 
@@ -757,6 +763,31 @@ class TestDispatchableExpertsToken:
         """
         before = self._token_for([_expert("alpha", body="original persona\n")])
         after = self._token_for([_expert("alpha", body="rewritten persona\n")])
+        assert before != after
+
+    def test_changes_when_a_description_is_edited(self):
+        """``description`` is baked into BOTH dispatch tools' schemas.
+
+        deepagents builds the ``task`` tool description from the folded
+        specs, and ``expert_async_subagent`` builds ``start_async_task``'s
+        the same way. An edited ``description:`` that didn't move the token
+        would leave the orchestrator choosing between experts on stale
+        blurbs, on both reaches, until something else forced a rebuild.
+        """
+        before = self._token_for([_expert("alpha", description="reviews physics")])
+        after = self._token_for([_expert("alpha", description="reviews chemistry")])
+        assert before != after
+
+    def test_changes_when_a_role_is_edited(self):
+        """``role`` is prepended to the frozen ``system_prompt``.
+
+        ``_compose_system_prompt`` turns it into the "You are …" line, so
+        hashing the raw actor body alone would miss it. Only legacy
+        frontmatter experts set ``role`` — the AGENTS.md contract forces it
+        empty — but those still ship in this tree.
+        """
+        before = self._token_for([_expert("alpha", role="a physics reviewer")])
+        after = self._token_for([_expert("alpha", role="a chemistry reviewer")])
         assert before != after
 
     def test_ignores_filesystem_ordering(self):
@@ -866,3 +897,44 @@ class TestDispatchableExpertsTokenSeesMidRunEdits:
             return_value=[_expert("alpha", body="rewritten persona\n")],
         ):
             assert dispatchable_experts_token() != before
+
+
+class TestRollbackDispatchableMemo:
+    """The token restamps the memo before anyone knows the rebuild worked.
+
+    When it didn't, the cue and the ``/expert`` popup would go on naming an
+    expert the still-seated agent cannot route to — the same
+    advertise-versus-provide gap this module exists to close, moved onto the
+    failure branch.
+    """
+
+    def test_rollback_restores_the_pre_probe_list(self):
+        _reset_dispatchable_experts_cache()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha")],
+        ):
+            # The set the seated agent was built from.
+            list_dispatchable_experts()
+
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha"), _expert("beta")],
+        ):
+            # A staleness probe: walks, restamps, decides a rebuild is due.
+            dispatchable_experts_token()
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha", "beta"]
+
+            # The rebuild failed, so the new expert is not reachable.
+            rollback_dispatchable_memo()
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha"]
+
+    def test_rollback_is_safe_before_any_walk(self):
+        """Nothing has been displaced yet; rolling back must not crash."""
+        _reset_dispatchable_experts_cache()
+        rollback_dispatchable_memo()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_expert("alpha")],
+        ):
+            assert [s.name for s in list_dispatchable_experts()] == ["alpha"]

--- a/tests/test_expert_registry_end_to_end.py
+++ b/tests/test_expert_registry_end_to_end.py
@@ -1,0 +1,105 @@
+"""The cue's expert set must match the set the seated agent was built from.
+
+Every other test of this machinery substitutes a fake for one of the two
+things that have to agree: the tree walk, or the token read that decides
+whether to rebuild. This one patches only the data source
+(``list_expert_skills``) and drives the real ``BackgroundAgentLoader``
+against the real ``dispatchable_experts_token``, so a rebuild reads the
+token as many times as the production path reads it — which is what any
+scheme keyed on "how many reads happened" gets wrong.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from EvoScientist.cli._agent_loader import BackgroundAgentLoader
+from EvoScientist.subagents.expert_container import (
+    dispatchable_experts_token,
+    list_dispatchable_experts,
+    publish_dispatchable_experts,
+)
+from EvoScientist.tools.skills_manager import SkillInfo
+
+_SKILLS = "EvoScientist.tools.skills_manager.list_expert_skills"
+
+
+def _expert(name: str) -> SkillInfo:
+    return SkillInfo(
+        name=name,
+        description=f"{name} description",
+        path=Path("/tmp/nope") / name,
+        source="builtin",
+        type="expert",
+        role=f"{name} role",
+        body="persona body\n",
+    )
+
+
+def _cue_names() -> list[str]:
+    """What the active-expert cue and the ``/expert`` popup would report."""
+    return [s.name for s in list_dispatchable_experts()]
+
+
+def _loader(fail_rebuild: bool) -> tuple[BackgroundAgentLoader, object, list[str]]:
+    seated = object()
+    rebuilt = object()
+    builds: list[int] = []
+    reported: list[str] = []
+
+    def loader_fn(**_kwargs: object) -> object:
+        builds.append(1)
+        if len(builds) == 1:
+            return seated
+        if fail_rebuild:
+            raise RuntimeError("rebuild boom")
+        return rebuilt
+
+    loader: BackgroundAgentLoader = BackgroundAgentLoader(
+        loader_fn,
+        on_rebuild_failed=lambda exc: reported.append(str(exc)),
+        build_token=dispatchable_experts_token,
+        publish_build=publish_dispatchable_experts,
+    )
+    return loader, seated if fail_rebuild else rebuilt, reported
+
+
+async def test_a_failed_rebuild_leaves_the_cue_on_the_seated_expert_set():
+    """The divergence this whole mechanism exists to prevent, on the branch
+    where it is hardest to get right.
+
+    ``await_ready`` reads the token and ``start`` reads it again, so any
+    scheme that stamps at decision time and undoes the stamp on failure has
+    two writes to undo and one slot to undo them with.
+    """
+    loader, expected_agent, reported = _loader(fail_rebuild=True)
+
+    with patch(_SKILLS, return_value=[_expert("alpha")]):
+        loader.start()
+        assert await loader.await_ready() is expected_agent
+        assert _cue_names() == ["alpha"]
+
+    # ``beta`` is authored mid-session. The rebuild it triggers fails, so the
+    # seated agent still cannot route ``task()`` to it.
+    with patch(_SKILLS, return_value=[_expert("alpha"), _expert("beta")]):
+        assert await loader.await_ready() is expected_agent
+        assert _cue_names() == ["alpha"]
+
+    assert reported == ["rebuild boom"]
+
+
+async def test_a_successful_rebuild_publishes_the_new_expert_set():
+    """The other half: withholding the stamp must not withhold it forever."""
+    loader, expected_agent, reported = _loader(fail_rebuild=False)
+
+    with patch(_SKILLS, return_value=[_expert("alpha")]):
+        loader.start()
+        await loader.await_ready()
+        assert _cue_names() == ["alpha"]
+
+    with patch(_SKILLS, return_value=[_expert("alpha"), _expert("beta")]):
+        assert await loader.await_ready() is expected_agent
+        assert _cue_names() == ["alpha", "beta"]
+
+    assert reported == []

--- a/tests/test_experts_command.py
+++ b/tests/test_experts_command.py
@@ -6,25 +6,16 @@ from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import patch
 
-import pytest
-
 from EvoScientist.commands.base import ChannelRuntime, CommandContext
 from EvoScientist.commands.implementation.experts import (
     ExpertCommand,
     ExpertsCommand,
-    invalidate_experts_cache,
 )
 
-
-@pytest.fixture(autouse=True)
-def _bust_experts_cache_between_tests():
-    """The dispatchable-experts cache in ``experts.py`` is module-level; without
-    resetting it, a test that patches ``list_expert_skills`` sees the previous
-    test's fakes.
-    """
-    invalidate_experts_cache()
-    yield
-    invalidate_experts_cache()
+# The dispatchable-experts memo these commands read through is reset around
+# every test by the autouse ``_reset_dispatchable_experts_cache`` fixture in
+# ``tests/conftest.py`` — without it, a test that patches
+# ``list_expert_skills`` would see the previous test's fakes.
 
 
 class _FakeUI:
@@ -169,6 +160,19 @@ class TestExpertToggle:
             await ExpertCommand().execute(ctx, args=["idea-brainstorm"])
         assert ctx.channel_runtime.active_teams == ["idea-brainstorm"]
         assert any("Invited expert: idea-brainstorm" in text for text, _ in ui.lines)
+
+    async def test_invite_does_not_tell_the_user_to_run_new(self):
+        """The agent rebuilds itself when the expert registry changes, so
+        an invite must not send the user through ``/new`` — which would
+        activate the expert at the cost of the conversation.
+        """
+        ctx, ui = _make_ctx()
+        with patch(
+            "EvoScientist.tools.skills_manager.list_expert_skills",
+            return_value=[_FakeSkillInfo(name="idea-brainstorm")],
+        ):
+            await ExpertCommand().execute(ctx, args=["idea-brainstorm"])
+        assert not any("/new" in text for text, _ in ui.lines)
 
     async def test_toggle_dismisses_when_already_invited(self):
         ctx, ui = _make_ctx(active_teams=["idea-brainstorm"])

--- a/tests/test_experts_command.py
+++ b/tests/test_experts_command.py
@@ -172,6 +172,10 @@ class TestExpertToggle:
             return_value=[_FakeSkillInfo(name="idea-brainstorm")],
         ):
             await ExpertCommand().execute(ctx, args=["idea-brainstorm"])
+        # Anchor the negative assertion to a successful invite — otherwise it
+        # also passes when the invite fails outright and prints "unknown
+        # expert", which mentions no ``/new`` either.
+        assert any("Invited expert: idea-brainstorm" in text for text, _ in ui.lines)
         assert not any("/new" in text for text, _ in ui.lines)
 
     async def test_toggle_dismisses_when_already_invited(self):

--- a/tests/test_registry_refresh.py
+++ b/tests/test_registry_refresh.py
@@ -1,0 +1,182 @@
+"""Tests for the deployed graph's background expert-registry refresh.
+
+The request path must stay inert — a staleness check there is blocking work on
+the event loop, which langgraph-dev's blockbuster guard raises on rather than
+merely slows. These tests pin that the watching happens off-request, that a
+skill install wakes it without waiting out the poll, and that a bad pass cannot
+end the watch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from EvoScientist.langgraph_dev import registry_refresh
+
+
+@pytest.fixture(autouse=True)
+def _deploy_mode(monkeypatch):
+    """Run as the deployed main agent unless a test says otherwise."""
+    monkeypatch.setenv("EVOSCIENTIST_DEPLOY_MODE", "full")
+
+
+@pytest.fixture(autouse=True)
+def _fast_poll(monkeypatch):
+    """Keep the poll backstop far below any test timeout."""
+    monkeypatch.setattr(registry_refresh, "POLL_INTERVAL_SECONDS", 0.01)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_skills_callbacks(monkeypatch):
+    """The callback list is process-scoped and never unregistered."""
+    from EvoScientist.tools import skills_manager
+
+    monkeypatch.setattr(skills_manager, "_skills_changed_callbacks", [])
+
+
+class _Registry:
+    """Stand-in for the token source and the rebuild."""
+
+    def __init__(self, token: str = "t0") -> None:
+        self.token = token
+        self.rebuilds = 0
+        self.restamp_calls: list[bool] = []
+        self.fail_next = False
+
+    def read_token(self, *, include_system: bool = True, restamp: bool = True) -> str:
+        self.restamp_calls.append(restamp)
+        return self.token
+
+    def rebuild(self):
+        self.rebuilds += 1
+        if self.fail_next:
+            raise RuntimeError("half-written expert")
+        return object()
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    reg = _Registry()
+    monkeypatch.setattr(
+        "EvoScientist.subagents.expert_container.dispatchable_experts_token",
+        reg.read_token,
+    )
+    monkeypatch.setattr(
+        "EvoScientist.langgraph_dev.main_graph.refresh_main_graph", reg.rebuild
+    )
+    return reg
+
+
+async def _settle(predicate, timeout: float = 2.0) -> None:
+    """Await a condition without pinning the test to a sleep duration."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError("condition not reached within timeout")
+
+
+class TestRefreshLoop:
+    async def test_builds_once_at_startup(self, registry):
+        async with registry_refresh.expert_registry_refresher():
+            await _settle(lambda: registry.rebuilds >= 1)
+        assert registry.rebuilds == 1
+
+    async def test_unchanged_registry_does_not_rebuild_again(self, registry):
+        async with registry_refresh.expert_registry_refresher():
+            await _settle(lambda: registry.rebuilds >= 1)
+            # Several poll intervals with a stable token.
+            await asyncio.sleep(0.1)
+        assert registry.rebuilds == 1
+
+    async def test_a_changed_token_rebuilds(self, registry):
+        async with registry_refresh.expert_registry_refresher():
+            await _settle(lambda: registry.rebuilds >= 1)
+            registry.token = "t1"
+            await _settle(lambda: registry.rebuilds >= 2)
+        assert registry.rebuilds == 2
+
+    async def test_detection_never_restamps_the_cue_memo(self, registry):
+        """Restamping at detection time would have the active-expert cue name
+        the new expert for the whole rebuild, before ``task()`` can route to it.
+        """
+        async with registry_refresh.expert_registry_refresher():
+            await _settle(lambda: registry.rebuilds >= 1)
+        assert registry.restamp_calls
+        assert not any(registry.restamp_calls)
+
+    async def test_a_failed_rebuild_does_not_end_the_watch(self, registry, caplog):
+        """A half-written expert must not disable refresh for the process."""
+        registry.fail_next = True
+        async with registry_refresh.expert_registry_refresher():
+            await _settle(lambda: registry.rebuilds >= 1)
+            registry.fail_next = False
+            registry.token = "t2"
+            await _settle(lambda: registry.rebuilds >= 2)
+        assert "refresh pass failed" in caplog.text
+
+    async def test_a_failed_pass_is_retried_rather_than_accepted(self, registry):
+        """The failed token must not be recorded as current, or the retry
+        would be skipped and the expert would never become reachable."""
+        registry.fail_next = True
+        async with registry_refresh.expert_registry_refresher():
+            await _settle(lambda: registry.rebuilds >= 2)
+        assert registry.rebuilds >= 2
+
+
+class TestPushWakeup:
+    async def test_a_skill_install_wakes_the_loop(self, registry, monkeypatch):
+        """Installs must not wait out the poll interval.
+
+        Set the poll far beyond the test's patience, so only the push hook can
+        drive the second rebuild.
+        """
+        monkeypatch.setattr(registry_refresh, "POLL_INTERVAL_SECONDS", 3600.0)
+        from EvoScientist.tools import skills_manager
+
+        async with registry_refresh.expert_registry_refresher():
+            await _settle(lambda: registry.rebuilds >= 1)
+            registry.token = "t1"
+            # Fires on a worker thread in production; the hop back to the loop
+            # is the loader's job, so exercise it from a thread here too.
+            await asyncio.to_thread(skills_manager._notify_skills_changed)
+            await _settle(lambda: registry.rebuilds >= 2)
+        assert registry.rebuilds == 2
+
+
+class TestDeployModeGate:
+    async def test_no_watch_outside_deploy_mode(self, registry, monkeypatch):
+        """Under ``EvoSci`` / ``EvoSci serve`` the deployed main agent is dead
+        code, so refreshing it would be pure waste."""
+        monkeypatch.setenv("EVOSCIENTIST_DEPLOY_MODE", "stripped")
+        async with registry_refresh.expert_registry_refresher():
+            await asyncio.sleep(0.1)
+        assert registry.rebuilds == 0
+
+    async def test_no_watch_when_unset(self, registry, monkeypatch):
+        monkeypatch.delenv("EVOSCIENTIST_DEPLOY_MODE", raising=False)
+        async with registry_refresh.expert_registry_refresher():
+            await asyncio.sleep(0.1)
+        assert registry.rebuilds == 0
+
+
+class TestShutdown:
+    async def test_exiting_cancels_the_task(self, registry):
+        async with registry_refresh.expert_registry_refresher():
+            await _settle(lambda: registry.rebuilds >= 1)
+        # No pending task should survive the context manager.
+        pending = [
+            t
+            for t in asyncio.all_tasks()
+            if t.get_name() == "evoscientist-expert-registry-refresh"
+        ]
+        assert pending == []
+
+    async def test_shutdown_is_clean_before_the_first_pass(self, registry):
+        """Entering and immediately leaving must not raise or warn."""
+        async with registry_refresh.expert_registry_refresher():
+            pass

--- a/tests/test_registry_refresh.py
+++ b/tests/test_registry_refresh.py
@@ -10,10 +10,30 @@ end the watch.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from EvoScientist.langgraph_dev import registry_refresh
+from EvoScientist.subagents.expert_container import (
+    dispatchable_experts_token as _REAL_TOKEN,
+)
+from EvoScientist.tools.skills_manager import SkillInfo
+
+_SKILLS = "EvoScientist.tools.skills_manager.list_expert_skills"
+
+
+def _expert(name: str) -> SkillInfo:
+    return SkillInfo(
+        name=name,
+        description=f"{name} description",
+        path=Path("/tmp/nope") / name,
+        source="builtin",
+        type="expert",
+        role=f"{name} role",
+        body="persona body\n",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -42,17 +62,17 @@ class _Registry:
     def __init__(self, token: str = "t0") -> None:
         self.token = token
         self.rebuilds = 0
-        self.restamp_calls: list[bool] = []
+        self.token_reads = 0
         self.fail_next = False
 
-    def read_token(self, *, include_system: bool = True, restamp: bool = True) -> str:
-        self.restamp_calls.append(restamp)
+    def read_token(self, *, include_system: bool = True) -> str:
+        self.token_reads += 1
         return self.token
 
     def rebuild(self):
         self.rebuilds += 1
         if self.fail_next:
-            raise RuntimeError("half-written expert")
+            raise RuntimeError("backend construction failed")
         return object()
 
 
@@ -100,17 +120,29 @@ class TestRefreshLoop:
             await _settle(lambda: registry.rebuilds >= 2)
         assert registry.rebuilds == 2
 
-    async def test_detection_never_restamps_the_cue_memo(self, registry):
-        """Restamping at detection time would have the active-expert cue name
+    async def test_detection_never_stamps_the_cue_memo(self, registry, monkeypatch):
+        """Stamping at detection time would have the active-expert cue name
         the new expert for the whole rebuild, before ``task()`` can route to it.
+
+        Restores the real token over the fixture's stand-in and asserts
+        against the real memo, so this still holds if the refresher starts
+        reading it some other way. The stubbed rebuild publishes nothing, so
+        anything in the memo afterwards came from detection.
         """
-        async with registry_refresh.expert_registry_refresher():
-            await _settle(lambda: registry.rebuilds >= 1)
-        assert registry.restamp_calls
-        assert not any(registry.restamp_calls)
+        from EvoScientist.subagents import expert_container
+
+        monkeypatch.setattr(
+            expert_container,
+            "dispatchable_experts_token",
+            _REAL_TOKEN,
+        )
+        with patch(_SKILLS, return_value=[_expert("alpha")]):
+            async with registry_refresh.expert_registry_refresher():
+                await _settle(lambda: registry.rebuilds >= 1)
+        assert expert_container._dispatchable_cache_value is None
 
     async def test_a_failed_rebuild_does_not_end_the_watch(self, registry, caplog):
-        """A half-written expert must not disable refresh for the process."""
+        """One bad build must not disable refresh for the rest of the process."""
         registry.fail_next = True
         async with registry_refresh.expert_registry_refresher():
             await _settle(lambda: registry.rebuilds >= 1)

--- a/tests/test_skills_manager.py
+++ b/tests/test_skills_manager.py
@@ -24,6 +24,7 @@ from EvoScientist.tools.skills_manager import (
     list_skills_by_tag,
     register_skills_changed_callback,
     resolve_remote_head,
+    skills_epoch,
     uninstall_skill,
 )
 
@@ -1850,3 +1851,51 @@ class TestSkillsChangedCallback:
         result = install_skill("/nonexistent/path", str(temp_skills_dir))
         assert result["success"] is False
         assert good == [True]
+
+
+class TestSkillsEpoch:
+    """``skills_epoch`` is the pull-side half of the skills-changed contract.
+
+    Consumers that can't subscribe (lazily-rebuilt module globals, the
+    per-request langgraph graph factory) compare it instead, so it has to
+    advance on exactly the paths the callbacks fire on.
+    """
+
+    def test_epoch_advances_on_install(self, sample_skill_dir, temp_skills_dir):
+        before = skills_epoch()
+        install_skill(str(sample_skill_dir), str(temp_skills_dir))
+        assert skills_epoch() > before
+
+    def test_epoch_advances_on_failed_install(self, temp_skills_dir):
+        """Same as the callbacks: notification is in a ``finally``.
+
+        An install that fails part-way can still have written files, so a
+        failure return is not evidence that nothing changed.
+        """
+        before = skills_epoch()
+        result = install_skill("/nonexistent/path", str(temp_skills_dir))
+        assert result["success"] is False
+        assert skills_epoch() > before
+
+    def test_epoch_advances_on_uninstall(self):
+        before = skills_epoch()
+        uninstall_skill("nonexistent-skill")
+        assert skills_epoch() > before
+
+    def test_epoch_is_stable_without_mutations(self):
+        assert skills_epoch() == skills_epoch()
+
+    def test_callbacks_observe_the_new_epoch(
+        self, isolated_skills_changed_callbacks, temp_skills_dir
+    ):
+        """The bump lands before subscribers run.
+
+        A subscriber that caches against the epoch would otherwise stamp
+        its refreshed value with the pre-mutation counter and go stale
+        immediately.
+        """
+        before = skills_epoch()
+        seen: list[int] = []
+        register_skills_changed_callback(lambda: seen.append(skills_epoch()))
+        install_skill("/nonexistent/path", str(temp_skills_dir))
+        assert seen == [before + 1]


### PR DESCRIPTION
Follow-up to #404. That PR landed the AGENTS.md expert-skill contract and defined what an expert is; this one makes the resulting registry live, so the set of dispatchable experts can change during a session.

## Problem

The expert prompt tells the orchestrator that every installed expert is reachable both in-turn and in the background. That was only ever true of experts that existed when the agent was constructed. `task` and `start_async_task` resolve `subagent_type` against dicts frozen inside `create_deep_agent`, so an expert installed mid-session stayed unreachable until `/new`, which rotates the thread and drops the conversation.

CodeRabbit flagged the visible half of this on #404, against `EvoScientist/middleware/active_team.py#L93-L115` ("Use the live expert registry for active-team reachability"). The active-expert cue was reading a fresh skills-tree walk on every model call, while dispatch resolved against the frozen dicts, so the two could disagree and the cue could name an expert the orchestrator could not reach. That walk was also synchronous filesystem and YAML work running inside `awrap_model_call`.

Both symptoms come from the same gap, so they are fixed together: the cue and the reachable set are now derived from one read.

## Mechanism

`expert_container.dispatchable_experts_token()` fingerprints the registry an agent would be built from. It answers exactly one question for any cache of a constructed agent, namely whether rebuilding right now would change which experts are reachable or what any of them is prompted with. Callers hold the previous value and rebuild when it differs.

The fingerprint covers exactly the three `SkillInfo` fields that get frozen at construction: `name`, `description`, and the composed system prompt. Hashing more than the name set is what makes an edit to an existing expert refresh a stale spec rather than sitting there invisibly. `description` matters on both reaches, not just the in-turn one: deepagents builds the `task` tool description from the folded specs and `middleware/expert_async_subagent.py` builds `start_async_task`'s the same way, so an edited `description:` would otherwise leave the orchestrator choosing between experts on stale blurbs. Composing through `_compose_system_prompt` rather than hashing the raw actor body is what catches a `role:` edit on a legacy frontmatter expert. Nothing else on `SkillInfo` reaches a frozen construct, and the async persona is re-resolved per model call rather than baked.

The token is deliberately narrower than a plain "skills changed" signal in one direction and wider in the other:

- Narrower: installing a utility skill leaves the token unchanged, so it costs no rebuild. Utility skills are already live through the `/skills/` mount.
- Wider: the token walks the skills tree rather than reading a mutation counter, so it also sees an expert authored or edited straight onto the writable workspace skills tier. That tier is writable precisely so the agent can author there, and such a change never calls `install_skill`. Without the walk, asking the agent to write a new expert would produce one it could not dispatch to until `/new`.

`skills_manager.skills_epoch()` is added as the pull-side counterpart to the existing `register_skills_changed_callback`, bumped inside the one existing publish point `_notify_skills_changed`. It keys the `list_dispatchable_experts` memo only. That memo has two readers that would otherwise walk the skills tree: the active-expert cue, which runs on every model call, and the `/expert` popup, which runs per keystroke. Writing it is the job of `publish_dispatchable_experts`, called from the success branch of every agent build and nowhere else, so both surfaces report the expert set the running agent was actually built from rather than merely a current one. The token itself only reads, and takes no argument that would let a caller stamp from a decision point, so a rebuild that raises leaves both surfaces describing the agent still serving - there is no failure branch to get right. One boundary: the memo's key is the epoch, which `install_skill` advances, so between an install and the next build a reader falls through to a fresh walk and can name the new expert a turn early. Tier writes never move the epoch, so the agent-authors-an-expert path is exact.

## Per-surface wiring

- `cli/_agent_loader.py`: `BackgroundAgentLoader` takes an optional `build_token` callable and rebuilds in place inside `await_ready()` when the value moves, replaying the kwargs stored by `start()`. Both UIs funnel every pre-turn agent access through that method, which is why the check lives there instead of in two turn loops. Replaying the stored kwargs preserves the SQLite checkpointer, the session event sink and the MCP tools cache, so there is no reconnect and no progress spam; the thread survives because it lives in session state and is passed per-run rather than being a build input at all. A failed rebuild logs a warning, keeps the previous agent seated, and reports through a distinct `on_rebuild_failed` callback so the UI can say "couldn't pick that up yet" rather than "the load died". A matching `on_rebuild_started` explains the pause, which is otherwise a silent multi-second freeze right after the user presses enter.
- `EvoScientist.py`: `_get_default_agent()` drops its cached agent when the token moves, publishes the new expert set once the build returns, and on a failed rebuild re-seats the previous agent and stamps the attempted token so the failing build is not retried once per request. `previous` is captured before the null-out, which is what keeps this safe alongside `_replace_chat_model`: that function nulls the global itself, so on a model switch there is nothing to fall back to and the failure still raises rather than resurrecting an agent bound to the superseded chat model.
- `langgraph_dev/main_graph.py` and `langgraph_dev/registry_refresh.py`: the deployed graph. See below.
- `commands/implementation/experts.py`: drops its own duplicate cache and its `/new` hint, which is now false. One cache at the choke point instead of two.

## The deployed graph: refreshed off-request

The `EvoScientist` entry in `langgraph.json` becomes a factory, so the graph can change without restarting the dev subprocess. But the factory itself does nothing except return the graph most recently published by `refresh_main_graph`. It performs no token read, no filesystem access and no thread hop.

That restraint is not an optimisation, it is required. `invoke_factory` calls the entry on the event loop for **every** request that touches the graph, and that is wider than run creation - `get_graph` is entered for read-only `GET /threads/{id}/state` and history too. Building the agent constructs the backend, which calls `os.makedirs`, and langgraph-dev installs a blockbuster guard that turns a filesystem call on the loop into a raised `BlockingError` rather than a slow request. A staleness check there does not merely cost time; it fails outright, and mid-session install never worked in the WebUI.

Keeping the graph current is instead the job of `expert_registry_refresher`, a lifespan-scoped background task on the custom Starlette app in `http.py`. langgraph-api merges a user lifespan with its own, so this is the supported seam; it must be `lifespan=` rather than `on_startup`, which `validate_router_lifespan_hooks` refuses to merge. The task is a no-op unless `EVOSCIENTIST_DEPLOY_MODE=full`, since under `EvoSci` / `EvoSci serve` the deployed main agent is dead code.

**It is both pushed and polled, and it needs to be both.** Only `install_skill` and `uninstall_skill` publish through `_notify_skills_changed`. Every other way an expert can appear is silent: `CompositeBackend.execute` is explicitly not path-routed and `USER_SKILLS_DIR` defaults to `WORKSPACE_ROOT / "skills"`, so the sandbox shell running `mkdir skills/<name>` is invisible to Python; autoskills proposal approval copies into that directory without notifying; `write_file` / `edit_file` reach it through three independent `MergedSkillsBackend` mutators with no shared choke point; and nothing at all observes a hand edit. Subscribing to the push hook alone would therefore catch skill installs and miss the agent authoring an expert, which is the case this feature exists to support. Polling alone would make every install wait out the interval. Together, installs take effect as soon as the rebuild finishes and the silent paths within one poll. The refresher is the first in-tree subscriber to `register_skills_changed_callback`, which #371's review kept as exactly this extension point.

Steady-state cost is therefore one skills-tree walk per poll interval on a worker thread, rather than anything at all per request. Detection only reads: stamping the cue's memo at detection time would let it name the new expert for the whole rebuild, before `task()` can route to it, and permanently if that rebuild then failed. The stamp happens in `_get_default_agent` once the build has returned an agent.

## Why the refresh is off-request: two rejected shapes

The CLI and TUI have a natural place to rebuild - the turn boundary, which every pre-turn agent access already funnels through. The deployed graph has no such boundary, and swapping a module global does not help: the runtime collects the compiled graph into `GRAPHS` once at startup and `--no-reload` is set. Making the `langgraph.json` entry a factory is the supported lever. The question was what that factory should do, and two shapes were built and measured before this one.

**A sync factory doing the check inline. Does not work at all.** Building the agent constructs the backend, which calls `os.makedirs`. langgraph-dev enables blockbuster by default (`--allow-blocking` is the only opt-out), which turns a filesystem call on the event loop into a raised `BlockingError` rather than a slow request. So every rebuild failed, every time, and mid-session install never worked in the WebUI. This is not a performance concern; it is a hard failure, and it was invisible to the test suite because blockbuster only runs under the dev server.

**An async factory handing the build to `asyncio.to_thread`. Works, but too expensive at the wrong layer.** This is upstream's own prescribed remedy - their blockbuster warning says verbatim that if an async driver is not available, wrap the blocking call in `asyncio.to_thread()` - and async is a supported factory shape rather than a trick, since `_classify_factory` reads only the signature and `as_asynccontextmanager` explicitly awaits a coroutine return value. It ran correctly. Measured over one WebUI session, it also:

- blocked a read-only `GET /threads/{id}/state` for **14.9 seconds** on a rebuild, which upstream's slow-graph guard escalated to `error`;
- produced **55** `Slow graph load` warnings;
- logged a median of **148 ms** per request against a steady-state token walk of only **17.9 ms** - the difference being `to_thread` scheduling latency while the server is busy streaming a run.

The warnings were themselves new, and the reason is worth recording: a sync factory returns a `CompiledStateGraph`, and `_generate_graph` hits `isinstance(value, Pregel)` and returns *before* the timing log is reached. A coroutine does not match, so it goes through the timed `as_asynccontextmanager` path. The per-request cost had existed from the moment the entry became a factory; async is what made it measurable.

Beyond the numbers, three concerns argued against it. It changes the contract of the framework's core graph entry - the path every WebUI request takes to reach the graph, not just the expert path. It couples us to `as_asynccontextmanager`'s coroutine branch, an upstream implementation detail. And every request pays a thread hop no matter how cheap the work is, so optimising the check would not have recovered the latency.

**What the current shape buys.** The request path becomes a cached-object return: no token read, no filesystem, no thread hop. There is nothing to be slow and nothing for blockbuster to catch, the graph entry stays a plain sync callable, and the rebuild happens entirely off the request path. Confirmed in a live session: zero `Slow graph load`, zero `BlockingError`.

## Known limitations and residual concerns

- **A rebuild takes 15-25 seconds**, and grows with the expert count - 14.1 s, then 21.7 s, then 24.5 s across one session as experts were added. Roughly 1 second is expert and subagent construction; the rest I could not attribute without a profile needing credentials. Worth a follow-up: `/new`, `/model` and the CLI/TUI in-place rebuild all pay it too, so attributing it would pay off well beyond this feature.
- **A staleness window equal to that rebuild.** Refreshing off-request means no request blocks, but an expert added and then needed within the rebuild window is not yet dispatchable. Installs start the rebuild immediately via the push hook; the silent paths start it within one poll.
- **The rebuild contends for the GIL.** It is CPU-bound Python on a worker thread, so "runs in a thread" is not the clean isolation it sounds like - the event loop is throttled for the duration. Bounded by the rebuild time, but real.
- **`WEB_CONCURRENCY` is unguarded.** uvicorn honours it and `manager.py` copies the parent environment without stripping it, so a user with it set above 1 would get one refresher and one graph per worker process. Duplicated work rather than incorrect behaviour, and not a mode anything in this repo selects, but it is an external input nothing checks.

## Tests

62 new tests. The interesting ones:

- The token is stable when nothing changed, moves on add and on remove, and moves when only an existing expert's actor body, `description:` or `role:` changes.
- A utility-skill install bumps the epoch but leaves the token unchanged, so it charges no rebuild.
- `TestDispatchableExpertsTokenSeesMidRunEdits` covers the no-install path end to end: an edited actor definition and a newly authored expert both move the token, the cue's memo follows the finished rebuild rather than the edit that triggered it, and a memo seeded before the edit never shadows the token. None of these bumps the epoch or resets the memo between the two states, which is the point.
- `tests/test_registry_refresh.py` pins the refresher: one build at startup, no rebuild while the token is stable, a rebuild when it moves, detection never stamping the cue's memo (asserted against the real memo with the real token rather than a flag on a stand-in), a skill install waking the loop without waiting out the poll (asserted with the interval set to an hour, so only the push path can drive it), a failed pass neither ending the watch nor being accepted as current, the deploy-mode gate, and clean cancellation on shutdown.
- `tests/test_default_agent_rebuild.py` pins the failure branch of the module agent: a failed rebuild returns the previously built agent, is not re-entered on the next call, leaves the cue reporting the seated agent's expert set, and still raises when there is no previous agent to fall back on. These run without credentials by stubbing the build.
- The factory contract: it is not a coroutine function, it returns the published graph without reading the skills tree (asserted by making `list_expert_skills` raise), and it reports clearly rather than building inline when nothing has been published yet.
- Loader: unchanged token does not rebuild, moved token rebuilds from the stored kwargs, a failed rebuild keeps serving the previous agent and reports through `on_rebuild_failed` while the fatal `on_failure` stays silent, a failed initial load still reports as fatal, a failed build publishes nothing, a raising publish does not break the load, and `adopt()` re-stamps the token and publishes, so a `/model` switch is neither immediately undone nor left describing the displaced agent.
- `tests/test_expert_registry_end_to_end.py` drives the real `BackgroundAgentLoader` against the real `dispatchable_experts_token`, patching only the skills listing underneath them. It is the one test here that fakes neither the walk nor the token, which is what lets it pin the invariant across however many token reads a real rebuild performs: a failed rebuild leaves the cue on the seated set, a successful one publishes the new one.

## Verification

`uv run pytest` in full: 3426 passed, 13 failed. All 13 failures are the pre-existing `OPENROUTER_API_KEY must be set` environment error; none is attributable to this branch.

That 13 was 19 before this branch. `_apply_filter_to_all_registered_graphs` caught only `ImportError` while the sibling graph modules it imports build their graphs at module scope, so a missing key surfaced as a `ValidationError` and propagated - which also made the function's own documented "best-effort, the deployment still starts" promise false. Widening the except unblocked six tests that never needed credentials in the first place.

Beyond the suite, the factory was probed directly: 200 calls on a live event loop with blockbuster active, zero `BlockingError`.

Confirmed end to end in the WebUI, across both detection paths, in one session with no `/new`: an expert added by hand on disk, and an expert the orchestrator wrote itself. Each was detected by the poll (neither calls `install_skill`, so neither emits any signal), rebuilt off-request, and dispatchable on the next turn. Over 50 minutes of 3-second polling the refresher logged exactly two lines, one per actual change. Zero `Slow graph load` warnings and zero `BlockingError` for the whole run - the same run shape produced 55 and 1 respectively before this design.

## Not changed

The expert prompt's claim that every installed expert is reachable both ways needs no edit, because this PR is what makes it true. The remaining nuance, that an expert appearing mid-turn is reachable from the next turn rather than the same one, is a runtime fact rather than a prompt-surface fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly installed or updated experts are detected automatically and become available without restarting.
  * Background rebuilding keeps the current working agent active while updates are applied.
  * Deployed environments refresh expert availability automatically, including after skill changes.

* **Bug Fixes**
  * Failed rebuilds no longer discard the last working agent.
  * Repeated retries are avoided until the expert configuration changes.
  * Expert listings are cached for faster responses and refreshed when changes occur.

* **User Experience**
  * Rebuild progress and non-fatal errors are now shown during interactive use.
  * Expert invitations no longer instruct users to run `/new`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->