### PR TITLE
feat(onboard): add NVIDIA BioNeMo Agent Toolkit to recommended skill packs

### DIFF
--- a/EvoScientist/config/onboard/steps.py
+++ b/EvoScientist/config/onboard/steps.py
@@ -1007,6 +1007,11 @@ _RECOMMENDED_SKILLS = [
         "label": "HuggingFace Skills  (dataset creation, model training & evaluation, third party by HuggingFace)",
         "source": "huggingface/skills@skills",
     },
+    # ── Third-party (NVIDIA BioNeMo) ──
+    {
+        "label": "BioNeMo Skills  (31 protein folding, docking, generative chemistry & genomics skills, third party by NVIDIA)",
+        "source": "NVIDIA-BioNeMo/bionemo-agent-toolkit@plugins/bionemo-agent-toolkit/skills",
+    },
 ]
 
 


### PR DESCRIPTION
## Description

Closes #333

Adds a **BioNeMo Skills** entry to the onboard Step 7 recommended-skills checkbox, pointing at `NVIDIA-BioNeMo/bionemo-agent-toolkit@plugins/bionemo-agent-toolkit/skills`. Selecting it installs all 31 life-science skills (protein folding, docking, generative chemistry, genomics, protein design) through the existing GitHub-shorthand installer — no installer or parser change.

Why the `plugins/bionemo-agent-toolkit/skills` sub-path rather than the repo root: upstream keeps skills in four category folders at mixed depths (`nim-skills/`, `nim-skills/meta-skills/`, `open-models-skills/<family>/`, `workflows/<name>/`), plus a flat aggregate copy under `plugins/…/skills/` (byte-identical to the sources). Installing from the repo root reaches only 14 of 31 because `_scan_skill_dirs` stops at two levels; the plugin directory is one level, so all 31 land. Installed-detection and update-detection work unchanged since the pack source is recorded in `.installed.yaml`.

Verified: real install of the pack → 31/31 installed, 0 failed, all 31 `SKILL.md` parse cleanly, contents identical to upstream HEAD; onboard shows the new choice, re-run marks it `(installed — re-select to sync)`; uninstall via `uninstall_skill()` removes all 31 and cleans the manifest.

Caveats users should know (upstream-side, not addressed here): the five `complexa-*` skills reference `.claude/skills/_shared/…` helper scripts that upstream's own plugin copy does not ship, so those paths break in any harness; all skills require a user-provided `NGC_API_KEY` / `NVIDIA_API_KEY`; local NIM mode needs Docker + NVIDIA GPU + `LOCAL_NIM_CACHE`.

## Type of change

- [ ] Bug fix
- [x] New feature — link issue: #333
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA BioNeMo’s recommended skills collection to the onboarding skill selections.
  * Included the collection’s source repository and description for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->