### PR TITLE
eval: add offline tool-selection scoring

### DIFF
--- a/EvoScientist/evals/__init__.py
+++ b/EvoScientist/evals/__init__.py
@@ -1,0 +1,15 @@
+"""Offline evaluation helpers for EvoScientist mechanisms."""
+
+from .tool_selection import (
+    ToolSelectionExpectation,
+    ToolSelectionReport,
+    ToolSelectionScore,
+    replay_tool_selections,
+)
+
+__all__ = [
+    "ToolSelectionExpectation",
+    "ToolSelectionReport",
+    "ToolSelectionScore",
+    "replay_tool_selections",
+]

--- a/EvoScientist/evals/tool_selection.py
+++ b/EvoScientist/evals/tool_selection.py
@@ -24,6 +24,13 @@ def _tool_names(value: object, *, context: str) -> frozenset[str]:
     return frozenset(names)
 
 
+def _event_tool_names(value: object, *, event_index: int) -> frozenset[str]:
+    context = f"tool_selection event at index {event_index} tools"
+    if not isinstance(value, list):
+        raise ValueError(f"{context} must be a list of tool-name strings")
+    return _tool_names(value, context=context)
+
+
 def _ratio(numerator: int, denominator: int, *, empty: float) -> float:
     return numerator / denominator if denominator else empty
 
@@ -183,10 +190,7 @@ def replay_tool_selections(
         selections.append(
             (
                 event_index,
-                _tool_names(
-                    event["tools"],
-                    context=f"tool_selection event at index {event_index} tools",
-                ),
+                _event_tool_names(event["tools"], event_index=event_index),
             )
         )
 

--- a/EvoScientist/evals/tool_selection.py
+++ b/EvoScientist/evals/tool_selection.py
@@ -1,0 +1,205 @@
+"""Offline scoring for tool-selection events.
+
+The runtime already exposes each selected tool set as a ``tool_selection``
+event in its ``stream-json`` protocol. This module consumes that public event
+shape directly so evaluation stays independent of providers and API keys.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+def _tool_names(value: object, *, context: str) -> frozenset[str]:
+    if isinstance(value, str) or not isinstance(value, Iterable):
+        raise ValueError(f"{context} must be an iterable of tool-name strings")
+
+    names: set[str] = set()
+    for index, name in enumerate(value):
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"{context}[{index}] must be a non-empty tool-name string")
+        names.add(name)
+    return frozenset(names)
+
+
+def _ratio(numerator: int, denominator: int, *, empty: float) -> float:
+    return numerator / denominator if denominator else empty
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSelectionExpectation:
+    """Expected tools for one recorded selection, identified by ``case_id``."""
+
+    case_id: str
+    expected_tools: frozenset[str]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.case_id, str) or not self.case_id:
+            raise ValueError("case_id must be a non-empty string")
+        object.__setattr__(
+            self,
+            "expected_tools",
+            _tool_names(
+                self.expected_tools,
+                context=f"expectation {self.case_id!r} expected_tools",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSelectionScore:
+    """Set-based score for one expected tool selection."""
+
+    case_id: str
+    selected_tools: frozenset[str]
+    expected_tools: frozenset[str]
+    true_positives: frozenset[str]
+    false_positives: frozenset[str]
+    false_negatives: frozenset[str]
+    precision: float
+    recall: float
+    f1: float
+    exact_match: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSelectionReport:
+    """Per-case scores plus macro and micro aggregates."""
+
+    scores: tuple[ToolSelectionScore, ...]
+    macro_precision: float
+    macro_recall: float
+    macro_f1: float
+    exact_match_rate: float
+    micro_precision: float
+    micro_recall: float
+    micro_f1: float
+
+    @property
+    def case_count(self) -> int:
+        return len(self.scores)
+
+
+def _score(
+    selected: frozenset[str], expectation: ToolSelectionExpectation
+) -> ToolSelectionScore:
+    expected = expectation.expected_tools
+    true_positives = selected & expected
+    false_positives = selected - expected
+    false_negatives = expected - selected
+
+    # Selecting nothing has no false positives, while expecting nothing has no
+    # false negatives. This makes an empty/empty case a perfect exact match and
+    # still penalizes a non-empty selection for an empty expectation.
+    precision = _ratio(len(true_positives), len(selected), empty=1.0)
+    recall = _ratio(len(true_positives), len(expected), empty=1.0)
+    f1 = _ratio(2 * precision * recall, precision + recall, empty=0.0)
+
+    return ToolSelectionScore(
+        case_id=expectation.case_id,
+        selected_tools=selected,
+        expected_tools=expected,
+        true_positives=true_positives,
+        false_positives=false_positives,
+        false_negatives=false_negatives,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        exact_match=selected == expected,
+    )
+
+
+def _report(scores: tuple[ToolSelectionScore, ...]) -> ToolSelectionReport:
+    if not scores:
+        return ToolSelectionReport(scores, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+    case_count = len(scores)
+    true_positives = sum(len(score.true_positives) for score in scores)
+    false_positives = sum(len(score.false_positives) for score in scores)
+    false_negatives = sum(len(score.false_negatives) for score in scores)
+    micro_precision = _ratio(
+        true_positives, true_positives + false_positives, empty=1.0
+    )
+    micro_recall = _ratio(true_positives, true_positives + false_negatives, empty=1.0)
+    micro_f1 = _ratio(
+        2 * micro_precision * micro_recall,
+        micro_precision + micro_recall,
+        empty=0.0,
+    )
+
+    return ToolSelectionReport(
+        scores=scores,
+        macro_precision=sum(score.precision for score in scores) / case_count,
+        macro_recall=sum(score.recall for score in scores) / case_count,
+        macro_f1=sum(score.f1 for score in scores) / case_count,
+        exact_match_rate=sum(score.exact_match for score in scores) / case_count,
+        micro_precision=micro_precision,
+        micro_recall=micro_recall,
+        micro_f1=micro_f1,
+    )
+
+
+def replay_tool_selections(
+    events: Iterable[Mapping[str, Any]],
+    expectations: Iterable[ToolSelectionExpectation],
+) -> ToolSelectionReport:
+    """Replay recorded ``tool_selection`` events against ordered expectations.
+
+    Unrecognized event types are ignored for forward compatibility with the
+    stream protocol. Relevant events are validated strictly and errors identify
+    their zero-based event position. Duplicate tool names use set semantics.
+    """
+
+    expected = tuple(expectations)
+    seen_case_ids: set[str] = set()
+    duplicate_ids: set[str] = set()
+    for expectation in expected:
+        if expectation.case_id in seen_case_ids:
+            duplicate_ids.add(expectation.case_id)
+        seen_case_ids.add(expectation.case_id)
+    if duplicate_ids:
+        duplicate_list = ", ".join(sorted(repr(case_id) for case_id in duplicate_ids))
+        raise ValueError(f"duplicate expectation case_id values: {duplicate_list}")
+
+    selections: list[tuple[int, frozenset[str]]] = []
+    for event_index, event in enumerate(events):
+        if not isinstance(event, Mapping):
+            raise ValueError(f"event at index {event_index} must be a mapping")
+        if event.get("type") != "tool_selection":
+            continue
+        if "tools" not in event:
+            raise ValueError(
+                f"tool_selection event at index {event_index} is missing 'tools'"
+            )
+        selections.append(
+            (
+                event_index,
+                _tool_names(
+                    event["tools"],
+                    context=f"tool_selection event at index {event_index} tools",
+                ),
+            )
+        )
+
+    if len(selections) < len(expected):
+        missing = expected[len(selections)]
+        raise ValueError(
+            "tool_selection count mismatch: "
+            f"expected {len(expected)}, found {len(selections)}; "
+            f"missing selection for case {missing.case_id!r}"
+        )
+    if len(selections) > len(expected):
+        extra_event_index = selections[len(expected)][0]
+        raise ValueError(
+            "tool_selection count mismatch: "
+            f"expected {len(expected)}, found {len(selections)}; "
+            f"first extra selection is at event index {extra_event_index}"
+        )
+
+    scores = tuple(
+        _score(selected, expectation)
+        for (_, selected), expectation in zip(selections, expected, strict=True)
+    )
+    return _report(scores)

--- a/EvoScientist/evals/tool_selection.py
+++ b/EvoScientist/evals/tool_selection.py
@@ -90,11 +90,11 @@ def _score(
     false_positives = selected - expected
     false_negatives = expected - selected
 
-    # Selecting nothing has no false positives, while expecting nothing has no
-    # false negatives. This makes an empty/empty case a perfect exact match and
-    # still penalizes a non-empty selection for an empty expectation.
-    precision = _ratio(len(true_positives), len(selected), empty=1.0)
-    recall = _ratio(len(true_positives), len(expected), empty=1.0)
+    # Only empty/empty is a perfect abstention. If exactly one side is empty,
+    # the undefined metric is zero so macro aggregates do not reward a miss.
+    both_empty = not selected and not expected
+    precision = _ratio(len(true_positives), len(selected), empty=float(both_empty))
+    recall = _ratio(len(true_positives), len(expected), empty=float(both_empty))
     f1 = _ratio(2 * precision * recall, precision + recall, empty=0.0)
 
     return ToolSelectionScore(
@@ -119,10 +119,17 @@ def _report(scores: tuple[ToolSelectionScore, ...]) -> ToolSelectionReport:
     true_positives = sum(len(score.true_positives) for score in scores)
     false_positives = sum(len(score.false_positives) for score in scores)
     false_negatives = sum(len(score.false_negatives) for score in scores)
+    all_empty = not true_positives and not false_positives and not false_negatives
     micro_precision = _ratio(
-        true_positives, true_positives + false_positives, empty=1.0
+        true_positives,
+        true_positives + false_positives,
+        empty=float(all_empty),
     )
-    micro_recall = _ratio(true_positives, true_positives + false_negatives, empty=1.0)
+    micro_recall = _ratio(
+        true_positives,
+        true_positives + false_negatives,
+        empty=float(all_empty),
+    )
     micro_f1 = _ratio(
         2 * micro_precision * micro_recall,
         micro_precision + micro_recall,

--- a/tests/test_tool_selection_eval.py
+++ b/tests/test_tool_selection_eval.py
@@ -1,0 +1,154 @@
+"""Tests for offline replay and scoring of tool-selection events."""
+
+import pytest
+
+from EvoScientist.evals import (
+    ToolSelectionExpectation,
+    replay_tool_selections,
+)
+
+
+def _expectation(case_id: str, *tools: str) -> ToolSelectionExpectation:
+    return ToolSelectionExpectation(case_id, frozenset(tools))
+
+
+def test_scores_perfect_missing_extra_and_disjoint_selections():
+    events = [
+        {"type": "tool_selection", "tools": ["read_file", "search"]},
+        {"type": "tool_selection", "tools": ["read_file"]},
+        {"type": "tool_selection", "tools": ["read_file", "execute"]},
+        {"type": "tool_selection", "tools": ["write_file"]},
+    ]
+    expectations = [
+        _expectation("perfect", "read_file", "search"),
+        _expectation("missing", "read_file", "search"),
+        _expectation("extra", "read_file"),
+        _expectation("disjoint", "search"),
+    ]
+
+    report = replay_tool_selections(events, expectations)
+
+    assert report.case_count == 4
+    perfect, missing, extra, disjoint = report.scores
+    assert perfect.exact_match
+    assert perfect.precision == perfect.recall == perfect.f1 == 1.0
+    assert missing.false_negatives == frozenset({"search"})
+    assert missing.precision == 1.0
+    assert missing.recall == 0.5
+    assert missing.f1 == pytest.approx(2 / 3)
+    assert extra.false_positives == frozenset({"execute"})
+    assert extra.precision == 0.5
+    assert extra.recall == 1.0
+    assert disjoint.precision == disjoint.recall == disjoint.f1 == 0.0
+
+
+def test_reports_macro_and_micro_aggregates():
+    report = replay_tool_selections(
+        [
+            {"type": "tool_selection", "tools": ["a", "b"]},
+            {"type": "tool_selection", "tools": ["c"]},
+        ],
+        [_expectation("one", "a"), _expectation("two", "c", "d")],
+    )
+
+    assert report.macro_precision == 0.75
+    assert report.macro_recall == 0.75
+    assert report.macro_f1 == pytest.approx(2 / 3)
+    assert report.exact_match_rate == 0.0
+    assert report.micro_precision == pytest.approx(2 / 3)
+    assert report.micro_recall == pytest.approx(2 / 3)
+    assert report.micro_f1 == pytest.approx(2 / 3)
+
+
+def test_empty_expectations_follow_explicit_zero_denominator_policy():
+    report = replay_tool_selections(
+        [
+            {"type": "tool_selection", "tools": []},
+            {"type": "tool_selection", "tools": ["unexpected"]},
+        ],
+        [_expectation("empty"), _expectation("false-positive")],
+    )
+
+    empty, false_positive = report.scores
+    assert empty.exact_match
+    assert empty.precision == empty.recall == empty.f1 == 1.0
+    assert not false_positive.exact_match
+    assert false_positive.precision == 0.0
+    assert false_positive.recall == 1.0
+    assert false_positive.f1 == 0.0
+
+
+def test_replay_ignores_unknown_events_and_deduplicates_tool_names():
+    report = replay_tool_selections(
+        [
+            {"type": "thinking", "content": "select tools"},
+            {"type": "future_event", "payload": 1},
+            {"type": "tool_selection", "tools": ["search", "search"]},
+            {"type": "done", "response": "ok"},
+        ],
+        [ToolSelectionExpectation("deduplicated", frozenset({"search"}))],
+    )
+
+    assert report.scores[0].selected_tools == frozenset({"search"})
+    assert report.scores[0].exact_match
+
+
+@pytest.mark.parametrize(
+    ("events", "message"),
+    [
+        ([{"type": "tool_selection"}], "index 0 is missing 'tools'"),
+        (
+            [{"type": "tool_selection", "tools": "search"}],
+            "index 0 tools must be an iterable",
+        ),
+        (
+            [{"type": "tool_selection", "tools": ["search", 7]}],
+            "index 0 tools\\[1\\] must be a non-empty",
+        ),
+        (["not-an-event"], "event at index 0 must be a mapping"),
+    ],
+)
+def test_replay_rejects_malformed_events_with_event_position(events, message):
+    with pytest.raises(ValueError, match=message):
+        replay_tool_selections(events, [_expectation("case", "search")])
+
+
+@pytest.mark.parametrize(
+    ("events", "expectations", "message"),
+    [
+        (
+            [],
+            [_expectation("missing", "search")],
+            "expected 1, found 0; missing selection for case 'missing'",
+        ),
+        (
+            [
+                {"type": "thinking"},
+                {"type": "tool_selection", "tools": ["search"]},
+            ],
+            [],
+            "expected 0, found 1; first extra selection is at event index 1",
+        ),
+    ],
+)
+def test_replay_rejects_selection_count_mismatches(events, expectations, message):
+    with pytest.raises(ValueError, match=message):
+        replay_tool_selections(events, expectations)
+
+
+def test_expectations_validate_case_and_tool_names():
+    with pytest.raises(ValueError, match="case_id must be a non-empty string"):
+        ToolSelectionExpectation("", frozenset({"search"}))
+    with pytest.raises(ValueError, match="expectation 'bad' expected_tools"):
+        ToolSelectionExpectation("bad", frozenset({""}))
+
+
+def test_replay_rejects_duplicate_case_ids():
+    with pytest.raises(ValueError, match=r"duplicate expectation case_id.*'same'"):
+        replay_tool_selections(
+            [
+                {"type": "tool_selection", "tools": []},
+                {"type": "tool_selection", "tools": []},
+            ],
+            [_expectation("same"), _expectation("same")],
+        )

--- a/tests/test_tool_selection_eval.py
+++ b/tests/test_tool_selection_eval.py
@@ -107,7 +107,15 @@ def test_replay_ignores_unknown_events_and_deduplicates_tool_names():
         ([{"type": "tool_selection"}], "index 0 is missing 'tools'"),
         (
             [{"type": "tool_selection", "tools": "search"}],
-            "index 0 tools must be an iterable",
+            "index 0 tools must be a list",
+        ),
+        (
+            [{"type": "tool_selection", "tools": ("search",)}],
+            "index 0 tools must be a list",
+        ),
+        (
+            [{"type": "tool_selection", "tools": {"search": True}}],
+            "index 0 tools must be a list",
         ),
         (
             [{"type": "tool_selection", "tools": ["search", 7]}],

--- a/tests/test_tool_selection_eval.py
+++ b/tests/test_tool_selection_eval.py
@@ -65,17 +65,25 @@ def test_empty_expectations_follow_explicit_zero_denominator_policy():
         [
             {"type": "tool_selection", "tools": []},
             {"type": "tool_selection", "tools": ["unexpected"]},
+            {"type": "tool_selection", "tools": []},
         ],
-        [_expectation("empty"), _expectation("false-positive")],
+        [
+            _expectation("empty"),
+            _expectation("false-positive"),
+            _expectation("false-negative", "missing"),
+        ],
     )
 
-    empty, false_positive = report.scores
+    empty, false_positive, false_negative = report.scores
     assert empty.exact_match
     assert empty.precision == empty.recall == empty.f1 == 1.0
     assert not false_positive.exact_match
     assert false_positive.precision == 0.0
-    assert false_positive.recall == 1.0
+    assert false_positive.recall == 0.0
     assert false_positive.f1 == 0.0
+    assert false_negative.precision == 0.0
+    assert false_negative.recall == 0.0
+    assert false_negative.f1 == 0.0
 
 
 def test_replay_ignores_unknown_events_and_deduplicates_tool_names():


### PR DESCRIPTION
## Description

Adds a minimal, provider-free evaluation slice for tool-selection correctness, following the proposal in #419.

The new `EvoScientist.evals` API:

- replays the existing `stream-json` `tool_selection` events in order;
- scores each labeled case with TP/FP/FN, precision, recall, F1, and exact match;
- reports macro and micro aggregates;
- applies set semantics to duplicate tool names;
- ignores unrelated and unknown event types for stream forward compatibility;
- validates the public event shape strictly and fails with event position or case ID when relevant input is malformed or counts differ.

Empty-set semantics are explicit: empty/empty is a perfect match, while a one-sided empty set scores zero for the undefined per-case metric so macro aggregates do not reward a miss.

This deliberately reuses the existing public event protocol. It adds no recorder, runtime middleware changes, CLI, provider calls, API-key tests, external evaluation service, or task-level benchmark.

Refs #419.

## Type of change

- [ ] Bug fix
- [x] New feature — link issue: #419
- [ ] Documentation / examples
- [x] Test improvement
- [ ] Refactor (no behavior change)

## Validation

- `python -m pytest tests/test_tool_selection_eval.py -q` — 14 passed
- `ruff check .` — passed
- `ruff format --check EvoScientist/evals tests/test_tool_selection_eval.py` — passed
- `git diff --check` — passed

The existing Windows sandbox cannot collect the older middleware-focused test module because `wasmtime` reports an empty/unsupported architecture. The new evaluation module is standard-library-only and its focused tests pass under Python 3.11. GitHub created the full Build, Docker, Lint, and Test runs, but they currently require maintainer approval for this first-time fork contribution; they are marked `action_required`, not failed.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [ ] `uv run pytest` passes

This is intentionally opened as a draft while maintainers and the original issue author confirm the package boundary and metric conventions, and approve the fork-originated workflow runs.