### PR TITLE
fix: use workspace-relative artifact links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bridge/package-lock.json
 .codex/
 .cursorrules
 .ruff_cache/
+.worktrees/
 
 # Project specific
 .langgraph_api/

--- a/EvoScientist/prompts.py
+++ b/EvoScientist/prompts.py
@@ -234,6 +234,8 @@ WRITING_GUIDELINES = """# Writing Guidelines
 - Use bullets for configs, stage lists, and key results; use short paragraphs for reasoning.
 - Avoid first-person singular ("I ..."). Prefer neutral phrasing ("This experiment...") or "we" style.
 - Professional, objective tone. Be precise, technical, and concise.
+- When linking to a file in the active workspace, use a Markdown link target relative to the workspace root with POSIX `/` separators, for example `[report](reports/final_report.md)`.
+- Never use host absolute paths, `file://` URLs, or `sandbox:` URLs for workspace files.
 """
 
 # =============================================================================

--- a/docs/superpowers/plans/2026-08-06-workspace-relative-answer-links.md
+++ b/docs/superpowers/plans/2026-08-06-workspace-relative-answer-links.md
@@ -1,0 +1,96 @@
+# Workspace-Relative Answer Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent EvoScientist's final answers from linking workspace artifacts with host absolute paths that the WebUI cannot resolve.
+
+**Architecture:** Extend the existing shared `WRITING_GUIDELINES` prompt section so the main agent always emits workspace-relative POSIX Markdown links. Protect the behavior with a focused assertion against the fully assembled system prompt.
+
+**Tech Stack:** Python 3.11+, pytest, Ruff
+
+## Global Constraints
+
+- Change the main EvoScientist system prompt only; do not modify `@evoscientist/webui` or add response post-processing.
+- Workspace artifact links must be relative to the active workspace root and use POSIX `/` separators.
+- Host absolute paths, `file://` URLs, and `sandbox:` URLs must be forbidden for workspace artifacts.
+
+---
+
+### Task 1: Constrain workspace artifact links in final answers
+
+**Files:**
+- Modify: `tests/test_prompts.py`
+- Modify: `EvoScientist/prompts.py`
+
+**Interfaces:**
+- Consumes: `get_system_prompt(dangerous: bool = False, cwd: str | None = None) -> str`
+- Produces: An assembled system prompt containing explicit workspace-link formatting rules.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add this method to `TestWritingGuidelines`:
+
+```python
+def test_requires_workspace_relative_artifact_links(self):
+    result = get_system_prompt()
+    assert "relative to the workspace root" in result
+    assert "POSIX `/` separators" in result
+    assert "host absolute paths" in result
+    assert "`file://`" in result
+    assert "`sandbox:`" in result
+    assert "[report](reports/final_report.md)" in result
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```powershell
+uv run pytest tests/test_prompts.py::TestWritingGuidelines::test_requires_workspace_relative_artifact_links -v
+```
+
+Expected: FAIL because the current system prompt does not contain the workspace-relative link rule.
+
+- [ ] **Step 3: Add the minimal prompt rule**
+
+Append these bullets to `WRITING_GUIDELINES` in `EvoScientist/prompts.py`:
+
+```text
+- When linking to a file in the active workspace, use a Markdown link target relative to the workspace root with POSIX `/` separators, for example `[report](reports/final_report.md)`.
+- Never use host absolute paths, `file://` URLs, or `sandbox:` URLs for workspace files.
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```powershell
+uv run pytest tests/test_prompts.py::TestWritingGuidelines::test_requires_workspace_relative_artifact_links -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run prompt regression tests and lint**
+
+Run:
+
+```powershell
+uv run pytest tests/test_prompts.py -v
+uv run ruff check EvoScientist/prompts.py tests/test_prompts.py
+uv run ruff format --check EvoScientist/prompts.py tests/test_prompts.py
+```
+
+Expected: all commands exit successfully with no failures or formatting changes required.
+
+- [ ] **Step 6: Review the diff and commit**
+
+Run:
+
+```powershell
+git diff --check
+git diff -- EvoScientist/prompts.py tests/test_prompts.py
+git add EvoScientist/prompts.py tests/test_prompts.py docs/superpowers/plans/2026-08-06-workspace-relative-answer-links.md
+git commit -m "fix: use workspace-relative artifact links"
+```
+
+Expected: one focused commit containing the regression test, prompt rule, and implementation plan.

--- a/docs/superpowers/specs/2026-08-06-workspace-relative-answer-links-design.md
+++ b/docs/superpowers/specs/2026-08-06-workspace-relative-answer-links-design.md
@@ -1,0 +1,35 @@
+# Workspace-Relative Answer Links Design
+
+## Problem
+
+EvoScientist can write a Markdown artifact inside the active workspace and then reference that artifact in its final answer using the host's absolute filesystem path. The WebUI treats workspace file links as workspace-relative paths, strips the leading slash, and consequently looks for a duplicated path below the workspace. The file remains accessible from the FILE SYSTEM panel, but the answer link fails with `Path is not accessible.`
+
+## Scope
+
+Change EvoScientist's main system prompt only. Do not modify the separately published `@evoscientist/webui` package or add response post-processing middleware.
+
+## Design
+
+Add file-link rules to the shared `WRITING_GUIDELINES` section of the main system prompt:
+
+- Links to files in the active workspace must use paths relative to the workspace root.
+- Link targets must use POSIX `/` separators.
+- Host absolute paths, `file://` URLs, and `sandbox:` URLs must not be used for workspace files.
+- Include a concrete correct example so the model can copy the expected Markdown form.
+
+The rule belongs in `WRITING_GUIDELINES`, rather than only in the experiment report step, because final answers may link to reports, figures, tables, logs, or other generated artifacts.
+
+The writing sub-agent prompt remains unchanged. It drafts report content, while the main agent owns the final user-facing answer and link.
+
+## Testing
+
+Extend `tests/test_prompts.py` with a regression test against the assembled system prompt. The test will require the workspace-relative and POSIX-path instructions and the three forbidden link forms. The test must fail before the prompt change and pass afterward.
+
+Run the focused prompt tests, followed by formatting/lint checks for the changed Python files.
+
+## Success Criteria
+
+- The assembled main system prompt explicitly instructs the model to emit workspace-relative POSIX Markdown links.
+- The prompt explicitly forbids host absolute paths, `file://`, and `sandbox:` for workspace artifacts.
+- Existing prompt tests and the new regression test pass.
+- No WebUI or runtime behavior is changed in this patch.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -146,6 +146,15 @@ class TestWritingGuidelines:
             or "I ..." in WRITING_GUIDELINES
         )
 
+    def test_requires_workspace_relative_artifact_links(self):
+        result = get_system_prompt()
+        assert "relative to the workspace root" in result
+        assert "POSIX `/` separators" in result
+        assert "host absolute paths" in result
+        assert "`file://`" in result
+        assert "`sandbox:`" in result
+        assert "[report](reports/final_report.md)" in result
+
 
 class TestShellGuidelines:
     def test_constant_not_empty(self):


### PR DESCRIPTION
## Summary

- require final-answer links to workspace artifacts to use workspace-relative POSIX paths
- forbid host absolute paths, `file://`, and `sandbox:` targets for workspace files
- add a regression test for the assembled main-agent system prompt

## Root cause

The main prompt did not define a link format for generated workspace artifacts. The model could therefore emit a host absolute path such as `/home/ubuntu/.../report.md`. The WebUI strips the leading slash and resolves the remainder relative to the active workspace, producing a duplicated, nonexistent path and returning `Path is not accessible.`

## Impact

Generated report and artifact links now instruct the main agent to use forms such as `[report](reports/final_report.md)`, which match the WebUI workspace resolver.

## Validation

- TDD regression test observed failing before the prompt change and passing afterward
- `tests/test_prompts.py`: 30 passed
- Ruff check and format check passed for changed Python files
- full suite: 3299 passed, 13 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for linking workspace artifacts using root-relative POSIX Markdown paths.
  * Documented restrictions against host-absolute, `file://`, and `sandbox:` URLs.
  * Added an implementation plan and design specification for workspace-relative answer links.

* **Tests**
  * Added regression coverage verifying the required link format and restrictions.

* **Chores**
  * Added `.worktrees/` to ignored development-tool paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->