### PR TITLE
ci: publish to PyPI via trusted publishing; build version images on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,19 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
 
+      # Same guard as publish.yml — a release whose tag mismatches pyproject
+      # must not publish versioned images either.
+      - name: Guard — package version must match the release tag
+        if: github.event_name == 'release'
+        run: |
+          VERSION=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"/\1/')
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "pyproject version: $VERSION | release tag: $TAG"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "::error::pyproject version ($VERSION) does not match release tag ($TAG); refusing to publish images."
+            exit 1
+          fi
+
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.7.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,10 @@ name: Docker
 on:
   push:
     branches: ["main"]
-    tags: ["v*"]
+  # Version images build when a GitHub Release is published — the same event
+  # that triggers the PyPI upload (publish.yml), so the two channels stay in sync.
+  release:
+    types: [published]
   pull_request:
     paths:
       - "Dockerfile"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish to PyPI
+
+# Publishes EvoScientist to PyPI via OpenID Connect (trusted publishing) — no
+# API token or password involved. Fires when a GitHub Release is published
+# (i.e. after `gh release create vX.Y.Z`), builds the sdist + wheel, guards
+# that the package version matches the release tag, then uploads with a
+# short-lived OIDC token.
+#
+# One-time PyPI setup (Manage project -> Publishing -> Add a new publisher):
+#   Owner:            EvoScientist
+#   Repository:       EvoScientist
+#   Workflow name:    publish.yml
+#   Environment name: pypi
+on:
+  release:
+    types: [published]
+  # Manual re-run escape hatch (run it from the release tag, not main).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/project/EvoScientist/
+    permissions:
+      id-token: write  # required to mint the OIDC token PyPI verifies
+    steps:
+      - uses: actions/checkout@v5
+      # Full tag required — setup-uv dropped major/minor tags in v8.0.0, so
+      # `@v9` does not resolve. See the note in lint.yml.
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          python-version: "3.11"
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      - name: Guard — package version must match the release tag
+        if: github.event_name == 'release'
+        run: |
+          VERSION=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"/\1/')
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "pyproject version: $VERSION | release tag: $TAG"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "::error::pyproject version ($VERSION) does not match release tag ($TAG); refusing to publish."
+            exit 1
+          fi
+
+      - name: Twine metadata check
+        run: uvx twine check dist/*
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,8 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           python-version: "3.11"
-          cache-dependency-glob: "**/pyproject.toml"
+          # No shared cache in the publishing job — build from clean sources only.
+          enable-cache: false
 
       - name: Build sdist + wheel
         run: uv build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,8 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
-  # Manual re-run escape hatch (run it from the release tag, not main).
+  # Manual re-run escape hatch — dispatch it from the release tag; the version
+  # guard rejects any non-tag ref.
   workflow_dispatch:
 
 permissions:
@@ -31,10 +32,12 @@ jobs:
     permissions:
       id-token: write  # required to mint the OIDC token PyPI verifies
     steps:
-      - uses: actions/checkout@v5
-      # Full tag required — setup-uv dropped major/minor tags in v8.0.0, so
-      # `@v9` does not resolve. See the note in lint.yml.
-      - uses: astral-sh/setup-uv@v9.0.0
+      # Actions in this job are pinned to full commit SHAs (like docker.yml):
+      # it holds id-token: write and PyPI publishing authority.
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           python-version: "3.11"
           cache-dependency-glob: "**/pyproject.toml"
@@ -43,8 +46,11 @@ jobs:
         run: uv build
 
       - name: Guard — package version must match the release tag
-        if: github.event_name == 'release'
         run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "::error::This workflow must run from a version tag (got ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}'); dispatch it from the release tag."
+            exit 1
+          fi
           VERSION=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"/\1/')
           TAG="${GITHUB_REF_NAME#v}"
           echo "pyproject version: $VERSION | release tag: $TAG"
@@ -57,4 +63,4 @@ jobs:
         run: uvx twine check dist/*
 
       - name: Publish to PyPI (trusted publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2


### PR DESCRIPTION
## Description

Automates the PyPI release channel via OIDC trusted publishing and unifies both distribution channels on the GitHub Release event.

- **New `publish.yml`** — fires on `release: published`: builds sdist + wheel with uv, guards that the `pyproject.toml` version matches the release tag (a mismatched or wrong-case tag fails the run instead of publishing), runs `twine check`, then uploads through `pypa/gh-action-pypi-publish` with a short-lived OIDC token. No API token is stored anywhere; `workflow_dispatch` is kept as a manual re-run escape hatch.
- **`docker.yml`** — version images now build on `release: published` instead of `tags: ["v*"]`, so the PyPI upload and the versioned Docker image are driven by the same event and cannot diverge (the case-sensitive `v*` glob silently skips tags like `V0.2.6`). PR validation builds and `latest`-on-main are unchanged.

One-time setup before the next release: add the trusted publisher on PyPI (owner `EvoScientist`, repository `EvoScientist`, workflow `publish.yml`, environment `pypi`) and create the `pypi` environment in repo settings (optionally with required reviewers).

## Type of change

- [ ] Bug fix
- [ ] New feature — link issue: #
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)
- [x] CI / release automation

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable (workflow YAML only — no Python changes)
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release & Distribution**
  * Package publishing to PyPI now occurs automatically when a release is published, with an option for manual triggering.
  * Docker images are built and published for published releases.
  * Release tags are validated against the package version before publishing to prevent mismatched artifacts.
  * Package metadata is verified before upload.
  * Secure, tokenless publishing is supported through trusted release authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->