### PR TITLE
fix(minimax): preserve M3 video input

### DIFF
--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -42,10 +42,10 @@ from .registry import (
     _OPENAI_ROUTED_PROVIDERS,
     _OPENROUTER_JSON_SCHEMA_STRUCTURED_OUTPUT_MODELS,  # noqa: F401 — re-exported
     _THINKING_CAPABLE_PROVIDERS,
-    _VIDEO_INPUT_MODELS,
     DEFAULT_MODEL,
     MODELS,
     _is_mandatory_thinking_kimi,
+    _video_input_format,
     get_model_info,  # noqa: F401 — re-exported for existing import sites
     get_models_for_provider,  # noqa: F401 — re-exported for existing import sites
     list_model_picker_entries,  # noqa: F401 — re-exported for existing import sites
@@ -568,11 +568,11 @@ def get_chat_model(
         # Anthropic-routed providers accept media in tool results natively;
         # only OpenAI-compatible providers need tool-media hoisting.
         _hoist = _original_provider not in _ANTHROPIC_ROUTED_PROVIDERS
-        _preserve_video = (_original_provider, model_id) in _VIDEO_INPUT_MODELS
+        _video_format = _video_input_format(_original_provider, model_id)
         _patch_openai_compat_content(
             chat_model,
             hoist_tool_media=_hoist,
-            preserve_video=_preserve_video,
+            video_format=_video_format,
         )
 
     if _is_openai_proxy:

--- a/EvoScientist/llm/models.py
+++ b/EvoScientist/llm/models.py
@@ -42,6 +42,7 @@ from .registry import (
     _OPENAI_ROUTED_PROVIDERS,
     _OPENROUTER_JSON_SCHEMA_STRUCTURED_OUTPUT_MODELS,  # noqa: F401 — re-exported
     _THINKING_CAPABLE_PROVIDERS,
+    _VIDEO_INPUT_MODELS,
     DEFAULT_MODEL,
     MODELS,
     _is_mandatory_thinking_kimi,
@@ -567,7 +568,12 @@ def get_chat_model(
         # Anthropic-routed providers accept media in tool results natively;
         # only OpenAI-compatible providers need tool-media hoisting.
         _hoist = _original_provider not in _ANTHROPIC_ROUTED_PROVIDERS
-        _patch_openai_compat_content(chat_model, hoist_tool_media=_hoist)
+        _preserve_video = (_original_provider, model_id) in _VIDEO_INPUT_MODELS
+        _patch_openai_compat_content(
+            chat_model,
+            hoist_tool_media=_hoist,
+            preserve_video=_preserve_video,
+        )
 
     if _is_openai_proxy:
         _patch_ccproxy_system_to_developer(chat_model)

--- a/EvoScientist/llm/patches.py
+++ b/EvoScientist/llm/patches.py
@@ -211,25 +211,62 @@ def _is_ccproxy_codex() -> bool:
 _SKIP_CONTENT_TYPES = frozenset({"thinking", "reasoning", "reasoning_content"})
 
 # Media block types preserved when flattening (positive allowlist;
-# thinking/reasoning still dropped).  Images + files (PDF/documents): both
-# serialize on OpenAI-compatible APIs and capable models read them.  `video` is
-# deliberately EXCLUDED (langchain-openai raises ValueError on it); `audio` is
-# omitted (almost no model support).  is_data_content_block is unreliable
-# (False for OpenAI image_url / Anthropic image-source).  Kept as separate
-# image/file sets so the no-media fallback can gate per modality.
+# thinking/reasoning still dropped). Images and files are enabled by default.
+# Video remains opt-in because not every adapter accepts video content blocks.
+# Kept as separate sets so the no-media fallback can gate per modality.
 _IMAGE_CONTENT_TYPES = frozenset({"image", "image_url", "input_image"})
 _FILE_CONTENT_TYPES = frozenset({"file", "input_file", "document"})
+_VIDEO_CONTENT_TYPES = frozenset({"video"})
 _MEDIA_CONTENT_TYPES = _IMAGE_CONTENT_TYPES | _FILE_CONTENT_TYPES
+_ALL_MEDIA_CONTENT_TYPES = _MEDIA_CONTENT_TYPES | _VIDEO_CONTENT_TYPES
 
 
-def _flatten_message_content(content: Any) -> str | list[Any] | Any:
+def _format_minimax_video_block(block: dict[str, Any]) -> dict[str, Any]:
+    """Convert a standard LangChain video block to MiniMax's API format."""
+    if "source" in block:
+        return block
+
+    source: dict[str, Any] | None = None
+    if url := block.get("url"):
+        source = {"type": "url", "url": url}
+    elif block.get("base64") or block.get("source_type") == "base64":
+        media_type = block.get("mime_type")
+        if not media_type:
+            raise ValueError("mime_type is required for base64 video input")
+        source = {
+            "type": "base64",
+            "media_type": media_type,
+            "data": block.get("base64") or block.get("data", ""),
+        }
+    elif file_id := block.get("file_id"):
+        source = {"type": "url", "url": f"mm_file://{file_id}"}
+    elif block.get("source_type") == "id" and (file_id := block.get("id")):
+        source = {"type": "url", "url": f"mm_file://{file_id}"}
+
+    if source is None:
+        return block
+
+    detail = block.get("detail")
+    if detail is None and isinstance(block.get("extras"), dict):
+        detail = block["extras"].get("detail")
+    if detail is not None:
+        source["detail"] = detail
+
+    formatted = {"type": "video", "source": source}
+    if "cache_control" in block:
+        formatted["cache_control"] = block["cache_control"]
+    return formatted
+
+
+def _flatten_message_content(
+    content: Any, *, preserve_video: bool = False
+) -> str | list[Any] | Any:
     """Convert list-of-blocks content to a string, preserving media blocks.
 
-    Thinking/reasoning blocks are dropped.  When a media block (image or file)
-    is present, returns a list in the ORIGINAL order — consecutive text is
-    joined into a single text block, media blocks kept as-is — so captions stay
-    next to the attachment they describe.  Otherwise returns a plain string.
-    Non-list input is returned unchanged.
+    Thinking/reasoning blocks are dropped. When an enabled media block is
+    present, returns a list in the original order so captions stay next to the
+    attachment they describe. Otherwise returns a plain string. Non-list input
+    is returned unchanged.
 
     Args:
         content: Message content — a string, a list of content blocks, or
@@ -243,6 +280,9 @@ def _flatten_message_content(content: Any) -> str | list[Any] | Any:
         return content
     if not isinstance(content, list):
         return content
+    media_content_types = (
+        _ALL_MEDIA_CONTENT_TYPES if preserve_video else _MEDIA_CONTENT_TYPES
+    )
     parts: list[str] = []
     ordered_blocks: list[Any] = []
     saw_media = False
@@ -255,11 +295,15 @@ def _flatten_message_content(content: Any) -> str | list[Any] | Any:
     for block in content:
         if isinstance(block, dict):
             btype = block.get("type")
-            if btype in _MEDIA_CONTENT_TYPES:
+            if btype in media_content_types:
                 # Keep media as-is (never mutate; upstream copy.copy is shallow)
                 # and preserve its position relative to surrounding text.
                 _flush_text()
-                ordered_blocks.append(block)
+                ordered_blocks.append(
+                    _format_minimax_video_block(block)
+                    if preserve_video and btype in _VIDEO_CONTENT_TYPES
+                    else block
+                )
                 saw_media = True
                 continue
             if btype in _SKIP_CONTENT_TYPES:
@@ -276,7 +320,9 @@ def _flatten_message_content(content: Any) -> str | list[Any] | Any:
 
 
 def _sanitize_messages(
-    messages: list[BaseMessage], hoist_tool_media: bool = True
+    messages: list[BaseMessage],
+    hoist_tool_media: bool = True,
+    preserve_video: bool = False,
 ) -> list[BaseMessage]:
     """Flatten list content for OpenAI-compatible APIs, preserving media.
 
@@ -307,7 +353,10 @@ def _sanitize_messages(
         if not isinstance(msg.content, list):
             out.append(msg)
             continue
-        flat = _flatten_message_content(msg.content)
+        flat = _flatten_message_content(
+            msg.content,
+            preserve_video=preserve_video,
+        )
         if hoist_tool_media and is_tool and isinstance(flat, list):
             text_blocks = [
                 b for b in flat if isinstance(b, dict) and b.get("type") == "text"
@@ -343,19 +392,25 @@ _UNSUPPORTED_MEDIA_PLACEHOLDER = (
 # type is remembered (not all media).  Generic markers map to all media.
 _IMAGE_ERROR_MARKERS = ("image_url", "image input", "support image")
 _FILE_ERROR_MARKERS = ("file input", "pdf input", "document input")
+_VIDEO_ERROR_MARKERS = ("video input", "support video", "type video")
 # `expected \`text\`` keeps the backticks — the bare "expected text" phrase is
 # too broad (matches non-media schema errors like "... expected text").
 _GENERIC_MEDIA_MARKERS = ("multimodal", "expected `text`")
 
 
-def _media_types_in(messages: list[BaseMessage]) -> set[str]:
+def _media_types_in(
+    messages: list[BaseMessage], preserve_video: bool = False
+) -> set[str]:
     """Set of preserved-media block types present across the messages."""
+    media_content_types = (
+        _ALL_MEDIA_CONTENT_TYPES if preserve_video else _MEDIA_CONTENT_TYPES
+    )
     found: set[str] = set()
     for msg in messages:
         content = getattr(msg, "content", None)
         if isinstance(content, list):
             for b in content:
-                if isinstance(b, dict) and b.get("type") in _MEDIA_CONTENT_TYPES:
+                if isinstance(b, dict) and b.get("type") in media_content_types:
                     found.add(b["type"])
     return found
 
@@ -372,8 +427,10 @@ def _media_error_types(exc: Exception) -> set[str]:
         types |= _IMAGE_CONTENT_TYPES
     if any(m in text for m in _FILE_ERROR_MARKERS):
         types |= _FILE_CONTENT_TYPES
+    if any(m in text for m in _VIDEO_ERROR_MARKERS):
+        types |= _VIDEO_CONTENT_TYPES
     if any(m in text for m in _GENERIC_MEDIA_MARKERS):
-        types |= _MEDIA_CONTENT_TYPES
+        types |= _ALL_MEDIA_CONTENT_TYPES
     return types
 
 
@@ -429,20 +486,28 @@ class _OpenAICompatContent:
         self,
         profile: Mapping[str, object] | None,
         hoist_tool_media: bool,
+        preserve_video: bool = False,
     ) -> None:
         self.hoist_tool_media = hoist_tool_media
+        self.preserve_video = preserve_video
         self.blocked: set[str] = set()
         if profile is not None:
             if profile.get("image_inputs") is False:
                 self.blocked |= _IMAGE_CONTENT_TYPES
             if profile.get("pdf_inputs") is False:
                 self.blocked |= _FILE_CONTENT_TYPES
+            if preserve_video and profile.get("video_inputs") is False:
+                self.blocked |= _VIDEO_CONTENT_TYPES
 
     def _prepare(self, messages: list[BaseMessage]) -> list[BaseMessage]:
         prepared = (
             _strip_media_types(messages, self.blocked) if self.blocked else messages
         )
-        return _sanitize_messages(prepared, self.hoist_tool_media)
+        return _sanitize_messages(
+            prepared,
+            self.hoist_tool_media,
+            self.preserve_video,
+        )
 
     def _stripped(
         self,
@@ -452,6 +517,7 @@ class _OpenAICompatContent:
         return _sanitize_messages(
             _strip_media_types(messages, self.blocked | suspects),
             self.hoist_tool_media,
+            self.preserve_video,
         )
 
     def invoke(
@@ -461,7 +527,7 @@ class _OpenAICompatContent:
         *args,
         **kwargs,
     ) -> Any:
-        suspects = _media_types_in(messages) - self.blocked
+        suspects = _media_types_in(messages, self.preserve_video) - self.blocked
         prepared = self._prepare(messages)
         if not suspects:
             return call(prepared, *args, **kwargs)
@@ -485,7 +551,7 @@ class _OpenAICompatContent:
         *args,
         **kwargs,
     ) -> Any:
-        suspects = _media_types_in(messages) - self.blocked
+        suspects = _media_types_in(messages, self.preserve_video) - self.blocked
         prepared = self._prepare(messages)
         if not suspects:
             return await call(prepared, *args, **kwargs)
@@ -510,7 +576,7 @@ class _OpenAICompatContent:
         *args,
         **kwargs,
     ) -> Iterator[Any]:
-        suspects = _media_types_in(messages) - self.blocked
+        suspects = _media_types_in(messages, self.preserve_video) - self.blocked
         prepared = self._prepare(messages)
         if not suspects:
             yield from call(prepared, *args, **kwargs)
@@ -547,7 +613,7 @@ class _OpenAICompatContent:
         *args,
         **kwargs,
     ) -> AsyncIterator[Any]:
-        suspects = _media_types_in(messages) - self.blocked
+        suspects = _media_types_in(messages, self.preserve_video) - self.blocked
         prepared = self._prepare(messages)
         if not suspects:
             async for chunk in call(prepared, *args, **kwargs):
@@ -581,7 +647,11 @@ class _OpenAICompatContent:
             raise media_exc from None
 
 
-def _patch_openai_compat_content(model: Any, hoist_tool_media: bool = True) -> None:
+def _patch_openai_compat_content(
+    model: Any,
+    hoist_tool_media: bool = True,
+    preserve_video: bool = False,
+) -> None:
     """Normalize content for OpenAI-compatible models lacking a native adapter."""
     import functools
 
@@ -589,6 +659,7 @@ def _patch_openai_compat_content(model: Any, hoist_tool_media: bool = True) -> N
     compat = _OpenAICompatContent(
         profile if isinstance(profile, Mapping) else None,
         hoist_tool_media,
+        preserve_video,
     )
 
     orig_generate = getattr(model, "_generate", None)

--- a/EvoScientist/llm/patches.py
+++ b/EvoScientist/llm/patches.py
@@ -211,9 +211,16 @@ def _is_ccproxy_codex() -> bool:
 _SKIP_CONTENT_TYPES = frozenset({"thinking", "reasoning", "reasoning_content"})
 
 # Media block types preserved when flattening (positive allowlist;
-# thinking/reasoning still dropped). Images and files are enabled by default.
-# Video remains opt-in because not every adapter accepts video content blocks.
-# Kept as separate sets so the no-media fallback can gate per modality.
+# thinking/reasoning still dropped).  Images + files (PDF/documents): both
+# serialize on OpenAI-compatible APIs and capable models read them.  `video` is
+# EXCLUDED by default (langchain-openai raises ValueError on it, so it stays off
+# for the OpenAI-compat path) and is opted into per model with a provider
+# specific formatter — see `_VIDEO_BLOCK_FORMATTERS`; `audio` is omitted (almost
+# no model support).  is_data_content_block is unreliable (False for OpenAI
+# image_url / Anthropic image-source), which is why the video formatter converts
+# to a `source` dict itself instead of relying on upstream normalization.
+# Kept as separate image/file/video sets so the no-media fallback can gate per
+# modality.
 _IMAGE_CONTENT_TYPES = frozenset({"image", "image_url", "input_image"})
 _FILE_CONTENT_TYPES = frozenset({"file", "input_file", "document"})
 _VIDEO_CONTENT_TYPES = frozenset({"video"})
@@ -222,7 +229,18 @@ _ALL_MEDIA_CONTENT_TYPES = _MEDIA_CONTENT_TYPES | _VIDEO_CONTENT_TYPES
 
 
 def _format_minimax_video_block(block: dict[str, Any]) -> dict[str, Any]:
-    """Convert a standard LangChain video block to MiniMax's API format."""
+    """Convert a standard LangChain video block to MiniMax's API format.
+
+    MiniMax takes video only on M3, as a ``type="video"`` block delivered one of
+    three ways — a URL, inline base64, or a Files API handle spelled
+    ``mm_file://{file_id}`` (MP4/AVI/MOV/MKV; 50 MB inline, 512 MB via Files) —
+    see the "Messages Field Support" table in
+    https://platform.minimax.io/docs/api-reference/text-anthropic-api.  The
+    branches below map the standard LangChain video shapes (v1 ``url`` /
+    ``base64`` / ``file_id``, v0 ``source_type``) onto exactly those three,
+    leaving anything unrecognized to the media-strip fallback.  ``detail`` is
+    passed through when the caller sets it and ``cache_control`` is preserved.
+    """
     if "source" in block:
         return block
 
@@ -232,7 +250,9 @@ def _format_minimax_video_block(block: dict[str, Any]) -> dict[str, Any]:
     elif block.get("base64") or block.get("source_type") == "base64":
         media_type = block.get("mime_type")
         if not media_type:
-            raise ValueError("mime_type is required for base64 video input")
+            # Unserializable without a media type — leave it for the
+            # media-strip fallback rather than failing the request.
+            return block
         source = {
             "type": "base64",
             "media_type": media_type,
@@ -258,19 +278,33 @@ def _format_minimax_video_block(block: dict[str, Any]) -> dict[str, Any]:
     return formatted
 
 
+# Video block formatters keyed by wire format name.  Video preservation is
+# opt-in per model (registry `_video_input_format`) and each format owns its own
+# serialization, so a future video-capable provider with a different spec
+# registers its own formatter here instead of reusing MiniMax's.
+_VIDEO_BLOCK_FORMATTERS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
+    "minimax": _format_minimax_video_block,
+}
+
+
 def _flatten_message_content(
-    content: Any, *, preserve_video: bool = False
+    content: Any,
+    *,
+    video_formatter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
 ) -> str | list[Any] | Any:
     """Convert list-of-blocks content to a string, preserving media blocks.
 
-    Thinking/reasoning blocks are dropped. When an enabled media block is
-    present, returns a list in the original order so captions stay next to the
-    attachment they describe. Otherwise returns a plain string. Non-list input
-    is returned unchanged.
+    Thinking/reasoning blocks are dropped.  When a preserved media block is
+    present, returns a list in the ORIGINAL order — consecutive text is joined
+    into a single text block, media blocks kept as-is — so captions stay next to
+    the attachment they describe.  Otherwise returns a plain string.  Non-list
+    input is returned unchanged.
 
     Args:
         content: Message content — a string, a list of content blocks, or
             another type.
+        video_formatter: When set, video blocks are preserved and serialized
+            with this provider-specific formatter; otherwise they are dropped.
 
     Returns:
         A plain string for text-only content, a list of blocks when media is
@@ -281,7 +315,7 @@ def _flatten_message_content(
     if not isinstance(content, list):
         return content
     media_content_types = (
-        _ALL_MEDIA_CONTENT_TYPES if preserve_video else _MEDIA_CONTENT_TYPES
+        _ALL_MEDIA_CONTENT_TYPES if video_formatter else _MEDIA_CONTENT_TYPES
     )
     parts: list[str] = []
     ordered_blocks: list[Any] = []
@@ -300,8 +334,8 @@ def _flatten_message_content(
                 # and preserve its position relative to surrounding text.
                 _flush_text()
                 ordered_blocks.append(
-                    _format_minimax_video_block(block)
-                    if preserve_video and btype in _VIDEO_CONTENT_TYPES
+                    video_formatter(block)
+                    if video_formatter and btype in _VIDEO_CONTENT_TYPES
                     else block
                 )
                 saw_media = True
@@ -321,8 +355,9 @@ def _flatten_message_content(
 
 def _sanitize_messages(
     messages: list[BaseMessage],
+    *,
     hoist_tool_media: bool = True,
-    preserve_video: bool = False,
+    video_formatter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
 ) -> list[BaseMessage]:
     """Flatten list content for OpenAI-compatible APIs, preserving media.
 
@@ -355,7 +390,7 @@ def _sanitize_messages(
             continue
         flat = _flatten_message_content(
             msg.content,
-            preserve_video=preserve_video,
+            video_formatter=video_formatter,
         )
         if hoist_tool_media and is_tool and isinstance(flat, list):
             text_blocks = [
@@ -399,11 +434,11 @@ _GENERIC_MEDIA_MARKERS = ("multimodal", "expected `text`")
 
 
 def _media_types_in(
-    messages: list[BaseMessage], preserve_video: bool = False
+    messages: list[BaseMessage], *, include_video: bool = False
 ) -> set[str]:
     """Set of preserved-media block types present across the messages."""
     media_content_types = (
-        _ALL_MEDIA_CONTENT_TYPES if preserve_video else _MEDIA_CONTENT_TYPES
+        _ALL_MEDIA_CONTENT_TYPES if include_video else _MEDIA_CONTENT_TYPES
     )
     found: set[str] = set()
     for msg in messages:
@@ -486,17 +521,21 @@ class _OpenAICompatContent:
         self,
         profile: Mapping[str, object] | None,
         hoist_tool_media: bool,
-        preserve_video: bool = False,
+        video_format: str | None = None,
     ) -> None:
         self.hoist_tool_media = hoist_tool_media
-        self.preserve_video = preserve_video
+        # KeyError on an unknown format is intentional: it surfaces a bad
+        # registry entry when the model is built, not mid-request.
+        self.video_formatter = (
+            _VIDEO_BLOCK_FORMATTERS[video_format] if video_format else None
+        )
         self.blocked: set[str] = set()
         if profile is not None:
             if profile.get("image_inputs") is False:
                 self.blocked |= _IMAGE_CONTENT_TYPES
             if profile.get("pdf_inputs") is False:
                 self.blocked |= _FILE_CONTENT_TYPES
-            if preserve_video and profile.get("video_inputs") is False:
+            if self.video_formatter and profile.get("video_inputs") is False:
                 self.blocked |= _VIDEO_CONTENT_TYPES
 
     def _prepare(self, messages: list[BaseMessage]) -> list[BaseMessage]:
@@ -505,8 +544,8 @@ class _OpenAICompatContent:
         )
         return _sanitize_messages(
             prepared,
-            self.hoist_tool_media,
-            self.preserve_video,
+            hoist_tool_media=self.hoist_tool_media,
+            video_formatter=self.video_formatter,
         )
 
     def _stripped(
@@ -516,8 +555,8 @@ class _OpenAICompatContent:
     ) -> list[BaseMessage]:
         return _sanitize_messages(
             _strip_media_types(messages, self.blocked | suspects),
-            self.hoist_tool_media,
-            self.preserve_video,
+            hoist_tool_media=self.hoist_tool_media,
+            video_formatter=self.video_formatter,
         )
 
     def invoke(
@@ -527,7 +566,10 @@ class _OpenAICompatContent:
         *args,
         **kwargs,
     ) -> Any:
-        suspects = _media_types_in(messages, self.preserve_video) - self.blocked
+        suspects = (
+            _media_types_in(messages, include_video=self.video_formatter is not None)
+            - self.blocked
+        )
         prepared = self._prepare(messages)
         if not suspects:
             return call(prepared, *args, **kwargs)
@@ -551,7 +593,10 @@ class _OpenAICompatContent:
         *args,
         **kwargs,
     ) -> Any:
-        suspects = _media_types_in(messages, self.preserve_video) - self.blocked
+        suspects = (
+            _media_types_in(messages, include_video=self.video_formatter is not None)
+            - self.blocked
+        )
         prepared = self._prepare(messages)
         if not suspects:
             return await call(prepared, *args, **kwargs)
@@ -576,7 +621,10 @@ class _OpenAICompatContent:
         *args,
         **kwargs,
     ) -> Iterator[Any]:
-        suspects = _media_types_in(messages, self.preserve_video) - self.blocked
+        suspects = (
+            _media_types_in(messages, include_video=self.video_formatter is not None)
+            - self.blocked
+        )
         prepared = self._prepare(messages)
         if not suspects:
             yield from call(prepared, *args, **kwargs)
@@ -613,7 +661,10 @@ class _OpenAICompatContent:
         *args,
         **kwargs,
     ) -> AsyncIterator[Any]:
-        suspects = _media_types_in(messages, self.preserve_video) - self.blocked
+        suspects = (
+            _media_types_in(messages, include_video=self.video_formatter is not None)
+            - self.blocked
+        )
         prepared = self._prepare(messages)
         if not suspects:
             async for chunk in call(prepared, *args, **kwargs):
@@ -650,16 +701,20 @@ class _OpenAICompatContent:
 def _patch_openai_compat_content(
     model: Any,
     hoist_tool_media: bool = True,
-    preserve_video: bool = False,
+    video_format: str | None = None,
 ) -> None:
-    """Normalize content for OpenAI-compatible models lacking a native adapter."""
+    """Normalize content for OpenAI-compatible models lacking a native adapter.
+
+    ``video_format`` names the provider-specific video block format from
+    `_VIDEO_BLOCK_FORMATTERS`; ``None`` keeps video blocks dropped.
+    """
     import functools
 
     profile = getattr(model, "profile", None)
     compat = _OpenAICompatContent(
         profile if isinstance(profile, Mapping) else None,
         hoist_tool_media,
-        preserve_video,
+        video_format,
     )
 
     orig_generate = getattr(model, "_generate", None)

--- a/EvoScientist/llm/registry.py
+++ b/EvoScientist/llm/registry.py
@@ -52,6 +52,9 @@ _ANTHROPIC_ROUTED_PROVIDERS: dict[str, tuple[str | None, str]] = {
 # Anthropic-routed providers that support extended thinking.
 _THINKING_CAPABLE_PROVIDERS: set[str] = {"minimax"}
 
+# MiniMax models that accept native video content blocks.
+_VIDEO_INPUT_MODELS: frozenset[tuple[str, str]] = frozenset({("minimax", "MiniMax-M3")})
+
 # Moonshot rejects a forced tool choice while thinking is enabled, and kimi-k3
 # cannot disable thinking — structured output must use json_schema there.
 # Moonshot-specific: do NOT widen to other mandatory-reasoning models.

--- a/EvoScientist/llm/registry.py
+++ b/EvoScientist/llm/registry.py
@@ -52,8 +52,10 @@ _ANTHROPIC_ROUTED_PROVIDERS: dict[str, tuple[str | None, str]] = {
 # Anthropic-routed providers that support extended thinking.
 _THINKING_CAPABLE_PROVIDERS: set[str] = {"minimax"}
 
-# MiniMax models that accept native video content blocks.
-_VIDEO_INPUT_MODELS: frozenset[tuple[str, str]] = frozenset({("minimax", "MiniMax-M3")})
+# Model-id prefixes that accept native video content blocks, per direct
+# provider.  The provider name doubles as the video wire-format name resolved by
+# `patches._VIDEO_BLOCK_FORMATTERS`.
+_VIDEO_INPUT_MODEL_PREFIXES: dict[str, tuple[str, ...]] = {"minimax": ("MiniMax-M3",)}
 
 # Moonshot rejects a forced tool choice while thinking is enabled, and kimi-k3
 # cannot disable thinking — structured output must use json_schema there.
@@ -67,6 +69,25 @@ def _is_mandatory_thinking_kimi(model_id: str) -> bool:
     """True for Kimi models whose thinking cannot be disabled (K3 family)."""
     short_id = model_id.split("/")[-1]
     return short_id.startswith("kimi-k3") or short_id == "kimi-for-coding"
+
+
+def _video_input_format(provider: str | None, model_id: str) -> str | None:
+    """Video block wire format for a video-capable model, else None.
+
+    Keyed on the model family prefix so speed variants of a video-capable model
+    (e.g. a future ``MiniMax-M3-highspeed``, mirroring the M2.5/M2.7 ones) are
+    covered without another registry edit.  Only direct providers are matched:
+    the aggregators (OpenRouter, SiliconFlow, NVIDIA) reach the same weights
+    over their own OpenAI-compatible schema, so each needs its own formatter
+    before video can be enabled there.
+    """
+    if provider is None:
+        return None
+    prefixes = _VIDEO_INPUT_MODEL_PREFIXES.get(provider)
+    if not prefixes:
+        return None
+    short_id = model_id.split("/")[-1]
+    return provider if short_id.startswith(prefixes) else None
 
 
 # Model registry: list of (short_name, model_id, provider)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1310,6 +1310,22 @@ class TestMiniMaxProvider:
         minimax_models = get_models_for_provider("minimax")
         assert len(minimax_models) > 0
 
+    @patch("EvoScientist.llm.models._patch_openai_compat_content")
+    @patch("EvoScientist.llm.models.init_chat_model")
+    def test_minimax_m3_enables_video_preservation(
+        self, mock_init, mock_content_patch, monkeypatch
+    ):
+        """MiniMax M3 should preserve video blocks for the Anthropic adapter."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+
+        get_chat_model("MiniMax-M3", provider="minimax")
+
+        mock_content_patch.assert_called_once_with(
+            mock_init.return_value,
+            hoist_tool_media=False,
+            preserve_video=True,
+        )
+
 
 # =============================================================================
 # Test _flatten_message_content
@@ -1396,25 +1412,49 @@ class TestFlattenMessageContent:
         f = {"type": "file", "base64": "FFF", "mime_type": "application/pdf"}
         assert _flatten_message_content([f]) == [f]
 
-    def test_unsupported_media_dropped(self):
-        # video/audio are NOT in the allowlist -> dropped, not crashing
-        # (langchain-openai raises ValueError on `video`).
+    def test_video_dropped_by_default(self):
         from EvoScientist.llm.patches import _flatten_message_content
 
-        for block in (
-            {"type": "video", "base64": "VVV", "mime_type": "video/mp4"},
-            {"type": "audio", "base64": "ZZZ", "mime_type": "audio/wav"},
-        ):
-            assert _flatten_message_content([block]) == ""
+        block = {"type": "video", "base64": "VVV", "mime_type": "video/mp4"}
+        assert _flatten_message_content([block]) == ""
 
-    def test_non_image_media_dropped_keeps_text(self):
+    @pytest.mark.parametrize(
+        ("block", "source"),
+        [
+            (
+                {"type": "video", "url": "https://example.com/clip.mp4"},
+                {"type": "url", "url": "https://example.com/clip.mp4"},
+            ),
+            (
+                {"type": "video", "base64": "VVV", "mime_type": "video/mp4"},
+                {"type": "base64", "media_type": "video/mp4", "data": "VVV"},
+            ),
+            (
+                {"type": "video", "file_id": "file-123"},
+                {"type": "url", "url": "mm_file://file-123"},
+            ),
+        ],
+    )
+    def test_video_preserved_when_enabled(self, block, source):
+        from EvoScientist.llm.patches import _flatten_message_content
+
+        assert _flatten_message_content([block], preserve_video=True) == [
+            {"type": "video", "source": source}
+        ]
+
+    def test_unsupported_audio_dropped(self):
+        from EvoScientist.llm.patches import _flatten_message_content
+
+        block = {"type": "audio", "base64": "ZZZ", "mime_type": "audio/wav"}
+        assert _flatten_message_content([block], preserve_video=True) == ""
+
+    def test_video_dropped_by_default_keeps_text(self):
         from EvoScientist.llm.patches import _flatten_message_content
 
         content = [
             {"type": "text", "text": "hi"},
             {"type": "video", "base64": "VVV", "mime_type": "video/mp4"},
         ]
-        # Video dropped, text kept -> plain string (no media list).
         assert _flatten_message_content(content) == "hi"
 
     def test_consolidates_text_and_image(self):
@@ -1582,6 +1622,40 @@ class TestPatchOpenAICompatContent:
 
         called_msgs = orig.call_args[0][0]
         assert called_msgs[0].content == [{"type": "text", "text": "see"}, img]
+
+    def test_generate_preserves_video_when_enabled(self):
+        from langchain_anthropic.chat_models import _format_messages
+        from langchain_core.messages import HumanMessage
+
+        from EvoScientist.llm.patches import _patch_openai_compat_content
+
+        model = self._make_model()
+        orig = model._generate
+        _patch_openai_compat_content(
+            model,
+            hoist_tool_media=False,
+            preserve_video=True,
+        )
+
+        video = {"type": "video", "url": "https://example.com/clip.mp4"}
+        msg = HumanMessage(content=[{"type": "text", "text": "see"}, video])
+        model._generate([msg])
+
+        called_msgs = orig.call_args[0][0]
+        expected_content = [
+            {"type": "text", "text": "see"},
+            {
+                "type": "video",
+                "source": {
+                    "type": "url",
+                    "url": "https://example.com/clip.mp4",
+                },
+            },
+        ]
+        assert called_msgs[0].content == expected_content
+
+        _, formatted_messages = _format_messages(called_msgs)
+        assert formatted_messages[0]["content"] == expected_content
 
     async def test_agenerate_preserves_media(self):
         from langchain_core.messages import HumanMessage

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1323,8 +1323,37 @@ class TestMiniMaxProvider:
         mock_content_patch.assert_called_once_with(
             mock_init.return_value,
             hoist_tool_media=False,
-            preserve_video=True,
+            video_format="minimax",
         )
+
+    @pytest.mark.parametrize("model_id", ["MiniMax-M2.7", "MiniMax-M2.5-highspeed"])
+    @patch("EvoScientist.llm.models._patch_openai_compat_content")
+    @patch("EvoScientist.llm.models.init_chat_model")
+    def test_other_minimax_models_do_not_enable_video(
+        self, mock_init, mock_content_patch, monkeypatch, model_id
+    ):
+        """Text-only MiniMax models must not opt into video preservation."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+
+        get_chat_model(model_id, provider="minimax")
+
+        mock_content_patch.assert_called_once_with(
+            mock_init.return_value,
+            hoist_tool_media=False,
+            video_format=None,
+        )
+
+    def test_video_input_format_scope(self):
+        """Video is enabled for the M3 family on the direct provider only."""
+        from EvoScientist.llm.registry import _video_input_format
+
+        assert _video_input_format("minimax", "MiniMax-M3") == "minimax"
+        # Future speed variants of the same family stay covered.
+        assert _video_input_format("minimax", "MiniMax-M3-highspeed") == "minimax"
+        assert _video_input_format("minimax", "MiniMax-M2.7") is None
+        # Aggregators need their own formatter before video can be enabled.
+        assert _video_input_format("openrouter", "minimax/minimax-m3") is None
+        assert _video_input_format(None, "minimax/minimax-m3") is None
 
 
 # =============================================================================
@@ -1429,24 +1458,130 @@ class TestFlattenMessageContent:
                 {"type": "video", "base64": "VVV", "mime_type": "video/mp4"},
                 {"type": "base64", "media_type": "video/mp4", "data": "VVV"},
             ),
+            # v0-style base64 block: source_type + data instead of base64.
+            (
+                {
+                    "type": "video",
+                    "source_type": "base64",
+                    "data": "VVV",
+                    "mime_type": "video/mp4",
+                },
+                {"type": "base64", "media_type": "video/mp4", "data": "VVV"},
+            ),
             (
                 {"type": "video", "file_id": "file-123"},
                 {"type": "url", "url": "mm_file://file-123"},
             ),
+            # v0-style file reference: source_type=id + id.
+            (
+                {"type": "video", "source_type": "id", "id": "file-123"},
+                {"type": "url", "url": "mm_file://file-123"},
+            ),
+            (
+                {
+                    "type": "video",
+                    "url": "https://example.com/clip.mp4",
+                    "detail": "low",
+                },
+                {
+                    "type": "url",
+                    "url": "https://example.com/clip.mp4",
+                    "detail": "low",
+                },
+            ),
+            (
+                {
+                    "type": "video",
+                    "url": "https://example.com/clip.mp4",
+                    "extras": {"detail": "high"},
+                },
+                {
+                    "type": "url",
+                    "url": "https://example.com/clip.mp4",
+                    "detail": "high",
+                },
+            ),
         ],
     )
     def test_video_preserved_when_enabled(self, block, source):
-        from EvoScientist.llm.patches import _flatten_message_content
+        from EvoScientist.llm.patches import (
+            _flatten_message_content,
+            _format_minimax_video_block,
+        )
 
-        assert _flatten_message_content([block], preserve_video=True) == [
-            {"type": "video", "source": source}
+        assert _flatten_message_content(
+            [block], video_formatter=_format_minimax_video_block
+        ) == [{"type": "video", "source": source}]
+
+    def test_video_already_formatted_passes_through(self):
+        """A block that already carries `source` is left untouched."""
+        from EvoScientist.llm.patches import (
+            _flatten_message_content,
+            _format_minimax_video_block,
+        )
+
+        block = {
+            "type": "video",
+            "source": {"type": "url", "url": "https://example.com/clip.mp4"},
+        }
+        assert _flatten_message_content(
+            [block], video_formatter=_format_minimax_video_block
+        ) == [block]
+
+    def test_video_preserves_cache_control(self):
+        from EvoScientist.llm.patches import (
+            _flatten_message_content,
+            _format_minimax_video_block,
+        )
+
+        block = {
+            "type": "video",
+            "url": "https://example.com/clip.mp4",
+            "cache_control": {"type": "ephemeral"},
+        }
+        assert _flatten_message_content(
+            [block], video_formatter=_format_minimax_video_block
+        ) == [
+            {
+                "type": "video",
+                "source": {"type": "url", "url": "https://example.com/clip.mp4"},
+                "cache_control": {"type": "ephemeral"},
+            }
         ]
 
+    @pytest.mark.parametrize(
+        "block",
+        [
+            # base64 without a media type cannot be serialized...
+            {"type": "video", "base64": "VVV"},
+            # ...and neither can a block with no recognized payload.
+            {"type": "video", "mime_type": "video/mp4"},
+        ],
+    )
+    def test_video_unserializable_left_for_media_strip(self, block):
+        """Unformattable video blocks stay as-is instead of raising."""
+        from EvoScientist.llm.patches import (
+            _flatten_message_content,
+            _format_minimax_video_block,
+        )
+
+        assert _flatten_message_content(
+            [block], video_formatter=_format_minimax_video_block
+        ) == [block]
+
     def test_unsupported_audio_dropped(self):
-        from EvoScientist.llm.patches import _flatten_message_content
+        from EvoScientist.llm.patches import (
+            _flatten_message_content,
+            _format_minimax_video_block,
+        )
 
         block = {"type": "audio", "base64": "ZZZ", "mime_type": "audio/wav"}
-        assert _flatten_message_content([block], preserve_video=True) == ""
+        assert (
+            _flatten_message_content(
+                [block], video_formatter=_format_minimax_video_block
+            )
+            == ""
+        )
 
     def test_video_dropped_by_default_keeps_text(self):
         from EvoScientist.llm.patches import _flatten_message_content
@@ -1634,7 +1769,7 @@ class TestPatchOpenAICompatContent:
         _patch_openai_compat_content(
             model,
             hoist_tool_media=False,
-            preserve_video=True,
+            video_format="minimax",
         )
 
         video = {"type": "video", "url": "https://example.com/clip.mp4"}


### PR DESCRIPTION
Reason: MiniMax-M3 supports video input, but the shared content sanitizer removes video blocks before request serialization.

Changes:
- Register MiniMax-M3 as video-input capable.
- Preserve and normalize URL, base64, and uploaded-file video blocks only for that model.
- Add regression coverage for opt-in gating and request serialization.

Checks:
- Repository Ruff lint passed.
- Repository Ruff format check passed.
- Full pytest suite passed: 3505 passed, 12 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video input support for compatible OpenAI-style model integrations.
  * Preserved native video content for MiniMax M3 requests.
  * Added improved handling for video formatting, streaming, retries, and unsupported media.

* **Bug Fixes**
  * Prevented supported video content from being incorrectly flattened or removed.
  * Maintained existing image and file handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->