### PR TITLE
feat: proactive research pushes (issue #263 MVP) - draft PoC

### DIFF
--- a/EvoScientist/EvoScientist.py
+++ b/EvoScientist/EvoScientist.py
@@ -938,6 +938,7 @@ def _get_default_middleware(
         create_context_editing_middleware,
         create_memory_lifecycle_middleware,
         create_memory_middleware,
+        create_proactive_mode_middleware,
         create_runtime_context_middleware,
         create_scheduler_middleware,
         create_tool_selector_middleware,
@@ -1044,6 +1045,14 @@ def _get_default_middleware(
                 memory_scheduler=memory_scheduler,
             )
         )
+
+    # Proactive shadow turns (#263) strip all tools so the model emits a
+    # text-only push/no-push decision. Inserted ahead of tool_selector (outer
+    # in the wrap stack) so the selector skips its LLM call when tools are
+    # already empty. Main agent only — the shadow runs the main graph, and the
+    # proactive_mode flag is never set on async sub-agent runs.
+    if not for_async_subagent:
+        mw.insert(0, create_proactive_mode_middleware())
 
     if cfg.enable_ask_user and not cfg.auto_mode and not for_async_subagent:
         from .middleware.ask_user import AskUserMiddleware

--- a/EvoScientist/cli/channel.py
+++ b/EvoScientist/cli/channel.py
@@ -633,6 +633,19 @@ def get_channel_origin(thread_id: str | None) -> _ChannelOrigin | None:
         return _thread_channel_origins.get(thread_id)
 
 
+def list_channel_origin_thread_ids() -> list[str]:
+    """Return a snapshot of every thread id with a remembered channel origin.
+
+    The proactive delivery poll (serve) uses this as its candidate set: a thread
+    can only be published back to if its origin is registered here, so iterating
+    these keys is exactly the set of threads a pending proactive push could be
+    delivered on. Snapshot under the lock so a concurrent register/forget can't
+    mutate the returned list.
+    """
+    with _thread_channel_origins_lock:
+        return list(_thread_channel_origins.keys())
+
+
 def forget_channel_origin(thread_id: str | None) -> None:
     """Drop the registry entry for ``thread_id`` (e.g. on ``/new`` rotation)."""
     if not thread_id:

--- a/EvoScientist/cli/commands.py
+++ b/EvoScientist/cli/commands.py
@@ -911,6 +911,7 @@ async def compact_conversation(
         target,
         thread_id,
         {"_summarization_event": new_event, "_summarization_session_id": session_id},
+        as_node="model",
     )
 
     return CompactResult(

--- a/EvoScientist/cli/commands.py
+++ b/EvoScientist/cli/commands.py
@@ -57,6 +57,7 @@ from .channel import (
     dispatch_channel_slash_command,
     forget_channel_origin,
     get_channel_origin,
+    list_channel_origin_thread_ids,
     publish_to_channel_origin,
     remember_channel_origin,
 )
@@ -1202,6 +1203,10 @@ def _serve_process_message(
         return
 
     remember_channel_origin(runtime_state.thread_id, msg)
+    # Companion to the in-process origin: stamp the server-side channel marker so the
+    # proactive cron's eligibility search can discover this thread. No-op unless serve
+    # runs on the server backend. Single chokepoint — every inbound message passes here.
+    _serve_stamp_channel_marker(runtime_state)
 
     runtime_workspace = runtime_state.workspace_dir or workspace_dir
 
@@ -1353,6 +1358,127 @@ def _serve_process_message(
 # =============================================================================
 # Serve command (headless mode)
 # =============================================================================
+
+
+# Throttle for the serve-side proactive delivery poll. The cron fires every ~10 min,
+# so re-reading channel threads on every ~0.5s idle tick would be wasteful.
+_PROACTIVE_POLL_INTERVAL_S = 20.0
+
+
+def _serve_server_client(runtime_state: ServeRuntimeState) -> Any | None:
+    """The langgraph SDK client backing serve, or None on the local backend.
+
+    The server ThreadStore carries a ``.client`` (async SDK); the local store does
+    not. Gates the proactive marker-stamp + delivery poll to the server backend,
+    where serve's threads are server-born and visible to the cron.
+    """
+    thread_store = getattr(runtime_state.runtime_gateways, "thread_store", None)
+    return getattr(thread_store, "client", None)
+
+
+def _serve_proactive_enabled(config: "EvoScientistConfig | None") -> bool:
+    """True when proactive pushes are on AND serve runs on the server backend."""
+    return (
+        config is not None
+        and bool(config.proactive_enabled)
+        and config.gateway_backend == "langgraph_server"
+    )
+
+
+def _serve_ensure_proactive_cron(config: "EvoScientistConfig | None") -> None:
+    """Register the periodic proactive-check cron once (idempotent, best-effort).
+
+    Only when proactive pushes are enabled on the server backend. An existing
+    proactive cron (from a previous serve session — crons persist in the
+    langgraph-dev store) is reused rather than duplicated. Registration failure
+    is logged, never fatal: serve keeps working, just without proactive ticks.
+    """
+    if not _serve_proactive_enabled(config):
+        return
+    from ..proactive import cron as proactive_cron
+
+    try:
+        existing = proactive_cron.list_proactive_schedules()
+        if existing:
+            _serve_logger.info(
+                "Proactive cron already registered (%d); not creating another",
+                len(existing),
+            )
+            return
+        created = proactive_cron.create_proactive_schedule()
+        _serve_logger.info(
+            "Registered proactive cron %s (schedule %s)",
+            created.get("cron_id"),
+            created.get("schedule"),
+        )
+    except Exception as exc:
+        _serve_logger.warning("Proactive cron registration failed: %s", exc)
+
+
+def _serve_stamp_channel_marker(runtime_state: ServeRuntimeState) -> None:
+    """Stamp the channel-origin marker on the active thread (server backend only).
+
+    Skipped when proactive pushes are disabled, so a serve session with the
+    feature off never marks threads as cron candidates.
+    """
+    if not _serve_proactive_enabled(runtime_state.config):
+        return
+    client = _serve_server_client(runtime_state)
+    thread_id = runtime_state.thread_id
+    if client is None or not thread_id:
+        return
+    from ..proactive.eligibility import stamp_channel_marker
+
+    try:
+        runtime_state.async_runtime.run_sync(
+            lambda: stamp_channel_marker(client, thread_id)
+        )
+    except Exception as exc:
+        _serve_logger.warning("Proactive channel-marker stamp failed: %s", exc)
+
+
+def _serve_deliver_proactive_pushes(
+    *, runtime_state: ServeRuntimeState, seen: set[str]
+) -> None:
+    """Publish any pending proactive pushes committed into channel threads.
+
+    One poll: read each channel-origin thread's state via the server SDK client,
+    extract a proactive-push-tagged message, and publish it to the thread's
+    channel. Idempotent across polls via the caller-owned ``seen`` set (a push id is
+    recorded only on a successful publish, so a failed publish retries next poll).
+    No-op on the local backend (no server client to read server-born threads).
+    """
+    client = _serve_server_client(runtime_state)
+    if client is None:
+        return
+    thread_ids = list_channel_origin_thread_ids()
+    if not thread_ids:
+        return
+
+    from ..proactive.delivery_watcher import deliver_pending_pushes
+    from ..proactive.service import _state_messages
+
+    async def _read_messages(thread_id: str) -> list:
+        state = await client.threads.get_state(thread_id)
+        return _state_messages(state)
+
+    async def _deliver() -> list[str]:
+        return await deliver_pending_pushes(
+            thread_ids,
+            read_messages=_read_messages,
+            publish=publish_to_channel_origin,
+            seen=seen,
+        )
+
+    try:
+        delivered = runtime_state.async_runtime.run_sync(_deliver)
+    except Exception as exc:
+        _serve_logger.warning("Proactive delivery poll failed: %s", exc)
+        return
+    if delivered:
+        _serve_logger.info(
+            "Delivered %d proactive push(es): %s", len(delivered), delivered
+        )
 
 
 def _serve_drain_notifications(
@@ -1561,7 +1687,21 @@ def serve(
 
     from ..gateway import create_runtime_gateways
 
-    runtime_gateways = create_runtime_gateways()
+    if config.gateway_backend == "langgraph_server":
+        # serve already started langgraph-dev above (_ensure_async_subagent_server),
+        # so this URL is live. Runs execute server-side and threads are server-born,
+        # which is what lets the proactive cron enumerate + commit into them and the
+        # serve-side delivery poll read them back. Interactive turns run against the
+        # stripped server (no MCP tools) while this backend is selected.
+        from ..langgraph_dev.sdk import configured_langgraph_dev_url
+
+        runtime_gateways = create_runtime_gateways(
+            backend="langgraph_server",
+            base_url=configured_langgraph_dev_url(),
+        )
+    else:
+        runtime_gateways = create_runtime_gateways()
+    _serve_ensure_proactive_cron(config)
     tid = async_runtime.run_sync(
         lambda: runtime_gateways.graph_gateway.create_thread(
             GraphTarget(workspace_dir=ws)
@@ -1616,6 +1756,7 @@ def serve(
     # second gate that the poll loop always observes.
     import signal
     import threading
+    import time
 
     shutdown_event = threading.Event()
     no_active_cancel_scope = object()
@@ -1643,6 +1784,13 @@ def serve(
 
     _orig_sigint = signal.signal(signal.SIGINT, _handle_shutdown)
     _orig_sigterm = signal.signal(signal.SIGTERM, _handle_shutdown)
+
+    # Serve-side proactive delivery state: cross-poll idempotency set + throttle
+    # clock. Only exercised when proactive pushes are enabled on the server backend
+    # (the server-born threads the proactive cron commits into).
+    proactive_delivery_on = _serve_proactive_enabled(config)
+    proactive_seen: set[str] = set()
+    last_proactive_poll = 0.0
 
     try:
         while not shutdown_event.is_set():
@@ -1686,6 +1834,16 @@ def serve(
                     )
                 finally:
                     active_cancel_scope = no_active_cancel_scope
+
+            # Publish any proactive pushes the cron committed into channel threads
+            # (server backend only), throttled so we don't re-read every idle tick.
+            if proactive_delivery_on:
+                now = time.monotonic()
+                if now - last_proactive_poll >= _PROACTIVE_POLL_INTERVAL_S:
+                    last_proactive_poll = now
+                    _serve_deliver_proactive_pushes(
+                        runtime_state=runtime_state, seen=proactive_seen
+                    )
     except KeyboardInterrupt:
         shutdown_event.set()
     finally:

--- a/EvoScientist/cli/commands.py
+++ b/EvoScientist/cli/commands.py
@@ -1203,10 +1203,6 @@ def _serve_process_message(
         return
 
     remember_channel_origin(runtime_state.thread_id, msg)
-    # Companion to the in-process origin: stamp the server-side channel marker so the
-    # proactive cron's eligibility search can discover this thread. No-op unless serve
-    # runs on the server backend. Single chokepoint — every inbound message passes here.
-    _serve_stamp_channel_marker(runtime_state)
 
     runtime_workspace = runtime_state.workspace_dir or workspace_dir
 
@@ -1324,7 +1320,7 @@ def _serve_process_message(
             console.print(f"[dim][{msg.channel_type}] Replied to {msg.sender}[/dim]")
             return
 
-        meta = build_metadata(runtime_workspace, model)
+        meta = _serve_turn_metadata(runtime_state, runtime_workspace, model)
         try:
             response = run_streaming(
                 ui_backend="cli",
@@ -1415,26 +1411,24 @@ def _serve_ensure_proactive_cron(config: "EvoScientistConfig | None") -> None:
         _serve_logger.warning("Proactive cron registration failed: %s", exc)
 
 
-def _serve_stamp_channel_marker(runtime_state: ServeRuntimeState) -> None:
-    """Stamp the channel-origin marker on the active thread (server backend only).
+def _serve_turn_metadata(
+    runtime_state: ServeRuntimeState, workspace_dir: str | None, model: str | None
+) -> dict[str, Any]:
+    """Run metadata for a channel turn.
 
-    Skipped when proactive pushes are disabled, so a serve session with the
-    feature off never marks threads as cron candidates.
+    The usual ``build_metadata`` payload, plus the channel-origin marker when
+    proactive pushes are enabled on the server backend. Sent as the run's
+    metadata, the marker reaches both the server thread registry (so the
+    proactive cron can enumerate the thread now) and the checkpoint rows (so
+    the registry restore carries it across a langgraph-dev restart). Companion
+    to ``remember_channel_origin``, which only records the origin in-process.
     """
-    if not _serve_proactive_enabled(runtime_state.config):
-        return
-    client = _serve_server_client(runtime_state)
-    thread_id = runtime_state.thread_id
-    if client is None or not thread_id:
-        return
-    from ..proactive.eligibility import stamp_channel_marker
+    meta = build_metadata(workspace_dir, model)
+    if _serve_proactive_enabled(runtime_state.config):
+        from ..proactive.eligibility import CHANNEL_ORIGIN_MARKER
 
-    try:
-        runtime_state.async_runtime.run_sync(
-            lambda: stamp_channel_marker(client, thread_id)
-        )
-    except Exception as exc:
-        _serve_logger.warning("Proactive channel-marker stamp failed: %s", exc)
+        meta = {**meta, **CHANNEL_ORIGIN_MARKER}
+    return meta
 
 
 def _serve_deliver_proactive_pushes(

--- a/EvoScientist/cli/commands.py
+++ b/EvoScientist/cli/commands.py
@@ -1396,6 +1396,12 @@ def _serve_ensure_proactive_cron(config: "EvoScientistConfig | None") -> None:
     try:
         existing = proactive_cron.list_proactive_schedules()
         if existing:
+            # A persisted cron may have been disabled (set_proactive_enabled);
+            # config says enabled, so reconcile rather than leave it inert.
+            for cron in existing:
+                if isinstance(cron, dict) and cron.get("enabled") is False:
+                    proactive_cron.set_proactive_enabled(cron["cron_id"], True)
+                    _serve_logger.info("Re-enabled proactive cron %s", cron["cron_id"])
             _serve_logger.info(
                 "Proactive cron already registered (%d); not creating another",
                 len(existing),

--- a/EvoScientist/config/settings.py
+++ b/EvoScientist/config/settings.py
@@ -547,6 +547,13 @@ class EvoScientistConfig:
             )
             self.memory_observation_cache_max_files = 2048
 
+        idle = self.proactive_idle_minutes
+        if not isinstance(idle, int) or isinstance(idle, bool) or idle < 0:
+            logging.getLogger(__name__).warning(
+                "Invalid proactive_idle_minutes %r; falling back to 120.", idle
+            )
+            self.proactive_idle_minutes = 120
+
         # auto_mode and dangerous_mode both imply auto_approve regardless of
         # source (CLI, env, config file, direct construction) — done here so the
         # "unattended → zero prompts" contract holds even when either is set via

--- a/EvoScientist/config/settings.py
+++ b/EvoScientist/config/settings.py
@@ -242,6 +242,22 @@ class EvoScientistConfig:
     # back to UTC if it can't be determined; set e.g. "Europe/London" to pin one.
     scheduler_default_timezone: str = ""
 
+    # --- Proactive pushes (issue #263) ---
+    # When enabled, a langgraph cron runs a tool-stripped shadow turn over idle
+    # channel threads every 10 minutes and may append ONE unprompted assistant
+    # message, which serve then delivers to the thread's channel. Requires serve
+    # to run on the langgraph-server gateway backend (the cron only sees
+    # server-born threads). Off by default.
+    proactive_enabled: bool = False
+    # Minimum minutes since the thread's last activity before a push is considered.
+    proactive_idle_minutes: int = 120
+    # Local-time window "HH:MM-HH:MM" (may wrap midnight) during which no push is
+    # generated. Empty string disables quiet hours.
+    proactive_quiet_hours: str = "22:00-08:00"
+    # IANA timezone the quiet-hours window is evaluated in. Empty string => the
+    # host's local zone (via tzlocal), falling back to UTC.
+    proactive_timezone: str = ""
+
     # Whether langgraph dev persists its runtime state to .langgraph_api/ next
     # to the subprocess cwd. True (default) keeps async-task, scheduler, and
     # Store API state across subprocess restarts — useful for future
@@ -862,6 +878,10 @@ _ENV_MAPPINGS = {
     "webui_host": "EVOSCIENTIST_WEBUI_HOST",
     "enable_scheduler": "EVOSCIENTIST_ENABLE_SCHEDULER",
     "scheduler_default_timezone": "EVOSCIENTIST_SCHEDULER_DEFAULT_TIMEZONE",
+    "proactive_enabled": "EVOSCIENTIST_PROACTIVE_ENABLED",
+    "proactive_idle_minutes": "EVOSCIENTIST_PROACTIVE_IDLE_MINUTES",
+    "proactive_quiet_hours": "EVOSCIENTIST_PROACTIVE_QUIET_HOURS",
+    "proactive_timezone": "EVOSCIENTIST_PROACTIVE_TIMEZONE",
     "code_interpreter_timeout": "EVOSCIENTIST_CODE_INTERPRETER_TIMEOUT",
     "code_interpreter_max_result_chars": "EVOSCIENTIST_CODE_INTERPRETER_MAX_RESULT_CHARS",
     "sandbox_execute_timeout": "EVOSCIENTIST_SANDBOX_EXECUTE_TIMEOUT",

--- a/EvoScientist/config/settings.py
+++ b/EvoScientist/config/settings.py
@@ -214,6 +214,14 @@ class EvoScientistConfig:
     # 2024. Override if it conflicts with another local service.
     langgraph_dev_port: int = 6174
 
+    # Which graph gateway serve executes through. "local" = in-process
+    # LocalGraphGateway (default, byte-identical to today); "langgraph_server" =
+    # route runs through the langgraph-dev server via the SDK, making serve's
+    # threads server-born so the proactive cron can enumerate + commit into them
+    # and serve can read them back for channel delivery. Required for
+    # proactive_enabled to take effect.
+    gateway_backend: str = "local"
+
     # Network interface the langgraph dev subprocess binds to. Loopback by
     # default — this is the unauthenticated agent API (the agent can run
     # shell), so "0.0.0.0" is opt-in and every launcher prints a PUBLIC BIND
@@ -873,6 +881,7 @@ _ENV_MAPPINGS = {
     "checkpoint_keep_per_thread": "EVOSCIENTIST_CHECKPOINT_KEEP_PER_THREAD",
     "enable_async_subagents": "EVOSCIENTIST_ENABLE_ASYNC_SUBAGENTS",
     "langgraph_dev_port": "EVOSCIENTIST_LANGGRAPH_DEV_PORT",
+    "gateway_backend": "EVOSCIENTIST_GATEWAY_BACKEND",
     "langgraph_dev_host": "EVOSCIENTIST_LANGGRAPH_DEV_HOST",
     "webui_port": "EVOSCIENTIST_WEBUI_PORT",
     "webui_host": "EVOSCIENTIST_WEBUI_HOST",

--- a/EvoScientist/gateway/local.py
+++ b/EvoScientist/gateway/local.py
@@ -190,9 +190,10 @@ class LocalGraphGateway:
         target: GraphTarget,
         thread_id: str,
         values: GraphStateValues,
+        *,
+        as_node: str | None = None,
     ) -> None:
         local_graph = self._require_local_graph(target)
-        as_node = "model" if "_summarization_event" in values else None
         await local_graph.aupdate_state(
             {"configurable": {"thread_id": thread_id}},
             values,

--- a/EvoScientist/gateway/local.py
+++ b/EvoScientist/gateway/local.py
@@ -192,10 +192,14 @@ class LocalGraphGateway:
         values: GraphStateValues,
         *,
         as_node: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         local_graph = self._require_local_graph(target)
+        config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
+        if metadata:
+            config["metadata"] = metadata
         await local_graph.aupdate_state(
-            {"configurable": {"thread_id": thread_id}},
+            config,
             values,
             as_node=as_node,
         )

--- a/EvoScientist/gateway/server.py
+++ b/EvoScientist/gateway/server.py
@@ -612,8 +612,9 @@ class LangGraphServerGateway:
         target: GraphTarget,
         thread_id: str,
         values: GraphStateValues,
+        *,
+        as_node: str | None = None,
     ) -> None:
-        as_node = "model" if "_summarization_event" in values else None
         await self.thread_store.client.threads.update_state(
             thread_id,
             values,

--- a/EvoScientist/gateway/server.py
+++ b/EvoScientist/gateway/server.py
@@ -614,7 +614,14 @@ class LangGraphServerGateway:
         values: GraphStateValues,
         *,
         as_node: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
+        # The server-side checkpointer (_ApiPruningCheckpointer) stamps
+        # ``agent_name`` from ``graph_id`` during normal runs. The SDK's
+        # ``update_state`` has no metadata parameter, so ``metadata`` is
+        # accepted for protocol compliance with the local gateway but not
+        # forwarded. The server path's checkpoint stamping is handled
+        # server-side.
         await self.thread_store.client.threads.update_state(
             thread_id,
             values,

--- a/EvoScientist/gateway/server.py
+++ b/EvoScientist/gateway/server.py
@@ -616,12 +616,12 @@ class LangGraphServerGateway:
         as_node: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        # The server-side checkpointer (_ApiPruningCheckpointer) stamps
-        # ``agent_name`` from ``graph_id`` during normal runs. The SDK's
-        # ``update_state`` has no metadata parameter, so ``metadata`` is
-        # accepted for protocol compliance with the local gateway but not
-        # forwarded. The server path's checkpoint stamping is handled
-        # server-side.
+        # Best-effort contract: the SDK's ``update_state`` has no metadata
+        # parameter, so ``metadata`` cannot be forwarded on this path. The
+        # server-side checkpointer (_ApiPruningCheckpointer) stamps ownership
+        # (``agent_name`` from ``graph_id``, ``workspace_dir``, ``updated_at``)
+        # itself, so restart recovery does not depend on the caller's metadata.
+        # A caller-supplied key that is not one of those is dropped here.
         await self.thread_store.client.threads.update_state(
             thread_id,
             values,

--- a/EvoScientist/gateway/types.py
+++ b/EvoScientist/gateway/types.py
@@ -182,5 +182,15 @@ class GraphGateway(Protocol):
         target: GraphTarget,
         thread_id: str,
         values: GraphStateValues,
+        *,
+        as_node: str | None = None,
     ) -> None:
-        """Update graph state values for a thread."""
+        """Update graph state values for a thread.
+
+        ``as_node`` controls which graph node's writers apply the update.
+        ``None`` lets LangGraph infer the node from checkpoint history (the
+        pre-existing default). A real node name (e.g. ``"model"``) runs that
+        node's channel writers — required for appending to the ``messages``
+        channel. ``END`` is only valid with ``values=None`` (clears pending
+        tasks; ``next`` becomes empty).
+        """

--- a/EvoScientist/gateway/types.py
+++ b/EvoScientist/gateway/types.py
@@ -184,6 +184,7 @@ class GraphGateway(Protocol):
         values: GraphStateValues,
         *,
         as_node: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """Update graph state values for a thread.
 
@@ -193,4 +194,14 @@ class GraphGateway(Protocol):
         node's channel writers — required for appending to the ``messages``
         channel. ``END`` is only valid with ``values=None`` (clears pending
         tasks; ``next`` becomes empty).
+
+        ``metadata`` is merged into the LangGraph checkpoint metadata via
+        the config (``config["metadata"]``) — the same mechanism normal
+        turns use (``stream_agent_events`` sets ``config["metadata"]``
+        from ``build_metadata``). The checkpoint saver's
+        ``get_checkpoint_metadata`` merges string scalars from
+        ``config["metadata"]`` into the stored checkpoint metadata, so
+        keys like ``agent_name`` and ``workspace_dir`` land on the
+        checkpoint row. When ``None``, behavior is byte-identical to the
+        pre-existing default (no metadata key on the config).
         """

--- a/EvoScientist/gateway/types.py
+++ b/EvoScientist/gateway/types.py
@@ -195,13 +195,14 @@ class GraphGateway(Protocol):
         channel. ``END`` is only valid with ``values=None`` (clears pending
         tasks; ``next`` becomes empty).
 
-        ``metadata`` is merged into the LangGraph checkpoint metadata via
-        the config (``config["metadata"]``) — the same mechanism normal
+        ``metadata`` is best-effort checkpoint metadata. The local gateway
+        merges it via ``config["metadata"]`` — the same mechanism normal
         turns use (``stream_agent_events`` sets ``config["metadata"]``
-        from ``build_metadata``). The checkpoint saver's
-        ``get_checkpoint_metadata`` merges string scalars from
-        ``config["metadata"]`` into the stored checkpoint metadata, so
-        keys like ``agent_name`` and ``workspace_dir`` land on the
-        checkpoint row. When ``None``, behavior is byte-identical to the
+        from ``build_metadata``), so keys like ``agent_name`` and
+        ``workspace_dir`` land on the checkpoint row. The server gateway
+        cannot forward it (the SDK's ``update_state`` has no metadata
+        parameter); there the server-side checkpointer stamps ownership
+        itself, so implementations must not rely on caller-supplied keys
+        surviving. When ``None``, behavior is byte-identical to the
         pre-existing default (no metadata key on the config).
         """

--- a/EvoScientist/langgraph_dev/langgraph.json
+++ b/EvoScientist/langgraph_dev/langgraph.json
@@ -5,6 +5,7 @@
         "writing-agent": "EvoScientist.langgraph_dev.graphs:writing_agent",
         "data-analysis-agent": "EvoScientist.langgraph_dev.graphs:data_analysis_agent",
         "scheduler": "EvoScientist.langgraph_dev.graphs:scheduler",
+        "proactive": "EvoScientist.proactive.graph:proactive_graph",
         "expert-container-async": "EvoScientist.langgraph_dev.graphs:expert_container_async",
         "evomemory-subagent-worker": "EvoScientist.langgraph_dev.graphs:evomemory_subagent_worker",
         "evomemory-turn-worker": "EvoScientist.langgraph_dev.graphs:evomemory_turn_worker",

--- a/EvoScientist/memory/observations/index.py
+++ b/EvoScientist/memory/observations/index.py
@@ -16,13 +16,18 @@ def build_observation_index_context(
     memory_dir: str | Path,
     project_id: str,
     max_inline_chars: int = DEFAULT_MAX_INLINE_OBSERVATION_INDEX_CHARS,
+    include_search_hints: bool = True,
 ) -> str:
-    """Build a compact observation-memory index for prompts."""
+    """Build a compact observation-memory index for prompts.
+
+    ``include_search_hints=False`` omits the tool-usage footer, for model calls
+    that carry no memory tools (the index is then the whole memory in context).
+    """
     return _format_observation_index_context(
         _observation_documents(memory_dir=memory_dir, project_id=project_id),
         include_counts=True,
         include_paths=True,
-        include_search_hints=True,
+        include_search_hints=include_search_hints,
         empty_context=True,
         intro="Indexed observations:",
         max_inline_chars=max_inline_chars,

--- a/EvoScientist/middleware/__init__.py
+++ b/EvoScientist/middleware/__init__.py
@@ -30,6 +30,10 @@ from .memory_lifecycle import (
     default_memory_scheduler,
 )
 from .model_fallback import ModelFallbackMiddleware, load_fallback_chain
+from .proactive_mode import (
+    ProactiveModeMiddleware,
+    create_proactive_mode_middleware,
+)
 from .runtime_context import RuntimeContextMiddleware, create_runtime_context_middleware
 from .scheduler import (
     SchedulerMiddleware,
@@ -52,6 +56,7 @@ __all__ = [
     "EvoMemoryLifecycleMiddleware",
     "EvoMemoryMiddleware",
     "ModelFallbackMiddleware",
+    "ProactiveModeMiddleware",
     "Question",
     "RuntimeContextMiddleware",
     "SchedulerMiddleware",
@@ -63,6 +68,7 @@ __all__ = [
     "create_context_editing_middleware",
     "create_memory_lifecycle_middleware",
     "create_memory_middleware",
+    "create_proactive_mode_middleware",
     "create_runtime_context_middleware",
     "create_scheduler_middleware",
     "create_tool_selector_middleware",

--- a/EvoScientist/middleware/memory.py
+++ b/EvoScientist/middleware/memory.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
 import os
 import re
@@ -95,6 +96,18 @@ Required memory preflight:
   the actual workspace work as appropriate.
 - Mention the result briefly before continuing: observation IDs used, or that
   no relevant observation was found. Keep this preflight short.
+"""
+
+# Variant for model calls that carry no tools (e.g. a proactive shadow turn):
+# the preflight above would tell the model to call tools it does not have, which
+# it then acts out as text instead of answering.
+OBSERVATION_MEMORY_READ_INSTRUCTIONS_NO_TOOLS = """
+Observation memory lives under `/memories/observations/`:
+- `/memories/observations/global/`: cross-project observations.
+- `/memories/observations/projects/{project_id}/`: observations for this workspace.
+
+No memory tools are available on this turn. The inlined observation index below
+is the memory in context for this reply; use it directly.
 """
 
 OBSERVATION_MEMORY_WRITE_INSTRUCTIONS = """
@@ -311,6 +324,17 @@ def _apply_bootstrap_view(
         "intro_asked_thread": view["intro_asked_thread"],
     }
     return merged
+
+
+def _request_has_tools(request: ModelRequest) -> bool:
+    """True unless the model request carries an empty tool list.
+
+    A request with no tools (a proactive shadow turn strips them all) must not
+    receive tool-usage directives: a model told to run a memory preflight with
+    no tools acts it out as text instead of answering.
+    """
+    tools = getattr(request, "tools", None)
+    return tools is None or bool(tools)
 
 
 def _current_thread_id() -> str | None:
@@ -759,7 +783,9 @@ class EvoMemoryMiddleware(AgentMiddleware):
             return PROFILE_BOOTSTRAP_RETRY
         return ""
 
-    def _refresh_observation_index_context(self) -> str:
+    def _refresh_observation_index_context(
+        self, *, include_search_hints: bool = True
+    ) -> str:
         """Refresh the prompt observation index from current memory files."""
         if not self._enable_observation_memory:
             return ""
@@ -768,6 +794,7 @@ class EvoMemoryMiddleware(AgentMiddleware):
             context = build_observation_index_context(
                 memory_dir=self._memory_dir,
                 project_id=self._project_id,
+                include_search_hints=include_search_hints,
             )
         except OSError as e:
             logger.warning("Failed to refresh observation memory index: %s", e)
@@ -778,9 +805,14 @@ class EvoMemoryMiddleware(AgentMiddleware):
         self._observation_index_context = context
         return context
 
-    def _observation_memory_instructions(self) -> str:
+    def _observation_memory_instructions(self, *, tools_available: bool = True) -> str:
         if not self._enable_observation_memory:
             return ""
+        if not tools_available:
+            # No tool directives (preflight / record) on a tool-less call.
+            return OBSERVATION_MEMORY_READ_INSTRUCTIONS_NO_TOOLS.format(
+                project_id=self._project_id
+            )
 
         instructions = OBSERVATION_MEMORY_READ_INSTRUCTIONS.format(
             project_id=self._project_id
@@ -789,14 +821,16 @@ class EvoMemoryMiddleware(AgentMiddleware):
             return instructions
         return instructions + OBSERVATION_MEMORY_WRITE_INSTRUCTIONS
 
-    def _memory_instructions_context(self) -> str:
+    def _memory_instructions_context(self, *, tools_available: bool = True) -> str:
         """Return static memory instructions for enabled memory features."""
         instructions = []
         if self._enable_profile_memory:
             instructions.append(
                 PROFILE_MEMORY_INSTRUCTIONS.format(project_id=self._project_id)
             )
-        if observation_instructions := self._observation_memory_instructions():
+        if observation_instructions := self._observation_memory_instructions(
+            tools_available=tools_available
+        ):
             instructions.append(observation_instructions)
         if not instructions:
             return ""
@@ -826,12 +860,13 @@ class EvoMemoryMiddleware(AgentMiddleware):
         observation_index_context: str,
         profile_content: str,
         bootstrap_context: str = "",
+        tools_available: bool = True,
     ) -> str:
         """Build request memory context ordered from static to dynamic."""
         return "\n\n".join(
             part
             for part in (
-                self._memory_instructions_context(),
+                self._memory_instructions_context(tools_available=tools_available),
                 observation_index_context,
                 self._profile_memory_context(profile_content),
                 bootstrap_context.strip(),
@@ -855,6 +890,7 @@ class EvoMemoryMiddleware(AgentMiddleware):
             observation_index_context=observation_index_context,
             profile_content=profile_content,
             bootstrap_context=bootstrap_context,
+            tools_available=_request_has_tools(request),
         )
         new_system = append_to_system_message(request.system_message, injection)
         return request.override(system_message=new_system)
@@ -869,7 +905,9 @@ class EvoMemoryMiddleware(AgentMiddleware):
         profile_content = self._profile_context_for_request()
         return self._inject_memory_context(
             request,
-            observation_index_context=self._refresh_observation_index_context(),
+            observation_index_context=self._refresh_observation_index_context(
+                include_search_hints=_request_has_tools(request)
+            ),
             profile_content=profile_content,
             bootstrap_context=self._bootstrap_context(
                 thread_id=_current_thread_id(),
@@ -885,16 +923,18 @@ class EvoMemoryMiddleware(AgentMiddleware):
         # Resolved on the event-loop thread: get_config() reads a contextvar.
         thread_id = _current_thread_id()
         human_messages = _count_human_messages(request.state)
+        refresh_index = functools.partial(
+            self._refresh_observation_index_context,
+            include_search_hints=_request_has_tools(request),
+        )
 
         if self._enable_observation_memory and self._enable_profile_memory:
             observation_index_context, profile_context = await asyncio.gather(
-                asyncio.to_thread(self._refresh_observation_index_context),
+                asyncio.to_thread(refresh_index),
                 asyncio.to_thread(self._read_profile_memory),
             )
         elif self._enable_observation_memory:
-            observation_index_context = await asyncio.to_thread(
-                self._refresh_observation_index_context
-            )
+            observation_index_context = await asyncio.to_thread(refresh_index)
         elif self._enable_profile_memory:
             profile_context = await asyncio.to_thread(self._read_profile_memory)
 

--- a/EvoScientist/middleware/memory.py
+++ b/EvoScientist/middleware/memory.py
@@ -98,6 +98,19 @@ Required memory preflight:
   no relevant observation was found. Keep this preflight short.
 """
 
+# Read-only profile guidance for model calls that carry no tools: the profile
+# context still shapes the reply, but there is nothing to edit it with.
+PROFILE_MEMORY_INSTRUCTIONS_NO_TOOLS = """
+These profile notes live under `/memories/profile/`:
+- `/memories/profile/SOUL.md`: how this copy should usually behave; voice and boundaries.
+- `/memories/profile/USER_PROFILE.md`: facts and preferences about the user.
+- `/memories/profile/RESEARCH_TASTE.md`: research interests, standards, methods that fit, and things to avoid.
+- `/memories/profile/projects/{project_id}/PROJECT_PROFILE.md`: conventions, commands, and pitfalls for this workspace.
+
+No file tools are available on this turn. Use the profile context below to shape
+the reply; profile files are not updated on this turn.
+"""
+
 # Variant for model calls that carry no tools (e.g. a proactive shadow turn):
 # the preflight above would tell the model to call tools it does not have, which
 # it then acts out as text instead of answering.
@@ -532,7 +545,9 @@ class EvoMemoryMiddleware(AgentMiddleware):
                     on_observation_recorded=self._record_observation_created,
                 )
             )
-        self._observation_index_context = ""
+        # Error-fallback cache, keyed by the search-hints variant so a tool-less
+        # request never receives the tool-usage footer on a refresh failure.
+        self._observation_index_contexts: dict[bool, str] = {}
         if not enable_observation_memory:
             return
 
@@ -798,11 +813,11 @@ class EvoMemoryMiddleware(AgentMiddleware):
             )
         except OSError as e:
             logger.warning("Failed to refresh observation memory index: %s", e)
-            return self._observation_index_context
+            return self._observation_index_contexts.get(include_search_hints, "")
         except Exception as e:
             logger.debug("Failed to refresh observation memory index: %s", e)
-            return self._observation_index_context
-        self._observation_index_context = context
+            return self._observation_index_contexts.get(include_search_hints, "")
+        self._observation_index_contexts[include_search_hints] = context
         return context
 
     def _observation_memory_instructions(self, *, tools_available: bool = True) -> str:
@@ -825,8 +840,13 @@ class EvoMemoryMiddleware(AgentMiddleware):
         """Return static memory instructions for enabled memory features."""
         instructions = []
         if self._enable_profile_memory:
+            profile_instructions = (
+                PROFILE_MEMORY_INSTRUCTIONS
+                if tools_available
+                else PROFILE_MEMORY_INSTRUCTIONS_NO_TOOLS
+            )
             instructions.append(
-                PROFILE_MEMORY_INSTRUCTIONS.format(project_id=self._project_id)
+                profile_instructions.format(project_id=self._project_id)
             )
         if observation_instructions := self._observation_memory_instructions(
             tools_available=tools_available

--- a/EvoScientist/middleware/proactive_mode.py
+++ b/EvoScientist/middleware/proactive_mode.py
@@ -1,0 +1,94 @@
+"""ProactiveModeMiddleware: strip all tools on a proactive shadow turn.
+
+A proactive turn (issue #263) reasons over a real, idle chat and emits a
+push/no-push *text* decision — it must not execute any tool against the real
+sandbox. This middleware reads ``configurable.proactive_mode`` fresh per turn
+and, when set, returns ``request.override(tools=[])`` so the model call carries
+zero tools. When the flag is absent the request passes through unchanged, so a
+normal turn is byte-identical to one without this middleware in the stack.
+
+The flag rides on the ``configurable`` primitive (read via
+``langgraph.config.get_config()``), not a server-side thread-state store
+(CLAUDE.md #5). Template: ``middleware/active_team.py``, which reads
+``configurable.active_teams`` the same way.
+
+Ordering: this middleware is placed *outer* of ``tool_selector`` in
+``_get_default_middleware`` (earlier in the list). langchain composes
+``wrap_model_call`` so the first middleware in the list is the outermost layer
+(``langchain/agents/factory.py``: "first in list becomes outermost layer"), so
+an outer ProactiveMode strips the tools *before* ``tool_selector`` runs — the
+selector then sees zero tools, skips its LLM selection call
+(``middleware/tool_selector.py``: short-circuit when ``len(request.tools) <=
+threshold``), and forwards the empty-tools request. No other default-stack
+middleware adds tools per request, so the strip is airtight in the composed
+stack; the proactive shadow runner additionally wraps the shadow model with a
+fail-closed spy that asserts zero bound tools, so a future re-adder is caught
+rather than silently leaked.
+
+Empty tools also removes ``ask_user`` (it is a tool), so a proactive turn can
+never park on a human-in-the-loop interrupt — no special-casing needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+
+
+def _read_proactive_mode() -> bool:
+    """Read ``configurable.proactive_mode`` from the current RunnableConfig.
+
+    Returns ``False`` when the config is absent, malformed, the key is missing
+    or non-boolean, or the call happens outside a runnable context (most common
+    in tests). Same degradation contract as ``active_team._read_active_teams``.
+    """
+    try:
+        from langgraph.config import get_config
+
+        cfg = get_config()
+    except Exception:
+        # Outside a runnable context or langgraph not importable — treat as off.
+        return False
+    if not isinstance(cfg, dict):
+        return False
+    configurable = cfg.get("configurable") or {}
+    if not isinstance(configurable, dict):
+        return False
+    return configurable.get("proactive_mode") is True
+
+
+class ProactiveModeMiddleware(AgentMiddleware):
+    """Strip all tools from the model request on a proactive turn."""
+
+    name = "proactive_mode"
+
+    def _apply(self, request: ModelRequest) -> ModelRequest:
+        """Return a tools-stripped request when proactive mode is on, else the
+        original request unchanged (byte-identical passthrough)."""
+        if _read_proactive_mode():
+            return request.override(tools=[])
+        return request
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        return handler(self._apply(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        return await handler(self._apply(request))
+
+
+def create_proactive_mode_middleware() -> ProactiveModeMiddleware:
+    """Build ProactiveModeMiddleware."""
+    return ProactiveModeMiddleware()

--- a/EvoScientist/proactive/__init__.py
+++ b/EvoScientist/proactive/__init__.py
@@ -1,0 +1,7 @@
+"""Proactive turns (issue #263).
+
+Home of the proactive-shadow machinery: a proactive turn reasons over a real,
+idle chat's history and decides whether to push an unprompted message, without
+persisting a synthetic trigger into the real thread and without executing any
+tool against the real sandbox.
+"""

--- a/EvoScientist/proactive/commit.py
+++ b/EvoScientist/proactive/commit.py
@@ -1,0 +1,335 @@
+"""Commit decision and commit execution for a proactive push.
+
+``decide_commit`` turns the shadow's reply into a decision (skip / stale /
+would_commit) and, for a push, builds the exact tagged ``AIMessage`` + checkpoint
+metadata the commit appends. ``commit_with_conflict_retry`` executes a
+``would_commit`` decision through an injected ``commit_fn``, deferring and
+retrying when the source thread has a run in flight. ``make_gateway_commit_fn``
+is the gateway-backed ``commit_fn``: append the tagged message as the ``model``
+node, then clear the pending ``next`` with ``as_node=END``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from langchain_core.messages import AIMessage
+from langgraph.graph import END
+from langgraph_sdk.errors import ConflictError
+
+from ..cli._constants import build_metadata
+
+logger = logging.getLogger(__name__)
+
+# Sentinel the shadow model emits to signal "do not push".
+NO_PUSH_SENTINEL = "NO_PUSH"
+
+# Longest reply that still counts as one channel message (a requested table or
+# summary fits; Telegram's hard limit is 4096). Anything longer is a runaway
+# generation, not a push, and is discarded rather than delivered.
+MAX_PUSH_CHARS = 4000
+
+# A model with no tools bound sometimes emits its tool-call envelope as plain
+# text (observed: ``<tool_call>execute...</tool_call>``). That is an attempted
+# action, never a message to send.
+_TOOL_CALL_TEXT_MARKERS = ("<tool_call>", "</tool_call>")
+
+
+def proactive_message_id(proactive_id: str) -> str:
+    """Stable message id for a committed push (addressable for later removal)."""
+    return f"proactive-{proactive_id}"
+
+
+# The committed assistant message is tagged under this ``additional_kwargs``
+# namespace so it can be told apart from normal replies:
+# ``{"evoscientist": {"is_proactive_push": True, "proactive_id": "<id>"}}``.
+PROACTIVE_TAG_NAMESPACE = "evoscientist"
+
+
+def build_proactive_tag(proactive_id: str) -> dict[str, Any]:
+    """``additional_kwargs`` payload that marks a message as a proactive push."""
+    return {
+        PROACTIVE_TAG_NAMESPACE: {
+            "is_proactive_push": True,
+            "proactive_id": proactive_id,
+        }
+    }
+
+
+def read_proactive_tag(additional_kwargs: Any) -> dict[str, Any] | None:
+    """Return the proactive-push tag inside ``additional_kwargs``, or ``None``.
+
+    ``None`` when the kwargs are not a mapping, carry no ``evoscientist``
+    namespace, or the namespace is not flagged ``is_proactive_push``.
+    """
+    if not isinstance(additional_kwargs, dict):
+        return None
+    tag = additional_kwargs.get(PROACTIVE_TAG_NAMESPACE)
+    if not isinstance(tag, dict) or not tag.get("is_proactive_push"):
+        return None
+    return tag
+
+
+@dataclass(frozen=True)
+class CommitDecision:
+    """Outcome of a commit decision.
+
+    ``action`` is one of ``"skip"`` (NO_PUSH/empty), ``"stale"`` (source thread
+    changed during shadow generation), or ``"would_commit"``. The ``message`` /
+    ``metadata`` / ``as_node`` fields are populated only for ``"would_commit"``
+    and describe exactly what a real commit WOULD append.
+    """
+
+    action: str
+    reason: str
+    message: AIMessage | None = None
+    metadata: dict[str, Any] | None = None
+    as_node: str | None = None
+
+
+def decide_commit(
+    reply: str | None,
+    *,
+    source_thread_id: str,
+    workspace_dir: str | None,
+    model: str | None,
+    pre_head: str | None,
+    current_head: str | None,
+    proactive_id: str,
+    max_reply_chars: int = MAX_PUSH_CHARS,
+) -> CommitDecision:
+    """Decide what to do with the shadow's reply; never writes.
+
+    - ``reply`` None/empty/``NO_PUSH`` → skip; longer than ``max_reply_chars`` →
+      skip with reason ``too_long``; a textual tool-call envelope → skip with
+      reason ``tool_call_text``.
+    - source ``pre_head != current_head`` (a user turn landed during the shadow) →
+      stale-discard.
+    - otherwise → build the tagged ``AIMessage`` + ``build_metadata`` + ``as_node
+      ="model"`` the commit uses, log it, and return it.
+    """
+    if reply is None:
+        return _skip(source_thread_id, "no_reply", reply)
+    stripped = reply.strip()
+    if not stripped:
+        return _skip(source_thread_id, "empty", reply)
+    if stripped == NO_PUSH_SENTINEL:
+        return _skip(source_thread_id, "no_push", reply)
+    if len(stripped) > max_reply_chars:
+        logger.warning(
+            "[proactive decision] skip: thread %s reply is %d chars (limit %d); "
+            "not a concise message, discarding",
+            source_thread_id,
+            len(stripped),
+            max_reply_chars,
+        )
+        return CommitDecision("skip", "too_long")
+    if any(marker in stripped for marker in _TOOL_CALL_TEXT_MARKERS):
+        logger.warning(
+            "[proactive decision] skip: thread %s reply contains a tool-call "
+            "envelope as text; discarding (preview=%r)",
+            source_thread_id,
+            stripped[:200],
+        )
+        return CommitDecision("skip", "tool_call_text")
+
+    if pre_head != current_head:
+        logger.info(
+            "[proactive decision] skip: thread %s changed during shadow (%s -> %s)",
+            source_thread_id,
+            pre_head,
+            current_head,
+        )
+        return CommitDecision("stale", "stale_source")
+
+    message = AIMessage(
+        content=reply,
+        id=proactive_message_id(proactive_id),
+        additional_kwargs=build_proactive_tag(proactive_id),
+    )
+    metadata = build_metadata(workspace_dir, model)
+    logger.info(
+        "[proactive decision] push for thread %s: append AIMessage "
+        "(proactive_id=%s, as_node='model', %d chars) then clear "
+        "(values=None, as_node=END); metadata=%s; preview=%r",
+        source_thread_id,
+        proactive_id,
+        len(reply),
+        metadata,
+        reply[:200],
+    )
+    return CommitDecision(
+        "would_commit",
+        "ok",
+        message=message,
+        metadata=metadata,
+        as_node="model",
+    )
+
+
+def _skip(source_thread_id: str, reason: str, reply: str | None) -> CommitDecision:
+    # INFO, not DEBUG: a skipped check is the common outcome and the only trace
+    # of what the shadow said, so it must be visible in ordinary server logs.
+    logger.info(
+        "[proactive decision] skip: thread %s reason=%s reply=%r",
+        source_thread_id,
+        reason,
+        (reply or "")[:160],
+    )
+    return CommitDecision("skip", reason)
+
+
+@dataclass(frozen=True)
+class CommitOutcome:
+    """Result of a proactive commit attempt.
+
+    ``status`` is one of ``"committed"`` (the tagged AIMessage was appended),
+    ``"stale"`` (a user turn landed on the source thread, so the shadow reply no
+    longer reflects the conversation → discarded), or ``"conflict_exhausted"``
+    (a user run stayed in flight across every retry → dropped; the next check
+    re-evaluates from a fresh snapshot). ``attempts`` counts commit tries made.
+    """
+
+    status: str
+    reason: str
+    attempts: int
+
+
+async def commit_with_conflict_retry(
+    decision: CommitDecision,
+    *,
+    source_thread_id: str,
+    commit_fn: Callable[
+        [AIMessage, dict[str, Any] | None, str | None], Awaitable[None]
+    ],
+    read_current_head: Callable[[], str | None],
+    pre_head: str | None,
+    max_retries: int = 3,
+    backoff: Callable[[int], Awaitable[None]] | None = None,
+) -> CommitOutcome:
+    """Commit a decided proactive push, deferring-and-retrying on ConflictError.
+
+    Gateway-agnostic: ``commit_fn`` performs the real append-tagged-AIMessage-as-
+    ``model`` + clear. The server-gateway path (``gateway.update_state_values`` →
+    langgraph_sdk) raises :class:`ConflictError` (409) when a user run is in flight;
+    a ``commit_fn`` that never conflicts simply takes the clean path.
+
+    On every attempt the source head is re-read first: if it moved past ``pre_head``
+    a user turn has landed, so the shadow reply is stale → discard (never overwrite a
+    fresh user turn with an older draft). On :class:`ConflictError` a user run is
+    still executing: defer (``backoff``) and retry — the next iteration's head check
+    discards the push once that run commits. Runs out of retries → drop.
+
+    ``decision`` MUST have ``action == "would_commit"`` (its message/metadata/as_node
+    are what gets committed).
+    """
+    if decision.action != "would_commit":
+        raise ValueError(
+            f"commit_with_conflict_retry expects a would_commit decision, "
+            f"got {decision.action!r}"
+        )
+    assert decision.message is not None  # would_commit always carries a message
+
+    for attempt in range(max_retries + 1):
+        if read_current_head() != pre_head:
+            logger.info(
+                "[proactive commit] skip: thread %s changed before commit "
+                "(head moved from %s) — discarding stale push",
+                source_thread_id,
+                pre_head,
+            )
+            return CommitOutcome("stale", "stale_source", attempt)
+        try:
+            await commit_fn(decision.message, decision.metadata, decision.as_node)
+        except ConflictError:
+            logger.warning(
+                "[proactive commit] ConflictError on thread %s (attempt %d/%d): "
+                "a user run is in flight; deferring",
+                source_thread_id,
+                attempt + 1,
+                max_retries + 1,
+            )
+            if backoff is not None:
+                await backoff(attempt)
+            continue
+        logger.info(
+            "[proactive commit] committed proactive push to thread %s (attempt %d)",
+            source_thread_id,
+            attempt + 1,
+        )
+        return CommitOutcome("committed", "ok", attempt + 1)
+
+    logger.warning(
+        "[proactive commit] gave up on thread %s: user run still in flight after "
+        "%d attempts — dropping push (next check will re-evaluate)",
+        source_thread_id,
+        max_retries + 1,
+    )
+    return CommitOutcome("conflict_exhausted", "retries_exhausted", max_retries + 1)
+
+
+class _StateGateway(Protocol):
+    """Minimal gateway surface the real commit uses: the widened
+    ``update_state_values`` (server path, langgraph_sdk-backed → raises
+    ``ConflictError`` on an in-flight run)."""
+
+    async def update_state_values(
+        self,
+        target: Any,
+        thread_id: str,
+        values: dict[str, Any] | None,
+        *,
+        as_node: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+def make_gateway_commit_fn(
+    gateway: _StateGateway,
+    target: Any,
+    thread_id: str,
+) -> Callable[[AIMessage, dict[str, Any] | None, str | None], Awaitable[None]]:
+    """Build the real server-path ``commit_fn`` for :func:`commit_with_conflict_retry`.
+
+    Commits a decided proactive push INTO the source thread via the widened gateway
+    ``update_state_values``: append the tagged ``AIMessage`` as the ``model`` node
+    (carrying ``metadata`` so the checkpoint stays visible), then clear the pending
+    ``next`` (``values=None`` with ``as_node=END`` — the only valid clear shape).
+    Either call raises :class:`ConflictError` (from the SDK) when a user run is in
+    flight; that propagates to ``commit_with_conflict_retry``'s defer-and-retry loop.
+
+    ``gateway``/``target`` are injected, so this is unit-testable against a fake
+    gateway.
+    """
+
+    async def _commit(
+        message: AIMessage,
+        metadata: dict[str, Any] | None,
+        as_node: str | None,
+    ) -> None:
+        # The append is the conflict-prone commit: a ConflictError here propagates
+        # so commit_with_conflict_retry can defer-and-retry (nothing committed yet).
+        await gateway.update_state_values(
+            target,
+            thread_id,
+            {"messages": [message]},
+            as_node=as_node,
+            metadata=metadata,
+        )
+        # The clear is best-effort cleanup (reset pending ``next``). It runs AFTER a
+        # successful append, so its ConflictError must NOT propagate — a retry would
+        # re-append and double-commit the push. A user run racing in right after the
+        # append leaves a benign non-empty ``next`` the user's own turn resolves.
+        try:
+            await gateway.update_state_values(target, thread_id, None, as_node=END)
+        except ConflictError:
+            logger.warning(
+                "[proactive commit] clear-next conflicted after a committed append "
+                "on thread %s; leaving pending next (benign, user run resolves it)",
+                thread_id,
+            )
+
+    return _commit

--- a/EvoScientist/proactive/commit.py
+++ b/EvoScientist/proactive/commit.py
@@ -11,6 +11,7 @@ node, then clear the pending ``next`` with ``as_node=END``.
 
 from __future__ import annotations
 
+import inspect
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -205,7 +206,7 @@ async def commit_with_conflict_retry(
     commit_fn: Callable[
         [AIMessage, dict[str, Any] | None, str | None], Awaitable[None]
     ],
-    read_current_head: Callable[[], str | None],
+    read_current_head: Callable[[], str | Awaitable[str | None] | None],
     pre_head: str | None,
     max_retries: int = 3,
     backoff: Callable[[int], Awaitable[None]] | None = None,
@@ -217,9 +218,10 @@ async def commit_with_conflict_retry(
     langgraph_sdk) raises :class:`ConflictError` (409) when a user run is in flight;
     a ``commit_fn`` that never conflicts simply takes the clean path.
 
-    On every attempt the source head is re-read first: if it moved past ``pre_head``
-    a user turn has landed, so the shadow reply is stale → discard (never overwrite a
-    fresh user turn with an older draft). On :class:`ConflictError` a user run is
+    On every attempt the source head is re-read first (``read_current_head`` may
+    return an awaitable, e.g. a server ``get_state`` fetch): if it moved past
+    ``pre_head`` a user turn (or another proactive tick) has landed, so the shadow
+    reply is stale → discard (never overwrite a fresh turn with an older draft). On :class:`ConflictError` a user run is
     still executing: defer (``backoff``) and retry — the next iteration's head check
     discards the push once that run commits. Runs out of retries → drop.
 
@@ -234,7 +236,7 @@ async def commit_with_conflict_retry(
     assert decision.message is not None  # would_commit always carries a message
 
     for attempt in range(max_retries + 1):
-        if read_current_head() != pre_head:
+        if await resolve_head(read_current_head) != pre_head:
             logger.info(
                 "[proactive commit] skip: thread %s changed before commit "
                 "(head moved from %s) — discarding stale push",
@@ -269,6 +271,16 @@ async def commit_with_conflict_retry(
         max_retries + 1,
     )
     return CommitOutcome("conflict_exhausted", "retries_exhausted", max_retries + 1)
+
+
+async def resolve_head(
+    read_current_head: Callable[[], str | Awaitable[str | None] | None],
+) -> str | None:
+    """Call ``read_current_head`` and await it if it returned an awaitable."""
+    head = read_current_head()
+    if inspect.isawaitable(head):
+        head = await head
+    return head
 
 
 class _StateGateway(Protocol):

--- a/EvoScientist/proactive/cron.py
+++ b/EvoScientist/proactive/cron.py
@@ -17,7 +17,7 @@ workspace's config points at. ``is_available()`` gates on that server being up.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from langgraph_sdk.schema import Cron
@@ -32,6 +32,12 @@ from ..langgraph_dev.sdk import (
 # proactive crons never collide with user-scheduled tasks.
 PROACTIVE_GRAPH_ID = "proactive"
 PROACTIVE_RUN_KIND = "proactive_check"
+# Metadata of the single server thread every proactive tick runs on. Pinning the
+# cron to one thread lets the server serialize ticks: with
+# ``multitask_strategy="reject"`` a fire that overlaps a still-running tick is
+# refused, so two ticks can never check (and push to) the same thread at once.
+PROACTIVE_THREAD_METADATA = {"run_kind": PROACTIVE_RUN_KIND}
+PROACTIVE_MULTITASK_STRATEGY = "reject"
 # Every 10 minutes (MVP cadence). Quiet-hours / idle are enforced per-thread by the
 # gate inside the check, not by the cron schedule.
 DEFAULT_PROACTIVE_SCHEDULE = "*/10 * * * *"
@@ -56,21 +62,41 @@ def is_available() -> bool:
     return bool(is_langgraph_dev_running(base_url=_proactive_url()))
 
 
+def ensure_proactive_thread(client: Any | None = None) -> str:
+    """Return the id of the dedicated proactive tick thread, creating it once.
+
+    Looked up by :data:`PROACTIVE_THREAD_METADATA` so serve restarts reuse it.
+    """
+    client = client or _client()
+    found = client.threads.search(metadata=PROACTIVE_THREAD_METADATA, limit=1)
+    for thread in found or []:
+        thread_id = thread.get("thread_id") if isinstance(thread, dict) else None
+        if thread_id:
+            return str(thread_id)
+    created = client.threads.create(metadata=PROACTIVE_THREAD_METADATA)
+    return str(created["thread_id"])
+
+
 def create_proactive_schedule(
     *, schedule: str = DEFAULT_PROACTIVE_SCHEDULE, timezone: str | None = None
 ) -> Cron:
     """Register the periodic proactive-check cron against the ``proactive`` graph.
 
-    ``input`` is None: the proactive graph enumerates eligible threads itself, so
-    each fire is a bare tick, not a message turn.
+    The cron is pinned to the dedicated tick thread with
+    ``multitask_strategy="reject"`` so overlapping fires are serialized by the
+    server (a tick that outlasts the cadence simply makes the next fire a no-op).
+    Each fire is a bare tick, not a message turn: the graph enumerates eligible
+    threads itself and ignores the (empty, non-null) input.
     """
-    return _client().crons.create(
-        assistant_id=PROACTIVE_GRAPH_ID,
+    client = _client()
+    return client.crons.create_for_thread(
+        ensure_proactive_thread(client),
+        PROACTIVE_GRAPH_ID,
         schedule=schedule,
         # Empty (not None): langgraph rejects a null run input (EmptyInputError).
-        # The proactive graph ignores input — it enumerates threads itself.
         input={},
         metadata={"run_kind": PROACTIVE_RUN_KIND},
+        multitask_strategy=PROACTIVE_MULTITASK_STRATEGY,
         timezone=timezone or _default_timezone(),
     )
 

--- a/EvoScientist/proactive/cron.py
+++ b/EvoScientist/proactive/cron.py
@@ -1,0 +1,93 @@
+"""Proactive-check cron registration.
+
+The proactive MVP "reuses cron, checks every 10 min". This is the thin wrapper —
+sibling of ``EvoScientist/cron/schedule.py`` — that registers that periodic cron.
+Unlike ``schedule.py`` (which targets the throwaway ``scheduler`` graph), this
+targets the dedicated ``proactive`` graph (registered in ``langgraph.json``): a
+periodic scan whose run enumerates server-registered channel-thread
+candidates (``eligibility.list_channel_thread_candidates``) and runs a proactive
+check on each. So there is no per-run message input — the graph enumerates threads
+itself; ``proactive_mode`` is set by the shadow turns the check spawns, not baked
+into the cron.
+
+Like ``schedule.py``, isolation is process-level: crons live in the langgraph-dev
+process's ``.langgraph_api`` store, so this reaches whichever dev server the active
+workspace's config points at. ``is_available()`` gates on that server being up.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from langgraph_sdk.schema import Cron
+
+from ..langgraph_dev.sdk import (
+    configured_langgraph_dev_url,
+    default_scheduler_timezone,
+    get_langgraph_sync_client,
+)
+
+# Registered in langgraph.json. Distinct from scheduler's graph so
+# proactive crons never collide with user-scheduled tasks.
+PROACTIVE_GRAPH_ID = "proactive"
+PROACTIVE_RUN_KIND = "proactive_check"
+# Every 10 minutes (MVP cadence). Quiet-hours / idle are enforced per-thread by the
+# gate inside the check, not by the cron schedule.
+DEFAULT_PROACTIVE_SCHEDULE = "*/10 * * * *"
+
+
+def _proactive_url() -> str:
+    return configured_langgraph_dev_url()
+
+
+def _client():
+    return get_langgraph_sync_client(url=_proactive_url())
+
+
+def _default_timezone() -> str | None:
+    return default_scheduler_timezone()
+
+
+def is_available() -> bool:
+    """True when the langgraph dev backend (which fires crons) is reachable."""
+    from ..langgraph_dev.manager import is_langgraph_dev_running
+
+    return bool(is_langgraph_dev_running(base_url=_proactive_url()))
+
+
+def create_proactive_schedule(
+    *, schedule: str = DEFAULT_PROACTIVE_SCHEDULE, timezone: str | None = None
+) -> Cron:
+    """Register the periodic proactive-check cron against the ``proactive`` graph.
+
+    ``input`` is None: the proactive graph enumerates eligible threads itself, so
+    each fire is a bare tick, not a message turn.
+    """
+    return _client().crons.create(
+        assistant_id=PROACTIVE_GRAPH_ID,
+        schedule=schedule,
+        # Empty (not None): langgraph rejects a null run input (EmptyInputError).
+        # The proactive graph ignores input — it enumerates threads itself.
+        input={},
+        metadata={"run_kind": PROACTIVE_RUN_KIND},
+        timezone=timezone or _default_timezone(),
+    )
+
+
+def list_proactive_schedules() -> list[Cron]:
+    """Return only proactive-check crons (server-side ``run_kind`` filter)."""
+    return _client().crons.search(
+        metadata={"run_kind": PROACTIVE_RUN_KIND},
+        limit=1000,
+    )
+
+
+def delete_proactive_schedule(cron_id: str) -> None:
+    """Delete a proactive-check cron by id."""
+    _client().crons.delete(cron_id)
+
+
+def set_proactive_enabled(cron_id: str, enabled: bool) -> Cron:
+    """Enable or disable a proactive-check cron by id."""
+    return _client().crons.update(cron_id, enabled=enabled)

--- a/EvoScientist/proactive/delivery_watcher.py
+++ b/EvoScientist/proactive/delivery_watcher.py
@@ -1,0 +1,104 @@
+"""Serve-side delivery watcher for committed proactive pushes.
+
+The cron commits the proactive ``AIMessage`` into the source thread (server-side,
+in langgraph-dev) and does NOT deliver it there — the channel origins live only in
+the serve process's memory (``_thread_channel_origins``). This watcher runs in serve:
+it notices committed proactive pushes and delivers them via
+``publish_to_channel_origin`` (same pattern as serve's async-notifier drain). No
+persisted outbox — delivery runs in the process that already holds the origins;
+restart-recovery is out of scope for the MVP.
+
+The core here is pure/DI'd (unit-testable without a server or bus): the serve loop
+that polls periodically with the real SDK read + ``publish_to_channel_origin`` + a
+persistent ``seen`` set is a thin wrapper wired at assembly.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .commit import read_proactive_tag
+
+logger = logging.getLogger(__name__)
+
+
+def extract_proactive_push(messages: list[Any]) -> tuple[str, str] | None:
+    """Return ``(proactive_id, content)`` for the most recent proactive push.
+
+    Scans from the newest message and returns the first one carrying the
+    proactive-push tag (see ``commit.build_proactive_tag``) with a non-empty
+    ``proactive_id`` and content. ``None`` when the thread carries no proactive
+    push. Handles both ``BaseMessage`` objects and plain dicts (server state may
+    return either).
+    """
+    for msg in reversed(messages or []):
+        tag = read_proactive_tag(_additional_kwargs(msg))
+        if tag is None:
+            continue
+        proactive_id = tag.get("proactive_id")
+        content = _content(msg)
+        if proactive_id and content:
+            return str(proactive_id), content
+    return None
+
+
+async def deliver_pending_pushes(
+    thread_ids: list[str],
+    *,
+    read_messages: Callable[[str], Awaitable[list[Any]]],
+    publish: Callable[[str, str], bool],
+    seen: set[str],
+) -> list[str]:
+    """Deliver each thread's undelivered proactive push; return delivered ids.
+
+    For every thread, reads its messages (``read_messages``), finds the latest
+    proactive push, and — if its ``proactive_id`` is not already in ``seen`` —
+    delivers it via ``publish`` (``publish_to_channel_origin``). A ``proactive_id``
+    is added to ``seen`` ONLY on a successful publish, so a failed publish (no
+    origin yet, bus down) is retried on the next poll rather than lost. ``seen`` is
+    the watcher's cross-poll idempotency set; the caller owns its lifetime.
+    """
+    delivered: list[str] = []
+    for thread_id in thread_ids:
+        push = extract_proactive_push(await read_messages(thread_id))
+        if push is None:
+            continue
+        proactive_id, content = push
+        if proactive_id in seen:
+            continue
+        if publish(thread_id, content):
+            seen.add(proactive_id)
+            delivered.append(proactive_id)
+            logger.info(
+                "[proactive delivery] pushed %s to thread %s",
+                proactive_id,
+                thread_id,
+            )
+        else:
+            logger.warning(
+                "[proactive delivery] publish returned False for thread %s "
+                "(push %s) — no origin/bus; will retry next poll",
+                thread_id,
+                proactive_id,
+            )
+    return delivered
+
+
+def _additional_kwargs(msg: Any) -> dict[str, Any]:
+    kwargs = (
+        getattr(msg, "additional_kwargs", None)
+        if not isinstance(msg, dict)
+        else msg.get("additional_kwargs")
+    )
+    return kwargs if isinstance(kwargs, dict) else {}
+
+
+def _content(msg: Any) -> str | None:
+    content = (
+        msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
+    )
+    if isinstance(content, str) and content.strip():
+        return content
+    return None

--- a/EvoScientist/proactive/eligibility.py
+++ b/EvoScientist/proactive/eligibility.py
@@ -8,10 +8,13 @@ has no channel origin). So the cron only ever sees server-born channel threads.
 
 Serve-side companion: ``remember_channel_origin`` records the origin only in the
 in-process ``_thread_channel_origins`` dict, invisible to the server/cron
-process. Serve therefore also stamps ``CHANNEL_ORIGIN_MARKER`` into the thread's
-server metadata (``stamp_channel_marker``) when it registers an origin. Without
-the stamp the search returns nothing — fail-closed, which is the safe direction
-(no thread gets a proactive push rather than the wrong one).
+process. Serve therefore also sends ``CHANNEL_ORIGIN_MARKER`` as the run
+metadata of every channel turn: the server gateway merges run metadata into the
+thread's registry metadata (live visibility) and the checkpointer persists it
+on the checkpoint rows, from which ``sessions.py`` restores the registry after a
+langgraph-dev restart (restart survival). Without the marker the search returns
+nothing — fail-closed, which is the safe direction (no thread gets a proactive
+push rather than the wrong one).
 
 This function returns coarse *candidates* with their last-activity time; the
 authoritative per-thread decision (quiet hours, precise idle, in-flight, origin
@@ -27,12 +30,13 @@ from collections.abc import Awaitable
 from datetime import UTC, datetime
 from typing import Any, Protocol
 
+from ..sessions import CHANNEL_ORIGIN_METADATA_KEY
+
 logger = logging.getLogger(__name__)
 
-# Server-metadata marker serve stamps on a thread when it registers a channel
-# origin (companion change). Threads.search matches metadata by containment, so a
-# value-equality marker is the queryable shape.
-CHANNEL_ORIGIN_MARKER: dict[str, Any] = {"has_channel_origin": True}
+# Metadata marker serve sends with every channel turn. Threads.search matches
+# metadata by containment, so a value-equality marker is the queryable shape.
+CHANNEL_ORIGIN_MARKER: dict[str, Any] = {CHANNEL_ORIGIN_METADATA_KEY: True}
 
 
 class _ThreadsSearchClient(Protocol):
@@ -103,25 +107,3 @@ def _parse_iso_utc(value: str) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=UTC)
     return parsed.astimezone(UTC)
-
-
-async def stamp_channel_marker(
-    client: Any,
-    thread_id: str,
-    *,
-    marker: dict[str, Any] | None = None,
-) -> None:
-    """Stamp the channel-origin marker into ``thread_id``'s server metadata.
-
-    Write-side companion to :func:`list_channel_thread_candidates`:
-    ``remember_channel_origin`` records the origin only in serve's in-process dict,
-    invisible to the cron/server process. Serve calls this (when it holds a server
-    client) so the thread becomes discoverable by the eligibility search.
-    ``client.threads.update`` merges metadata server-side, so the marker does not
-    clobber ``agent_name``/``graph_id``/etc.
-    """
-    update = client.threads.update(
-        thread_id, metadata=marker if marker is not None else CHANNEL_ORIGIN_MARKER
-    )
-    if isinstance(update, Awaitable):
-        await update

--- a/EvoScientist/proactive/eligibility.py
+++ b/EvoScientist/proactive/eligibility.py
@@ -1,0 +1,127 @@
+"""Server-scoped candidate enumeration for the proactive cron.
+
+The proactive cron must pick which threads to run a check on. Candidates are
+enumerated from the **server registry** via ``client.threads.search`` restricted
+to threads carrying a channel-origin marker — NOT from a raw ``sessions.db`` scan
+(which also holds CLI/TUI threads the cron must never touch, and whose delivery
+has no channel origin). So the cron only ever sees server-born channel threads.
+
+Serve-side companion: ``remember_channel_origin`` records the origin only in the
+in-process ``_thread_channel_origins`` dict, invisible to the server/cron
+process. Serve therefore also stamps ``CHANNEL_ORIGIN_MARKER`` into the thread's
+server metadata (``stamp_channel_marker``) when it registers an origin. Without
+the stamp the search returns nothing — fail-closed, which is the safe direction
+(no thread gets a proactive push rather than the wrong one).
+
+This function returns coarse *candidates* with their last-activity time; the
+authoritative per-thread decision (quiet hours, precise idle, in-flight, origin
+presence) stays with ``gate.evaluate_gate`` in ``service.run_proactive_check``. It
+deliberately does not re-implement the idle test, to avoid a divergent second copy
+of the gate logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Server-metadata marker serve stamps on a thread when it registers a channel
+# origin (companion change). Threads.search matches metadata by containment, so a
+# value-equality marker is the queryable shape.
+CHANNEL_ORIGIN_MARKER: dict[str, Any] = {"has_channel_origin": True}
+
+
+class _ThreadsSearchClient(Protocol):
+    """Minimal client surface: ``client.threads.search(...)`` (langgraph_sdk)."""
+
+    @property
+    def threads(self) -> Any: ...
+
+
+async def list_channel_thread_candidates(
+    client: _ThreadsSearchClient,
+    *,
+    marker: dict[str, Any] | None = None,
+    limit: int = 50,
+    status: str | None = "idle",
+) -> list[tuple[str, datetime | None]]:
+    """Return ``(thread_id, last_activity)`` for server-registered channel threads.
+
+    Queries ``client.threads.search`` for threads whose server metadata contains
+    ``marker`` (default :data:`CHANNEL_ORIGIN_MARKER`) and whose ``status`` matches
+    ``status`` (default ``"idle"`` — no run in flight, the gate's in-flight
+    condition enforced cheaply server-side; pass ``None`` to skip it), newest-active
+    first, capped at ``limit``. ``last_activity`` is parsed from the thread's
+    ``updated_at`` (UTC; ``None`` when absent/unparseable) and is meant to be fed
+    straight into the gate. Threads without an id are skipped. An empty list means
+    "no eligible candidates" (including the fail-closed case where serve hasn't
+    stamped the marker yet).
+    """
+    search = client.threads.search(
+        metadata=marker if marker is not None else CHANNEL_ORIGIN_MARKER,
+        status=status,
+        sort_by="updated_at",
+        sort_order="desc",
+        limit=limit,
+    )
+    threads = await search if isinstance(search, Awaitable) else search
+
+    candidates: list[tuple[str, datetime | None]] = []
+    for thread in threads or []:
+        thread_id = thread.get("thread_id") if isinstance(thread, dict) else None
+        if not thread_id:
+            continue
+        candidates.append((str(thread_id), _thread_last_activity(thread)))
+
+    logger.debug(
+        "[proactive cron] %d channel-thread candidate(s) from server registry",
+        len(candidates),
+    )
+    return candidates
+
+
+def _thread_last_activity(thread: dict[str, Any]) -> datetime | None:
+    """Parse a thread's ``updated_at`` into a UTC datetime (None if absent/bad)."""
+    value = thread.get("updated_at")
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    return _parse_iso_utc(str(value))
+
+
+def _parse_iso_utc(value: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp; treat naive values as UTC."""
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+async def stamp_channel_marker(
+    client: Any,
+    thread_id: str,
+    *,
+    marker: dict[str, Any] | None = None,
+) -> None:
+    """Stamp the channel-origin marker into ``thread_id``'s server metadata.
+
+    Write-side companion to :func:`list_channel_thread_candidates`:
+    ``remember_channel_origin`` records the origin only in serve's in-process dict,
+    invisible to the cron/server process. Serve calls this (when it holds a server
+    client) so the thread becomes discoverable by the eligibility search.
+    ``client.threads.update`` merges metadata server-side, so the marker does not
+    clobber ``agent_name``/``graph_id``/etc.
+    """
+    update = client.threads.update(
+        thread_id, metadata=marker if marker is not None else CHANNEL_ORIGIN_MARKER
+    )
+    if isinstance(update, Awaitable):
+        await update

--- a/EvoScientist/proactive/gate.py
+++ b/EvoScientist/proactive/gate.py
@@ -1,0 +1,123 @@
+"""Proactive gate: decide whether a check should proceed.
+
+Pure logic over the disabled flag, origin presence, an in-flight lock, the
+idle-minutes threshold, and a quiet-hours window. Every rejection carries a
+reason (logged); no model call happens before the gate returns
+``should_run=True``. Kept decoupled from ``EvoScientistConfig`` — the caller
+supplies a ``ProactiveGateSettings`` so the logic stays pure and testable.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+from ..config.settings import _normalize_hhmm
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProactiveGateSettings:
+    """Static gate configuration for a proactive check."""
+
+    enabled: bool
+    idle_minutes: int
+    quiet_hours: str | None  # "HH:MM-HH:MM" (local to ``timezone``) or None
+    timezone: str  # IANA name, e.g. "America/New_York"
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    should_run: bool
+    reason: str
+
+
+def evaluate_gate(
+    settings: ProactiveGateSettings,
+    *,
+    now: datetime,
+    last_activity: datetime | None,
+    has_origin: bool,
+    in_flight: bool,
+) -> GateDecision:
+    """Return whether a proactive check should run, with a reason for the record.
+
+    Checks are ordered cheap-first so the recorded reason names the first failing
+    condition. ``now`` and ``last_activity`` are compared in UTC (naive values are
+    treated as UTC); quiet hours are evaluated in ``settings.timezone``.
+    """
+    now = _as_utc(now)
+    decision = _evaluate(
+        settings,
+        now=now,
+        last_activity=last_activity,
+        has_origin=has_origin,
+        in_flight=in_flight,
+    )
+    logger.debug("proactive gate decision: %s", decision.reason)
+    return decision
+
+
+def _evaluate(
+    settings: ProactiveGateSettings,
+    *,
+    now: datetime,
+    last_activity: datetime | None,
+    has_origin: bool,
+    in_flight: bool,
+) -> GateDecision:
+    if not settings.enabled:
+        return GateDecision(False, "disabled")
+    if not has_origin:
+        return GateDecision(False, "no_origin")
+    if in_flight:
+        return GateDecision(False, "in_flight")
+    if last_activity is None:
+        return GateDecision(False, "no_activity")
+    idle_minutes = (now - _as_utc(last_activity)).total_seconds() / 60.0
+    if idle_minutes < settings.idle_minutes:
+        return GateDecision(False, "idle_below_threshold")
+    if _in_quiet_hours(now, settings.quiet_hours, settings.timezone):
+        return GateDecision(False, "quiet_hours")
+    return GateDecision(True, "ok")
+
+
+def _in_quiet_hours(now: datetime, quiet_hours: str | None, timezone: str) -> bool:
+    window = _parse_window(quiet_hours)
+    if window is None:
+        return False
+    start, end = window
+    if start == end:
+        # Degenerate window — treat as "never quiet" rather than "always".
+        return False
+    local = now.astimezone(ZoneInfo(timezone))
+    minutes = local.hour * 60 + local.minute
+    if start < end:
+        return start <= minutes < end
+    # Wraparound window, e.g. 22:00-08:00.
+    return minutes >= start or minutes < end
+
+
+def _parse_window(quiet_hours: str | None) -> tuple[int, int] | None:
+    if not quiet_hours:
+        return None
+    parts = quiet_hours.split("-")
+    if len(parts) != 2:
+        return None
+    start = _normalize_hhmm(parts[0])
+    end = _normalize_hhmm(parts[1])
+    if start is None or end is None:
+        return None
+    return _to_minutes(start), _to_minutes(end)
+
+
+def _to_minutes(hhmm: str) -> int:
+    hour, minute = hhmm.split(":")
+    return int(hour) * 60 + int(minute)
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)

--- a/EvoScientist/proactive/gateway_delivery.py
+++ b/EvoScientist/proactive/gateway_delivery.py
@@ -1,0 +1,58 @@
+"""Server-path delivery: commit the proactive push INTO the source thread.
+
+The MVP appends the tagged ``AIMessage`` to the ORIGINAL thread via the server
+gateway. This ``Deliverer`` does exactly that, reusing
+:func:`commit.make_gateway_commit_fn` so the ConflictError defer-and-retry —
+owned by ``run_proactive_check``'s ``commit_with_conflict_retry`` loop — drives
+the retries: a ``ConflictError`` from the append propagates out of ``deliver``
+and is retried by that outer loop.
+
+Channel delivery is a SEPARATE serve-side concern: once the push is committed
+here, the ``delivery_watcher`` (running in serve, holding the channel origins)
+notices it and pushes it via ``publish_to_channel_origin``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.messages import AIMessage
+
+from .commit import build_proactive_tag, make_gateway_commit_fn, proactive_message_id
+
+
+class GatewayDeliverer:
+    """Commit proactive replies into the source thread via the server gateway.
+
+    ``gateway`` is the widened server gateway (``update_state_values`` accepting
+    ``as_node``/``metadata``); ``target`` is its ``GraphTarget``. Metadata is left
+    ``None`` — the server checkpointer stamps ``agent_name`` from ``graph_id`` on
+    the commit, so the thread stays visible without forwarding it (verified: the
+    server path accepts-but-ignores ``metadata``).
+    """
+
+    def __init__(self, gateway: Any, target: Any, *, as_node: str = "model") -> None:
+        self._gateway = gateway
+        self._target = target
+        self._as_node = as_node
+
+    async def deliver(
+        self,
+        source_thread_id: str,
+        reply: str,
+        proactive_id: str,
+        *,
+        source_messages: list | None = None,
+    ) -> bool:
+        message = AIMessage(
+            content=reply,
+            id=proactive_message_id(proactive_id),
+            additional_kwargs=build_proactive_tag(proactive_id),
+        )
+        commit_fn = make_gateway_commit_fn(
+            self._gateway, self._target, source_thread_id
+        )
+        # Append-conflict propagates (outer commit_with_conflict_retry retries);
+        # clear-conflict is swallowed inside make_gateway_commit_fn.
+        await commit_fn(message, None, self._as_node)
+        return True

--- a/EvoScientist/proactive/graph.py
+++ b/EvoScientist/proactive/graph.py
@@ -1,0 +1,290 @@
+"""The ``proactive`` graph (registered in ``langgraph.json``, fired by a cron).
+
+One cron tick: enumerate server-registered idle channel threads and run a
+proactive check on each (gate → tool-stripped shadow → commit into the SOURCE
+thread via the gateway; the serve-side ``delivery_watcher`` then pushes it).
+
+``run_proactive_graph_tick`` is the node body with every dependency injected, so
+it is unit-testable without a server or model. The langgraph ``StateGraph`` node
+that langgraph-dev runs constructs the real deps lazily on the first tick — the
+gateway's async SDK client, the server gateway (``create_runtime_gateways(
+backend="langgraph_server")``), and a tool-stripped shadow runner (``shadow.py``'s
+``build_shadow_graph``/``run_shadow_turn``) — and calls it.
+
+Importing this module is cheap (no MCP/model load), so it is safe for
+langgraph-dev to import at startup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+from .gate import ProactiveGateSettings
+from .gateway_delivery import GatewayDeliverer
+from .service import ProactiveCheckResult, make_read_source, run_proactive_tick
+
+logger = logging.getLogger(__name__)
+
+
+async def run_proactive_graph_tick(
+    *,
+    client: Any,
+    gateway: Any,
+    target: Any,
+    shadow_runner: Callable[[list, str], Awaitable[str | None]],
+    settings: ProactiveGateSettings,
+    trigger: str,
+    workspace_dir: str | None,
+    model: str | None,
+    now: datetime | None = None,
+    marker: dict[str, Any] | None = None,
+    limit: int = 50,
+) -> list[ProactiveCheckResult]:
+    """Run one proactive tick with the server adapters wired in.
+
+    Composes ``make_read_source`` (server ``get_state`` reads), ``GatewayDeliverer``
+    (commit into the source thread via ``gateway``), and ``run_proactive_tick``
+    (enumerate idle marked channel threads → per-thread gate/shadow/commit).
+    ``client`` is the sync langgraph SDK client (enumeration + state reads);
+    ``gateway``/``target`` are the server gateway used for the commit.
+    """
+    return await run_proactive_tick(
+        client,
+        now=now or datetime.now(UTC),
+        settings=settings,
+        read_source=make_read_source(client),
+        shadow_runner=shadow_runner,
+        deliverer=GatewayDeliverer(gateway, target),
+        trigger=trigger,
+        workspace_dir=workspace_dir,
+        model=model,
+        marker=marker,
+        limit=limit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The langgraph ``proactive`` graph (registered in langgraph.json).
+#
+# Importing this module + building the graph object is cheap (a one-node
+# StateGraph compile, no MCP/model), so langgraph-dev can import it at startup.
+# The real dependencies (SDK client, server gateway, in-process tool-stripped
+# shadow) are built lazily on the FIRST tick and memoized — never at import.
+# ---------------------------------------------------------------------------
+
+
+class _ProactiveTickState(TypedDict, total=False):
+    """Cron-run state. ``messages`` is the (ignored) cron input; ``result`` holds
+    one summary dict per checked thread (see :func:`summarize_results`)."""
+
+    messages: list
+    result: list
+
+
+_REPLY_PREVIEW_CHARS = 600
+
+
+def summarize_results(results: list[ProactiveCheckResult]) -> list[dict[str, Any]]:
+    """Per-thread tick summary stored on the cron run's state.
+
+    ``stage``/``reason`` say what happened (``no_push`` with reason ``no_reply``
+    is a failed shadow, with reason ``no_push`` the model's own decision);
+    ``reply`` is a preview of the shadow's text so a NO_PUSH verdict or a
+    delivered push can be inspected from the run without server logs.
+    """
+    summary: list[dict[str, Any]] = []
+    for r in results:
+        reply = (r.reply or "").strip()
+        summary.append(
+            {
+                "thread_id": r.source_thread_id,
+                "stage": r.stage,
+                "reason": r.reason,
+                "reply": reply[:_REPLY_PREVIEW_CHARS] if reply else None,
+            }
+        )
+    return summary
+
+
+@dataclass(frozen=True)
+class _ProactiveDeps:
+    client: Any
+    gateway: Any
+    target: Any
+    shadow_runner: Callable[[list, str], Awaitable[str | None]]
+    settings: ProactiveGateSettings
+    trigger: str
+    workspace_dir: str | None
+    model: str | None
+
+
+_DEPS: _ProactiveDeps | None = None
+# Config fingerprint the memoized deps were built from. The deps are rebuilt when
+# it changes, so a ``/model`` switch or a ``proactive_*`` edit in config.yaml
+# applies on the next tick instead of after a langgraph-dev restart.
+_DEPS_KEY: tuple[Any, ...] | None = None
+
+
+def _system_timezone() -> str:
+    """Best-effort IANA name of the machine's local timezone (falls back to UTC).
+
+    Uses ``tzlocal``, which honours the ``TZ`` env var the langgraph-dev subprocess
+    inherits — so the gate's quiet hours are evaluated in the user's actual local
+    time rather than a hardcoded UTC. Falls back to UTC if resolution fails.
+    """
+    try:
+        import tzlocal
+
+        return tzlocal.get_localzone_name()
+    except Exception:
+        logger.warning(
+            "[proactive graph] could not resolve system timezone; using UTC",
+            exc_info=True,
+        )
+        return "UTC"
+
+
+def _resolve_timezone(configured: str | None) -> str:
+    """Resolve the gate timezone: the configured IANA name, else the system tz.
+
+    Validates the result against ``zoneinfo`` (the gate builds a ``ZoneInfo`` from
+    it), falling back to UTC on an unknown name so a bad value can never crash a
+    tick.
+    """
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    name = configured.strip() if configured and configured.strip() else ""
+    name = name or _system_timezone()
+    try:
+        ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        logger.warning(
+            "[proactive graph] proactive_timezone=%r is not a valid IANA timezone; "
+            "using UTC",
+            name,
+        )
+        return "UTC"
+    return name
+
+
+def gate_settings_from_config(cfg: Any) -> ProactiveGateSettings:
+    """Build the gate settings from the ``proactive_*`` config fields.
+
+    ``proactive_quiet_hours`` empty/blank disables the quiet-hours window;
+    ``proactive_timezone`` empty resolves to the host's local zone.
+    """
+    quiet = str(cfg.proactive_quiet_hours or "").strip() or None
+    return ProactiveGateSettings(
+        enabled=bool(cfg.proactive_enabled),
+        idle_minutes=int(cfg.proactive_idle_minutes),
+        quiet_hours=quiet,
+        timezone=_resolve_timezone(cfg.proactive_timezone),
+    )
+
+
+def _build_deps() -> _ProactiveDeps:
+    """Construct (and memoize) the live tick dependencies.
+
+    Heavy — runs on the first tick inside langgraph-dev, not at import. The
+    effective config is re-read on every tick (cheap; this runs off-loop) and the
+    deps are rebuilt only when the model, provider, workspace, or gate settings
+    changed, so config edits take effect without a server restart.
+    """
+    global _DEPS, _DEPS_KEY
+
+    from .. import paths
+    from ..config.settings import get_effective_config
+    from ..EvoScientist import _build_chat_model
+    from ..gateway import create_runtime_gateways
+    from ..gateway.types import GraphTarget
+    from ..langgraph_dev.sdk import (
+        configured_langgraph_dev_url,
+        langgraph_dev_headers,
+    )
+    from .service import PROACTIVE_TRIGGER
+    from .shadow import build_shadow_graph, run_shadow_turn
+
+    cfg = get_effective_config()
+    workspace_dir = cfg.default_workdir or str(paths.WORKSPACE_ROOT)
+    settings = gate_settings_from_config(cfg)
+    key = (cfg.model, cfg.provider, workspace_dir, settings)
+    if _DEPS is not None and _DEPS_KEY == key:
+        return _DEPS
+
+    url = configured_langgraph_dev_url()
+    logger.info(
+        "[proactive graph] %s tick deps (model=%s provider=%s workspace=%s "
+        "enabled=%s idle_minutes=%d quiet_hours=%s timezone=%s)",
+        "rebuilding" if _DEPS is not None else "building",
+        cfg.model,
+        cfg.provider,
+        workspace_dir,
+        settings.enabled,
+        settings.idle_minutes,
+        settings.quiet_hours,
+        settings.timezone,
+    )
+
+    gateways = create_runtime_gateways(
+        backend="langgraph_server", base_url=url, headers=langgraph_dev_headers()
+    )
+    # Reuse the gateway's ASYNC SDK client for enumeration + state reads: every I/O
+    # in the tick runs on langgraph-dev's event loop, which forbids blocking calls
+    # (blockbuster), so sync-client reads are out.
+    client = gateways.thread_store.client
+    shadow_graph = build_shadow_graph(cfg, _build_chat_model(cfg), workspace_dir)
+
+    async def _shadow(messages: list, trigger: str) -> str | None:
+        return await run_shadow_turn(shadow_graph, messages, trigger)
+
+    _DEPS = _ProactiveDeps(
+        client=client,
+        gateway=gateways.graph_gateway,
+        target=GraphTarget(),  # server update_state_values ignores target
+        shadow_runner=_shadow,
+        settings=settings,
+        trigger=PROACTIVE_TRIGGER,
+        workspace_dir=workspace_dir,
+        model=cfg.model,
+    )
+    _DEPS_KEY = key
+    return _DEPS
+
+
+async def _proactive_tick_node(state: _ProactiveTickState) -> _ProactiveTickState:
+    # Building deps loads the in-process shadow agent (create_cli_agent does sync
+    # filesystem I/O), which blockbuster forbids on the event loop — build it in a
+    # thread. Memoized, so this cost is paid once.
+    deps = await asyncio.to_thread(_build_deps)
+    results = await run_proactive_graph_tick(
+        client=deps.client,
+        gateway=deps.gateway,
+        target=deps.target,
+        shadow_runner=deps.shadow_runner,
+        settings=deps.settings,
+        trigger=deps.trigger,
+        workspace_dir=deps.workspace_dir,
+        model=deps.model,
+    )
+    summary = summarize_results(results)
+    logger.info("[proactive graph] tick complete: %s", summary)
+    return {"result": summary}
+
+
+def _build_graph():
+    graph = StateGraph(_ProactiveTickState)
+    graph.add_node("tick", _proactive_tick_node)
+    graph.add_edge(START, "tick")
+    graph.add_edge("tick", END)
+    return graph.compile()
+
+
+# Module-level compiled graph langgraph.json points at (cheap; deps stay lazy).
+proactive_graph = _build_graph()

--- a/EvoScientist/proactive/service.py
+++ b/EvoScientist/proactive/service.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Protocol
 
-from .commit import commit_with_conflict_retry, decide_commit
+from .commit import commit_with_conflict_retry, decide_commit, resolve_head
 from .eligibility import list_channel_thread_candidates
 from .gate import ProactiveGateSettings, evaluate_gate
 
@@ -105,7 +105,7 @@ async def run_proactive_check(
     in_flight: bool,
     source_messages: list,
     shadow_runner: Callable[[list, str], Awaitable[str | None]],
-    read_current_head: Callable[[], str | None],
+    read_current_head: Callable[[], str | Awaitable[str | None] | None],
     deliverer: Deliverer,
     trigger: str,
     workspace_dir: str | None,
@@ -143,7 +143,7 @@ async def run_proactive_check(
         workspace_dir=workspace_dir,
         model=model,
         pre_head=pre_head,
-        current_head=read_current_head(),
+        current_head=await resolve_head(read_current_head),
         proactive_id=proactive_id,
     )
     if decision.action == "skip":
@@ -205,7 +205,7 @@ class SourceRead:
     pre_head: str | None
     has_origin: bool
     in_flight: bool
-    read_current_head: Callable[[], str | None]
+    read_current_head: Callable[[], str | Awaitable[str | None] | None]
 
 
 async def run_proactive_scan(
@@ -282,24 +282,28 @@ def make_read_source(client: Any) -> Callable[[str], Awaitable[SourceRead]]:
     (``status="idle"`` + the channel marker), so ``has_origin=True`` and
     ``in_flight=False`` by construction.
 
-    ``read_current_head`` returns the head captured at read time — it does NO I/O,
-    because it is a SYNC callable invoked on the event loop and cannot block there.
-    Consequently the head-comparison stale check is a no-op on this path; staleness
-    is instead guarded by the ``status="idle"`` enumeration filter + the commit's
-    ``ConflictError`` defer-and-retry. (A fully-async ``read_current_head`` is a
-    possible later hardening if the completed-turn-during-shadow window matters.)
+    ``read_current_head`` re-fetches the thread's head (``get_state`` →
+    ``checkpoint_id``) each time it is called, so the pre-commit stale check sees a
+    user turn or another tick's push that landed while the shadow was running and
+    discards the now-stale reply instead of appending after it.
     """
 
-    async def _read(thread_id: str) -> SourceRead:
+    async def _fetch_state(thread_id: str) -> Any:
         result = client.threads.get_state(thread_id)
-        state = await result if isinstance(result, Awaitable) else result
-        head = _state_checkpoint_id(state)
+        return await result if isinstance(result, Awaitable) else result
+
+    async def _read(thread_id: str) -> SourceRead:
+        state = await _fetch_state(thread_id)
+
+        async def _current_head() -> str | None:
+            return _state_checkpoint_id(await _fetch_state(thread_id))
+
         return SourceRead(
             messages=_state_messages(state),
-            pre_head=head,
+            pre_head=_state_checkpoint_id(state),
             has_origin=True,
             in_flight=False,
-            read_current_head=lambda: head,
+            read_current_head=_current_head,
         )
 
     return _read

--- a/EvoScientist/proactive/service.py
+++ b/EvoScientist/proactive/service.py
@@ -13,6 +13,7 @@ Delivery is abstracted behind the ``Deliverer`` protocol; in production the
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from collections import deque
@@ -48,6 +49,15 @@ PROACTIVE_TRIGGER = (
 
 # In-memory log of recent check outcomes (observability; bounded).
 _LEDGER: deque[ProactiveCheckResult] = deque(maxlen=200)
+
+
+async def _conflict_backoff(attempt: int) -> None:
+    """Wait before re-trying a commit that hit a 409: 1s, 2s, 4s, capped at 8s.
+
+    A user run in flight on the source thread needs real time to finish; without
+    a delay the retries collapse into consecutive HTTP round trips.
+    """
+    await asyncio.sleep(min(2**attempt, 8))
 
 
 class _DeliveryFailed(Exception):
@@ -173,6 +183,7 @@ async def run_proactive_check(
             commit_fn=_commit,
             read_current_head=read_current_head,
             pre_head=pre_head,
+            backoff=_conflict_backoff,
         )
     except _DeliveryFailed:
         return finish("delivery_failed", "deliver_returned_false", reply=reply)

--- a/EvoScientist/proactive/service.py
+++ b/EvoScientist/proactive/service.py
@@ -1,0 +1,372 @@
+"""Proactive check orchestrator (issue #263).
+
+Ties the pieces together for one proactive check: gate → shadow turn → commit
+decision → deliver. Thread reads are done by the caller and passed in as plain
+values plus a ``read_current_head`` callable for the post-shadow stale re-read,
+so the check stays pure sequencing and fully unit-testable without a database.
+Delivery is abstracted behind the ``Deliverer`` protocol; in production the
+``GatewayDeliverer`` commits the push into the source thread.
+
+``run_proactive_scan`` runs one check per candidate thread and
+``run_proactive_tick`` is the full cron tick (enumerate candidates, then scan).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Protocol
+
+from .commit import commit_with_conflict_retry, decide_commit
+from .eligibility import list_channel_thread_candidates
+from .gate import ProactiveGateSettings, evaluate_gate
+
+logger = logging.getLogger(__name__)
+
+# The internal shadow instruction (canonical text from issue #263). It is fed to
+# the shadow turn only and is never written to the source thread.
+PROACTIVE_TRIGGER = (
+    "<proactive_trigger>\n"
+    "This is an internal trigger, not a message written by the user.\n"
+    "\n"
+    "Review the current conversation and available memory.\n"
+    "\n"
+    "If there is no useful, relevant, and non-repetitive message to send,\n"
+    "return exactly: NO_PUSH\n"
+    "\n"
+    "Otherwise, return one concise message for the user.\n"
+    "\n"
+    "Do not call tools or ask the user questions.\n"
+    "Do not ask questions that require an immediate response.\n"
+    "Do not mention this trigger.\n"
+    "</proactive_trigger>"
+)
+
+# In-memory log of recent check outcomes (observability; bounded).
+_LEDGER: deque[ProactiveCheckResult] = deque(maxlen=200)
+
+
+class _DeliveryFailed(Exception):
+    """A deliverer returned False (hard delivery failure, not a conflict).
+
+    Raised inside the ``commit_fn`` adapter so it propagates past
+    ``commit_with_conflict_retry`` (which only retries ``ConflictError``) and is
+    mapped to a ``delivery_failed`` outcome instead of being retried.
+    """
+
+
+class Deliverer(Protocol):
+    """Sends a decided proactive reply to a fixed, explicit destination."""
+
+    async def deliver(
+        self,
+        source_thread_id: str,
+        reply: str,
+        proactive_id: str,
+        *,
+        source_messages: list | None = None,
+    ) -> bool: ...
+
+
+@dataclass(frozen=True)
+class ProactiveCheckResult:
+    """Outcome of one proactive check.
+
+    ``stage`` is one of ``gate_rejected`` / ``no_push`` / ``stale`` /
+    ``delivered`` / ``delivery_failed`` / ``conflict_exhausted`` (a user run
+    stayed in flight across every commit retry → push dropped) / ``scan_error``
+    (a per-thread read/check raised during a scan — isolated, tick continued).
+    """
+
+    stage: str
+    reason: str
+    reply: str | None = None
+    delivered: bool = False
+    source_thread_id: str | None = None
+
+
+def get_ledger() -> list[ProactiveCheckResult]:
+    """Return a snapshot of the in-memory decision ledger (newest last)."""
+    return list(_LEDGER)
+
+
+async def run_proactive_check(
+    *,
+    settings: ProactiveGateSettings,
+    source_thread_id: str,
+    now: datetime,
+    last_activity: datetime | None,
+    pre_head: str | None,
+    has_origin: bool,
+    in_flight: bool,
+    source_messages: list,
+    shadow_runner: Callable[[list, str], Awaitable[str | None]],
+    read_current_head: Callable[[], str | None],
+    deliverer: Deliverer,
+    trigger: str,
+    workspace_dir: str | None,
+    model: str | None,
+    proactive_id: str,
+) -> ProactiveCheckResult:
+    """Run gate → shadow → commit-decision → deliver for one source thread."""
+
+    def finish(stage, reason, *, reply=None, delivered=False):
+        return _record(
+            ProactiveCheckResult(
+                stage,
+                reason,
+                reply=reply,
+                delivered=delivered,
+                source_thread_id=source_thread_id,
+            )
+        )
+
+    gate = evaluate_gate(
+        settings,
+        now=now,
+        last_activity=last_activity,
+        has_origin=has_origin,
+        in_flight=in_flight,
+    )
+    if not gate.should_run:
+        return finish("gate_rejected", gate.reason)
+
+    reply = await shadow_runner(source_messages, trigger)
+
+    decision = decide_commit(
+        reply,
+        source_thread_id=source_thread_id,
+        workspace_dir=workspace_dir,
+        model=model,
+        pre_head=pre_head,
+        current_head=read_current_head(),
+        proactive_id=proactive_id,
+    )
+    if decision.action == "skip":
+        return finish("no_push", decision.reason, reply=reply)
+    if decision.action == "stale":
+        return finish("stale", decision.reason, reply=reply)
+
+    # action == "would_commit": commit-and-deliver with conflict handling. The
+    # commit is delegated to the deliverer; wrapping it as a commit_fn lets
+    # commit_with_conflict_retry own the during-commit stale re-check and the
+    # ConflictError defer-and-retry (a gateway-backed deliverer raises it when a
+    # user run is in flight on the source thread).
+    async def _commit(_message, _metadata, _as_node):
+        # The deliverer rebuilds the tagged AIMessage from reply/proactive_id, so
+        # the decided message/metadata/as_node are not needed here. A False
+        # return is a hard delivery failure, not a conflict, so surface it past
+        # the retry loop.
+        if not await deliverer.deliver(
+            source_thread_id, reply, proactive_id, source_messages=source_messages
+        ):
+            raise _DeliveryFailed
+
+    try:
+        outcome = await commit_with_conflict_retry(
+            decision,
+            source_thread_id=source_thread_id,
+            commit_fn=_commit,
+            read_current_head=read_current_head,
+            pre_head=pre_head,
+        )
+    except _DeliveryFailed:
+        return finish("delivery_failed", "deliver_returned_false", reply=reply)
+    except Exception:
+        logger.warning("proactive delivery raised", exc_info=True)
+        return finish("delivery_failed", "exception", reply=reply)
+
+    if outcome.status == "stale":
+        return finish("stale", outcome.reason, reply=reply)
+    if outcome.status == "conflict_exhausted":
+        return finish("conflict_exhausted", outcome.reason, reply=reply)
+    logger.info(
+        "proactive check delivered for source %s (proactive_id=%s)",
+        source_thread_id,
+        proactive_id,
+    )
+    return finish("delivered", "ok", reply=reply, delivered=True)
+
+
+@dataclass(frozen=True)
+class SourceRead:
+    """Per-thread inputs a scan gathers before running one check.
+
+    Populated server-side (SDK reads: thread messages, head token, in-flight run,
+    origin presence) in production; injected in tests. ``read_current_head`` is the
+    post-shadow stale re-read the check calls after generation.
+    """
+
+    messages: list
+    pre_head: str | None
+    has_origin: bool
+    in_flight: bool
+    read_current_head: Callable[[], str | None]
+
+
+async def run_proactive_scan(
+    candidates: list[tuple[str, datetime | None]],
+    *,
+    now: datetime,
+    settings: ProactiveGateSettings,
+    read_source: Callable[[str], Awaitable[SourceRead]],
+    shadow_runner: Callable[[list, str], Awaitable[str | None]],
+    deliverer: Deliverer,
+    trigger: str,
+    workspace_dir: str | None,
+    model: str | None,
+    new_proactive_id: Callable[[], str] | None = None,
+) -> list[ProactiveCheckResult]:
+    """Run a proactive check on each candidate thread — one cron tick.
+
+    ``candidates`` is ``(thread_id, last_activity)`` from
+    ``eligibility.list_channel_thread_candidates``. For each, gathers per-thread
+    inputs via ``read_source`` and runs :func:`run_proactive_check` with the shared
+    shadow/deliverer/settings, minting a fresh ``proactive_id`` per thread. The gate
+    (idle/quiet-hours/origin/in-flight) stays authoritative inside each check — the
+    scan only sequences candidates and threads their ``last_activity`` through.
+
+    Per-candidate failures are isolated: a raised ``read_source`` or check is logged
+    and recorded as a ``scan_error`` result, and the tick continues — one bad thread
+    never aborts the whole scan.
+    """
+    gen_id = new_proactive_id or (lambda: uuid.uuid4().hex)
+    results: list[ProactiveCheckResult] = []
+    for thread_id, last_activity in candidates:
+        try:
+            src = await read_source(thread_id)
+            result = await run_proactive_check(
+                settings=settings,
+                source_thread_id=thread_id,
+                now=now,
+                last_activity=last_activity,
+                pre_head=src.pre_head,
+                has_origin=src.has_origin,
+                in_flight=src.in_flight,
+                source_messages=src.messages,
+                shadow_runner=shadow_runner,
+                read_current_head=src.read_current_head,
+                deliverer=deliverer,
+                trigger=trigger,
+                workspace_dir=workspace_dir,
+                model=model,
+                proactive_id=gen_id(),
+            )
+        except Exception:
+            logger.warning(
+                "proactive scan: check raised for thread %s", thread_id, exc_info=True
+            )
+            result = _record(
+                ProactiveCheckResult(
+                    "scan_error", "exception", source_thread_id=thread_id
+                )
+            )
+        results.append(result)
+    return results
+
+
+def make_read_source(client: Any) -> Callable[[str], Awaitable[SourceRead]]:
+    """Build a server-backed ``read_source`` for :func:`run_proactive_scan`.
+
+    Reads thread state via ``client.threads.get_state`` (shapes verified against a
+    live langgraph-dev): ``messages`` from ``values.messages``, the head token from
+    ``checkpoint_id`` (falling back to ``checkpoint.checkpoint_id``). The read is
+    awaited (the tick runs on langgraph-dev's event loop, which forbids blocking
+    calls — an async client is required; a sync/awaitable result is handled either
+    way). Candidates are already pre-filtered to idle channel threads by
+    :func:`~EvoScientist.proactive.eligibility.list_channel_thread_candidates`
+    (``status="idle"`` + the channel marker), so ``has_origin=True`` and
+    ``in_flight=False`` by construction.
+
+    ``read_current_head`` returns the head captured at read time — it does NO I/O,
+    because it is a SYNC callable invoked on the event loop and cannot block there.
+    Consequently the head-comparison stale check is a no-op on this path; staleness
+    is instead guarded by the ``status="idle"`` enumeration filter + the commit's
+    ``ConflictError`` defer-and-retry. (A fully-async ``read_current_head`` is a
+    possible later hardening if the completed-turn-during-shadow window matters.)
+    """
+
+    async def _read(thread_id: str) -> SourceRead:
+        result = client.threads.get_state(thread_id)
+        state = await result if isinstance(result, Awaitable) else result
+        head = _state_checkpoint_id(state)
+        return SourceRead(
+            messages=_state_messages(state),
+            pre_head=head,
+            has_origin=True,
+            in_flight=False,
+            read_current_head=lambda: head,
+        )
+
+    return _read
+
+
+def _state_messages(state: Any) -> list:
+    values = state.get("values") if isinstance(state, dict) else None
+    messages = values.get("messages") if isinstance(values, dict) else None
+    return messages if isinstance(messages, list) else []
+
+
+def _state_checkpoint_id(state: Any) -> str | None:
+    if not isinstance(state, dict):
+        return None
+    checkpoint_id = state.get("checkpoint_id")
+    if checkpoint_id:
+        return str(checkpoint_id)
+    checkpoint = state.get("checkpoint")
+    if isinstance(checkpoint, dict) and checkpoint.get("checkpoint_id"):
+        return str(checkpoint["checkpoint_id"])
+    return None
+
+
+async def run_proactive_tick(
+    client: Any,
+    *,
+    now: datetime,
+    settings: ProactiveGateSettings,
+    read_source: Callable[[str], Awaitable[SourceRead]],
+    shadow_runner: Callable[[list, str], Awaitable[str | None]],
+    deliverer: Deliverer,
+    trigger: str,
+    workspace_dir: str | None,
+    model: str | None,
+    marker: dict[str, Any] | None = None,
+    limit: int = 50,
+    new_proactive_id: Callable[[], str] | None = None,
+) -> list[ProactiveCheckResult]:
+    """One proactive cron tick: enumerate server-registered channel-thread
+    candidates, then run a check on each.
+
+    Composes the two halves — ``eligibility.list_channel_thread_candidates`` (the
+    server-scoped, always-server-born candidate set) and :func:`run_proactive_scan`
+    — leaving the server-backed ``read_source`` / ``shadow_runner`` / ``deliverer``
+    as injected seams. This is the body the ``proactive`` graph node calls.
+    """
+    candidates = await list_channel_thread_candidates(
+        client, marker=marker, limit=limit
+    )
+    logger.info("proactive tick: %d candidate thread(s)", len(candidates))
+    return await run_proactive_scan(
+        candidates,
+        now=now,
+        settings=settings,
+        read_source=read_source,
+        shadow_runner=shadow_runner,
+        deliverer=deliverer,
+        trigger=trigger,
+        workspace_dir=workspace_dir,
+        model=model,
+        new_proactive_id=new_proactive_id,
+    )
+
+
+def _record(result: ProactiveCheckResult) -> ProactiveCheckResult:
+    _LEDGER.append(result)
+    logger.debug(
+        "proactive check result: stage=%s reason=%s", result.stage, result.reason
+    )
+    return result

--- a/EvoScientist/proactive/shadow.py
+++ b/EvoScientist/proactive/shadow.py
@@ -1,0 +1,280 @@
+"""In-memory shadow runner for proactive turns (issue #263).
+
+A proactive "shadow" turn runs the *real* config-neutered agent graph over a
+real chat's message history and produces a push/no-push text decision. Two
+orthogonal properties make it safe to run against a live, populated setup:
+
+- **Isolation** — the shadow uses an ``InMemorySaver`` checkpointer, so its
+  thread state never touches ``sessions.db``; and a side-effect-neutered config
+  (``_shadow_cfg``) disables the scheduler, the memory worker, and ask_user, so
+  no writer survives outside the tool surface (an audit of the default
+  middleware chain established that the tool surface plus these three flags is
+  the whole side-effect axis: every other writer is either tool-backed and thus
+  killed by the strip, or gated by one of these flags).
+- **Tool-strip** — the turn runs with ``configurable.proactive_mode`` set, so
+  ``ProactiveModeMiddleware`` strips every tool from the model request. This is
+  the entire safety story, so it is enforced, not trusted: the shadow model is
+  wrapped with a fail-closed spy that raises if any tool is ever bound.
+
+The reasoning axis (system prompt, memory injection, model, context management)
+is left intact — that is what makes the shadow's push/no-push judgment faithful
+to what the real agent would decide.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .. import sessions as session_store
+
+if TYPE_CHECKING:
+    from langgraph.graph.state import CompiledStateGraph
+
+    from ..config.settings import EvoScientistConfig
+
+logger = logging.getLogger(__name__)
+
+
+# --- fail-closed tool-strip interlock ----------------------------------------
+
+
+class ProactiveToolLeakError(RuntimeError):
+    """Raised when a proactive shadow turn binds a tool to the model.
+
+    The proactive tool-strip is the whole safety story: a shadow turn must be a
+    pure reasoning turn. This is the fail-closed interlock. On
+    the correctly-stripped path langchain never calls ``bind_tools`` (it calls
+    ``model.bind`` when the tool list is empty), so this only fires if the strip
+    ever regresses — and when it does, we raise rather than let a tool execute
+    against the real sandbox.
+    """
+
+
+class _ToolStripSpyMixin:
+    """Mixin whose ``bind_tools`` refuses any non-empty tool list.
+
+    Installed on the shadow chat model via ``__class__`` reassignment so the
+    check rides on the exact model object langchain binds against
+    (``request.model.bind_tools(...)``), independent of middleware ordering.
+    """
+
+    def bind_tools(self, tools, *args, **kwargs):  # type: ignore[override]
+        if tools:
+            names = [_tool_label(t) for t in tools]
+            raise ProactiveToolLeakError(
+                f"proactive shadow turn attempted to bind {len(tools)} tool(s): {names}"
+            )
+        return super().bind_tools(tools, *args, **kwargs)  # type: ignore[misc]
+
+
+def _tool_label(tool: Any) -> str:
+    """Best-effort human label for a tool in a leak error message."""
+    name = getattr(tool, "name", None)
+    if name:
+        return str(name)
+    if isinstance(tool, dict):
+        return str(tool.get("name") or tool.get("type") or "dict-tool")
+    return type(tool).__name__
+
+
+def _install_tool_strip_spy(model: Any) -> Any:
+    """Reassign ``model.__class__`` to a spy subclass and return the same model.
+
+    The spy subclass adds only a ``bind_tools`` override (no new fields), so the
+    reassignment is layout-compatible with the pydantic model and
+    ``isinstance(model, <original class>)`` stays true.
+    """
+    spy_cls = type(
+        f"ToolStripSpy_{type(model).__name__}",
+        (_ToolStripSpyMixin, type(model)),
+        {},
+    )
+    model.__class__ = spy_cls
+    return model
+
+
+# --- config neutering --------------------------------------------------------
+
+# The side-effect axis: every flag here gates a writer identified by the
+# middleware audit. The reasoning axis (prompt, memory injection, model, context) is left
+# untouched. ``auto_approve=True`` is belt-and-braces (ask_user is already off);
+# note ``__post_init__`` also forces it true under auto/dangerous mode, which is
+# harmless because we want it true here anyway.
+_SHADOW_FLAGS: dict[str, Any] = {
+    "enable_scheduler": False,
+    "memory_workers_enabled": False,
+    "enable_ask_user": False,
+    "auto_approve": True,
+    "model_fallbacks": "",
+}
+
+
+def _shadow_cfg(cfg: EvoScientistConfig) -> EvoScientistConfig:
+    """Return a side-effect-neutered copy of *cfg* for a shadow turn."""
+    return dataclasses.replace(cfg, **_SHADOW_FLAGS)
+
+
+# --- shadow graph + turn -----------------------------------------------------
+
+
+def build_shadow_graph(
+    cfg: EvoScientistConfig,
+    chat_model: Any,
+    workspace_dir: str,
+) -> CompiledStateGraph:
+    """Build the config-neutered shadow graph with the tool-strip spy installed.
+
+    ``chat_model`` is spied in place, then passed with ``_shadow_cfg(cfg)`` to
+    ``create_cli_agent`` on its pure path (both ``config`` and ``chat_model``
+    non-None → no module globals are written). ``workspace_dir`` MUST be the
+    live setup's REAL workspace so profile-file seeding on the memory read path
+    is a no-op. Build once per process and reuse across checks.
+    """
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from ..EvoScientist import create_cli_agent
+
+    _install_tool_strip_spy(chat_model)
+    return create_cli_agent(
+        workspace_dir=workspace_dir,
+        checkpointer=InMemorySaver(),
+        config=_shadow_cfg(cfg),
+        chat_model=chat_model,
+    )
+
+
+async def run_shadow_turn(
+    graph: CompiledStateGraph,
+    source_messages: list[Any],
+    trigger: str,
+    *,
+    thread_id: str | None = None,
+) -> str | None:
+    """Run one proactive shadow turn and return the terminal assistant text.
+
+    Seeds ``source_messages`` into a fresh in-memory thread, then drains a
+    ``proactive_mode`` turn driven by ``trigger``. Returns the terminal ``done``
+    text (possibly empty — the NO_PUSH/empty decision belongs to the caller).
+    Returns ``None`` on any error, including a ``ProactiveToolLeakError`` from
+    the spy, and when the model did not finish cleanly (a truncated, errored, or
+    filtered generation is never a message to send): the caller treats ``None``
+    as "abort, do not push" (fail-closed). The shadow thread is deleted from the
+    in-memory checkpointer afterwards to bound memory across reused checks.
+    """
+    from ..stream.events import stream_agent_events
+
+    tid = thread_id or session_store.generate_thread_id()
+    final = ""
+    try:
+        await graph.aupdate_state(
+            {"configurable": {"thread_id": tid}},
+            {"messages": source_messages},
+        )
+        async for event in stream_agent_events(
+            graph,
+            trigger,
+            tid,
+            configurable_extra={"proactive_mode": True},
+        ):
+            etype = event.get("type")
+            if etype == "text":
+                final += event.get("content", "")
+            elif etype == "done":
+                final = event.get("content", "") or final
+        last = await _last_message(graph, tid)
+        if not final.strip():
+            _log_empty_reply(last)
+        if not _finished_cleanly(last):
+            return None
+    except ProactiveToolLeakError:
+        # The interlock fired — a tool reached the model. Never deliver.
+        logger.warning(
+            "proactive shadow turn aborted: tool-strip regressed (spy fired)",
+            exc_info=True,
+        )
+        return None
+    except Exception:
+        logger.warning("proactive shadow turn failed", exc_info=True)
+        return None
+    finally:
+        await _delete_shadow_thread(graph, tid)
+    return final
+
+
+# ``finish_reason`` values that mean the generation is complete. Anything else
+# (``length``, ``error``, ``content_filter``, provider-specific codes) is not a
+# message the user should receive. Absent metadata is treated as clean, so
+# providers that do not report a finish reason still work.
+_CLEAN_FINISH_REASONS = frozenset({"stop", "end_turn", "STOP"})
+
+
+async def _last_message(graph: CompiledStateGraph, thread_id: str) -> Any | None:
+    """The shadow thread's last message, or None if the state cannot be read."""
+    try:
+        state = await graph.aget_state({"configurable": {"thread_id": thread_id}})
+        values = getattr(state, "values", None) or {}
+        messages = values.get("messages") or []
+        return messages[-1] if messages else None
+    except Exception:
+        logger.debug("could not read shadow state after the turn", exc_info=True)
+        return None
+
+
+def _finish_reason(message: Any | None) -> str | None:
+    metadata = getattr(message, "response_metadata", None) or {}
+    reason = metadata.get("finish_reason") if isinstance(metadata, dict) else None
+    return str(reason) if reason else None
+
+
+def _finished_cleanly(message: Any | None) -> bool:
+    """False when the model reports a non-clean finish (truncated / errored)."""
+    reason = _finish_reason(message)
+    if reason is None or reason in _CLEAN_FINISH_REASONS:
+        return True
+    logger.warning(
+        "proactive shadow turn discarded: model finish_reason=%r (not a clean "
+        "stop); response_metadata=%s",
+        reason,
+        {
+            k: str(v)[:200]
+            for k, v in (getattr(message, "response_metadata", None) or {}).items()
+        },
+    )
+    return False
+
+
+def _log_empty_reply(last: Any | None) -> None:
+    """INFO-log the raw last message when the shadow produced no text.
+
+    The shadow thread is deleted right after the turn, so this is the only place
+    a reasoning-only response, a refusal, or a provider quirk can be told apart
+    from a genuine NO_PUSH.
+    """
+    logger.info(
+        "proactive shadow turn returned no text; last message=%s content=%r "
+        "additional_kwargs=%s response_metadata=%s",
+        type(last).__name__,
+        str(getattr(last, "content", ""))[:300],
+        {
+            k: str(v)[:200]
+            for k, v in (getattr(last, "additional_kwargs", None) or {}).items()
+        },
+        {
+            k: str(v)[:200]
+            for k, v in (getattr(last, "response_metadata", None) or {}).items()
+        },
+    )
+
+
+async def _delete_shadow_thread(graph: CompiledStateGraph, thread_id: str) -> None:
+    """Best-effort deletion of the shadow thread from the in-memory saver."""
+    checkpointer = getattr(graph, "checkpointer", None)
+    adelete = getattr(checkpointer, "adelete_thread", None)
+    if adelete is None:
+        return
+    try:
+        await adelete(thread_id)
+    except Exception:
+        logger.debug("failed to delete shadow thread %s", thread_id, exc_info=True)

--- a/EvoScientist/proactive/shadow.py
+++ b/EvoScientist/proactive/shadow.py
@@ -236,38 +236,34 @@ def _finished_cleanly(message: Any | None) -> bool:
     reason = _finish_reason(message)
     if reason is None or reason in _CLEAN_FINISH_REASONS:
         return True
+    metadata = getattr(message, "response_metadata", None) or {}
     logger.warning(
         "proactive shadow turn discarded: model finish_reason=%r (not a clean "
-        "stop); response_metadata=%s",
+        "stop); model=%s",
         reason,
-        {
-            k: str(v)[:200]
-            for k, v in (getattr(message, "response_metadata", None) or {}).items()
-        },
+        metadata.get("model_name") if isinstance(metadata, dict) else None,
     )
     return False
 
 
 def _log_empty_reply(last: Any | None) -> None:
-    """INFO-log the raw last message when the shadow produced no text.
+    """INFO-log shape diagnostics when the shadow produced no text.
 
     The shadow thread is deleted right after the turn, so this is the only place
     a reasoning-only response, a refusal, or a provider quirk can be told apart
-    from a genuine NO_PUSH.
+    from a genuine NO_PUSH. Only non-sensitive shape is logged: message type,
+    content length, which ``additional_kwargs`` keys are present (e.g. a
+    reasoning field), and the provider's finish reason. Never the text itself.
     """
+    metadata = getattr(last, "response_metadata", None) or {}
     logger.info(
-        "proactive shadow turn returned no text; last message=%s content=%r "
-        "additional_kwargs=%s response_metadata=%s",
+        "proactive shadow turn returned no text; last message=%s content_chars=%d "
+        "additional_kwargs_keys=%s finish_reason=%s model=%s",
         type(last).__name__,
-        str(getattr(last, "content", ""))[:300],
-        {
-            k: str(v)[:200]
-            for k, v in (getattr(last, "additional_kwargs", None) or {}).items()
-        },
-        {
-            k: str(v)[:200]
-            for k, v in (getattr(last, "response_metadata", None) or {}).items()
-        },
+        len(str(getattr(last, "content", "") or "")),
+        sorted((getattr(last, "additional_kwargs", None) or {}).keys()),
+        metadata.get("finish_reason") if isinstance(metadata, dict) else None,
+        metadata.get("model_name") if isinstance(metadata, dict) else None,
     )
 
 

--- a/EvoScientist/proactive/shadow.py
+++ b/EvoScientist/proactive/shadow.py
@@ -99,13 +99,16 @@ def _install_tool_strip_spy(model: Any) -> Any:
 
 # The side-effect axis: every flag here gates a writer identified by the
 # middleware audit. The reasoning axis (prompt, memory injection, model, context) is left
-# untouched. ``auto_approve=True`` is belt-and-braces (ask_user is already off);
-# note ``__post_init__`` also forces it true under auto/dangerous mode, which is
-# harmless because we want it true here anyway.
+# untouched. ``auto_mode=True`` declares "no human in the loop": it disables the
+# first-contact profile bootstrap (which would ask a consent question AND write
+# session/intro bookkeeping into the real profile file from every shadow turn)
+# and ask_user. ``auto_approve=True`` is belt-and-braces (``__post_init__`` forces
+# it under auto mode anyway).
 _SHADOW_FLAGS: dict[str, Any] = {
     "enable_scheduler": False,
     "memory_workers_enabled": False,
     "enable_ask_user": False,
+    "auto_mode": True,
     "auto_approve": True,
     "model_fallbacks": "",
 }

--- a/EvoScientist/sessions.py
+++ b/EvoScientist/sessions.py
@@ -70,6 +70,12 @@ if not hasattr(aiosqlite.Connection, "is_alive"):
 # ---------------------------------------------------------------------------
 
 AGENT_NAME = "EvoScientist"
+
+# Checkpoint-metadata key serve stamps (via the run's metadata) on threads that
+# have a channel origin. The server thread registry is rebuilt from checkpoint
+# rows on restart, so the marker is restored from here — it is what lets the
+# proactive cron enumerate channel threads after a langgraph-dev restart.
+CHANNEL_ORIGIN_METADATA_KEY = "has_channel_origin"
 MAIN_THREAD_FILTER_SQL = (
     "json_extract(metadata, '$.agent_name') = ? "
     "AND (json_extract(metadata, '$.graph_id') IS NULL "
@@ -1575,6 +1581,7 @@ class _RestoredThreadInfo:
     graph_id: str
     workspace_dir: str
     model: str | None
+    has_channel_origin: bool = False
 
 
 async def _restore_webui_threads_to_global_store() -> bool:
@@ -1649,7 +1656,8 @@ async def _restore_webui_threads_to_global_store() -> bool:
                            MAX(json_extract(metadata, '$.graph_id')) as graph_id,
                            MAX(json_extract(metadata, '$.workspace_dir')) as workspace_dir,
                            MAX(json_extract(metadata, '$.model')) as model,
-                           MAX(json_extract(metadata, '$.agent_name')) as agent_name
+                           MAX(json_extract(metadata, '$.agent_name')) as agent_name,
+                           MAX(json_extract(metadata, '$.has_channel_origin')) as has_channel_origin
                     FROM checkpoints
                     WHERE thread_id LIKE '________-____-____-____-____________'
                       AND (
@@ -1671,6 +1679,7 @@ async def _restore_webui_threads_to_global_store() -> bool:
                     workspace_dir,
                     model,
                     agent_name,
+                    has_channel_origin,
                 ) = row
                 thread_uuid = _to_uuid_safe(thread_id_str)
                 if thread_uuid is None:
@@ -1688,6 +1697,7 @@ async def _restore_webui_threads_to_global_store() -> bool:
                     graph_id=restored_graph_id,
                     workspace_dir=workspace_dir,
                     model=model,
+                    has_channel_origin=bool(has_channel_origin),
                 )
 
             # Derive a sidebar title from each scoped thread's first human
@@ -1756,6 +1766,11 @@ async def _restore_webui_threads_to_global_store() -> bool:
                 if info.model and meta.get("model") != info.model:
                     meta["model"] = info.model
                     changed = True
+                if info.has_channel_origin and not meta.get(
+                    CHANNEL_ORIGIN_METADATA_KEY
+                ):
+                    meta[CHANNEL_ORIGIN_METADATA_KEY] = True
+                    changed = True
                 if "title" not in meta and tid_uuid in titles:
                     meta["title"] = titles[tid_uuid]
                     changed = True
@@ -1785,6 +1800,8 @@ async def _restore_webui_threads_to_global_store() -> bool:
                 stub_metadata["assistant_id"] = str(info.assistant_id)
             if info.model:
                 stub_metadata["model"] = info.model
+            if info.has_channel_origin:
+                stub_metadata[CHANNEL_ORIGIN_METADATA_KEY] = True
             if thread_uuid in titles:
                 stub_metadata["title"] = titles[thread_uuid]
             ts = _parse_dt(info.updated_at)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -313,7 +313,9 @@ class FakeGraphGateway(GraphGateway):
         self.clone_calls: list[
             tuple[str, dict[str, Any] | None, GraphTarget | None]
         ] = []
-        self.updated_states: list[tuple[GraphTarget, str, GraphStateValues]] = []
+        self.updated_states: list[
+            tuple[GraphTarget, str, GraphStateValues, str | None]
+        ] = []
 
     async def create_thread(
         self,
@@ -414,8 +416,10 @@ class FakeGraphGateway(GraphGateway):
         target: GraphTarget,
         thread_id: str,
         values: GraphStateValues,
+        *,
+        as_node: str | None = None,
     ) -> None:
-        self.updated_states.append((target, thread_id, values))
+        self.updated_states.append((target, thread_id, values, as_node))
 
 
 class FakeLangGraphRunModule:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -314,7 +314,7 @@ class FakeGraphGateway(GraphGateway):
             tuple[str, dict[str, Any] | None, GraphTarget | None]
         ] = []
         self.updated_states: list[
-            tuple[GraphTarget, str, GraphStateValues, str | None]
+            tuple[GraphTarget, str, GraphStateValues, str | None, dict[str, Any] | None]
         ] = []
 
     async def create_thread(
@@ -418,8 +418,9 @@ class FakeGraphGateway(GraphGateway):
         values: GraphStateValues,
         *,
         as_node: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
-        self.updated_states.append((target, thread_id, values, as_node))
+        self.updated_states.append((target, thread_id, values, as_node, metadata))
 
 
 class FakeLangGraphRunModule:

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -32,6 +32,8 @@ def _make_config(
         auto_mode=auto_mode,
         enable_ask_user=enable_ask_user,
         dangerous_mode=dangerous_mode,
+        gateway_backend="local",
+        proactive_enabled=False,
         enable_async_subagents=False,
         enable_scheduler=False,
         memory_profile_enabled=True,

--- a/tests/test_graph_gateway.py
+++ b/tests/test_graph_gateway.py
@@ -156,12 +156,31 @@ async def test_local_graph_gateway_updates_state_values():
         GraphTarget(local_graph=agent),
         "abc12345",
         {"_summarization_event": {"cutoff_index": 2}},
+        as_node="model",
     )
 
     agent.aupdate_state.assert_awaited_once_with(
         {"configurable": {"thread_id": "abc12345"}},
         {"_summarization_event": {"cutoff_index": 2}},
         as_node="model",
+    )
+
+
+async def test_local_graph_gateway_updates_state_values_defaults_as_node_none():
+    agent = MagicMock()
+    agent.aupdate_state = AsyncMock()
+    gateway = LocalGraphGateway()
+
+    await gateway.update_state_values(
+        GraphTarget(local_graph=agent),
+        "abc12345",
+        {"async_tasks": {"task-1": {}}},
+    )
+
+    agent.aupdate_state.assert_awaited_once_with(
+        {"configurable": {"thread_id": "abc12345"}},
+        {"async_tasks": {"task-1": {}}},
+        as_node=None,
     )
 
 
@@ -702,10 +721,32 @@ async def test_langgraph_server_gateway_updates_state_values():
         GraphTarget(),
         "abc12345",
         {"_summarization_event": {"cutoff_index": 2}},
+        as_node="model",
     )
 
     assert threads.state_updates == [
         ("abc12345", {"_summarization_event": {"cutoff_index": 2}}, "model")
+    ]
+
+
+async def test_langgraph_server_gateway_updates_state_values_defaults_as_node_none():
+    threads = FakeLangGraphThreadsClient(
+        threads=[{"thread_id": "abc12345", "metadata": {"graph_id": "EvoScientist"}}],
+    )
+    gateway = LangGraphServerGateway(
+        LangGraphServerThreadStore(
+            client=FakeLangGraphClient(threads),
+        )
+    )
+
+    await gateway.update_state_values(
+        GraphTarget(),
+        "abc12345",
+        {"async_tasks": {"task-1": {}}},
+    )
+
+    assert threads.state_updates == [
+        ("abc12345", {"async_tasks": {"task-1": {}}}, None)
     ]
 
 

--- a/tests/test_graph_gateway.py
+++ b/tests/test_graph_gateway.py
@@ -184,6 +184,45 @@ async def test_local_graph_gateway_updates_state_values_defaults_as_node_none():
     )
 
 
+async def test_local_graph_gateway_update_state_values_forwards_metadata():
+    agent = MagicMock()
+    agent.aupdate_state = AsyncMock()
+    gateway = LocalGraphGateway()
+
+    await gateway.update_state_values(
+        GraphTarget(local_graph=agent),
+        "abc12345",
+        {"messages": []},
+        as_node="model",
+        metadata={"agent_name": "EvoScientist", "workspace_dir": "/tmp/ws"},
+    )
+
+    agent.aupdate_state.assert_awaited_once_with(
+        {
+            "configurable": {"thread_id": "abc12345"},
+            "metadata": {"agent_name": "EvoScientist", "workspace_dir": "/tmp/ws"},
+        },
+        {"messages": []},
+        as_node="model",
+    )
+
+
+async def test_local_graph_gateway_update_state_values_omits_metadata_when_none():
+    agent = MagicMock()
+    agent.aupdate_state = AsyncMock()
+    gateway = LocalGraphGateway()
+
+    await gateway.update_state_values(
+        GraphTarget(local_graph=agent),
+        "abc12345",
+        {"messages": []},
+        as_node="model",
+    )
+
+    config = agent.aupdate_state.await_args.args[0]
+    assert "metadata" not in config
+
+
 async def test_local_stream_events_delegates_aclose_to_inner():
     cleanup_ran = False
 

--- a/tests/test_proactive_commit.py
+++ b/tests/test_proactive_commit.py
@@ -1,0 +1,332 @@
+"""Tests for EvoScientist.proactive.commit (decision + conflict-aware commit)."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from langgraph.graph import END
+from langgraph_sdk.errors import ConflictError
+
+from EvoScientist.proactive.commit import (
+    NO_PUSH_SENTINEL,
+    commit_with_conflict_retry,
+    decide_commit,
+    make_gateway_commit_fn,
+    read_proactive_tag,
+)
+
+
+def _decide(reply, *, pre_head="h1", current_head="h1"):
+    return decide_commit(
+        reply,
+        source_thread_id="src-thread",
+        workspace_dir="/ws",
+        model="some-model",
+        pre_head=pre_head,
+        current_head=current_head,
+        proactive_id="pid-123",
+    )
+
+
+@pytest.mark.parametrize(
+    ("reply", "reason"),
+    [
+        (None, "no_reply"),
+        ("", "empty"),
+        ("   ", "empty"),
+        (NO_PUSH_SENTINEL, "no_push"),
+        (f"  {NO_PUSH_SENTINEL}  ", "no_push"),
+    ],
+)
+def test_skip_cases(reply, reason):
+    d = _decide(reply)
+    assert d.action == "skip"
+    assert d.reason == reason
+    assert d.message is None
+
+
+def test_stale_when_source_head_changed():
+    d = _decide("Hey, checking in!", pre_head="h1", current_head="h2")
+    assert d.action == "stale"
+    assert d.reason == "stale_source"
+    assert d.message is None
+
+
+def test_would_commit_builds_tagged_message_and_metadata():
+    d = _decide("Hey, want to pick this back up?")
+    assert d.action == "would_commit"
+    assert d.as_node == "model"
+    # tagged AIMessage
+    assert d.message is not None
+    assert d.message.content == "Hey, want to pick this back up?"
+    tag = d.message.additional_kwargs["evoscientist"]
+    assert tag == {"is_proactive_push": True, "proactive_id": "pid-123"}
+    assert read_proactive_tag(d.message.additional_kwargs) == tag
+    # metadata carries the agent_name the main-thread filter keys on
+    assert d.metadata is not None
+    assert d.metadata["agent_name"] == "EvoScientist"
+    assert d.metadata["workspace_dir"] == "/ws"
+    assert d.metadata["model"] == "some-model"
+    assert "updated_at" in d.metadata
+
+
+def test_would_commit_logs_the_ledger_line(caplog):
+    with caplog.at_level(logging.INFO, logger="EvoScientist.proactive.commit"):
+        _decide("Hey there")
+    assert any(
+        "push for thread src-thread: append AIMessage" in r.message
+        for r in caplog.records
+    )
+
+
+def test_would_commit_does_not_mutate_or_write():
+    # decide_commit is pure: returns a decision object, performs no I/O. The
+    # message is a fresh AIMessage each call (no shared state).
+    d1 = _decide("first")
+    d2 = _decide("second")
+    assert d1.message is not d2.message
+    assert d1.message.content == "first"
+    assert d2.message.content == "second"
+
+
+# ---- commit_with_conflict_retry (ConflictError defer-and-retry) ----
+
+
+def _conflict() -> ConflictError:
+    resp = httpx.Response(409, request=httpx.Request("POST", "http://test"))
+    return ConflictError("run in flight", response=resp, body=None)
+
+
+class _FakeCommitFn:
+    """Injectable commit callable; raises ConflictError on the first ``fail``
+    attempts, then records the committed message."""
+
+    def __init__(self, fail: int = 0) -> None:
+        self._fail = fail
+        self.calls = 0
+        self.committed: list = []
+
+    async def __call__(self, message, metadata, as_node) -> None:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise _conflict()
+        self.committed.append((message, metadata, as_node))
+
+
+class _Head:
+    """read_current_head callable that returns ``value`` and can be flipped."""
+
+    def __init__(self, value: str | None) -> None:
+        self.value = value
+
+    def __call__(self) -> str | None:
+        return self.value
+
+
+async def _retry(commit_fn, head, *, pre_head="h1", max_retries=3):
+    decision = _decide("Hey, want to pick this back up?")
+    assert decision.action == "would_commit"
+    return await commit_with_conflict_retry(
+        decision,
+        source_thread_id="src-thread",
+        commit_fn=commit_fn,
+        read_current_head=head,
+        pre_head=pre_head,
+        max_retries=max_retries,
+    )
+
+
+async def test_clean_commit_first_try():
+    commit_fn = _FakeCommitFn(fail=0)
+    outcome = await _retry(commit_fn, _Head("h1"))
+    assert outcome.status == "committed"
+    assert outcome.attempts == 1
+    assert commit_fn.calls == 1
+    assert commit_fn.committed[0][0].content == "Hey, want to pick this back up?"
+    assert commit_fn.committed[0][2] == "model"
+
+
+async def test_conflict_once_then_succeeds(caplog):
+    commit_fn = _FakeCommitFn(fail=1)
+    with caplog.at_level(logging.WARNING, logger="EvoScientist.proactive.commit"):
+        outcome = await _retry(commit_fn, _Head("h1"))
+    assert outcome.status == "committed"
+    assert outcome.attempts == 2
+    assert commit_fn.calls == 2
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "ConflictError" in warnings[0].message
+
+
+async def test_conflict_then_head_moved_discards_as_stale():
+    commit_fn = _FakeCommitFn(fail=1)
+    head = _Head("h1")
+
+    async def move_head_backoff(_attempt: int) -> None:
+        head.value = "h2"  # the in-flight user run committed
+
+    decision = _decide("Hey there")
+    outcome = await commit_with_conflict_retry(
+        decision,
+        source_thread_id="src-thread",
+        commit_fn=commit_fn,
+        read_current_head=head,
+        pre_head="h1",
+        backoff=move_head_backoff,
+    )
+    assert outcome.status == "stale"
+    assert outcome.reason == "stale_source"
+    # committed exactly zero times: the one call raised, the retry saw the moved head
+    assert commit_fn.committed == []
+
+
+async def test_conflict_every_attempt_exhausts_retries(caplog):
+    commit_fn = _FakeCommitFn(fail=99)
+    with caplog.at_level(logging.WARNING, logger="EvoScientist.proactive.commit"):
+        outcome = await _retry(commit_fn, _Head("h1"), max_retries=3)
+    assert outcome.status == "conflict_exhausted"
+    assert outcome.attempts == 4  # max_retries + 1
+    assert commit_fn.calls == 4
+    assert commit_fn.committed == []
+
+
+async def test_head_already_moved_at_entry_is_stale():
+    commit_fn = _FakeCommitFn(fail=0)
+    outcome = await _retry(commit_fn, _Head("h2"), pre_head="h1")
+    assert outcome.status == "stale"
+    assert outcome.attempts == 0
+    assert commit_fn.calls == 0
+
+
+async def test_non_would_commit_decision_rejected():
+    skip = _decide(NO_PUSH_SENTINEL)
+    assert skip.action == "skip"
+    with pytest.raises(ValueError, match="would_commit"):
+        await commit_with_conflict_retry(
+            skip,
+            source_thread_id="src-thread",
+            commit_fn=_FakeCommitFn(),
+            read_current_head=_Head("h1"),
+            pre_head="h1",
+        )
+
+
+# ---- make_gateway_commit_fn (server-path commit) ----
+
+
+class _FakeGateway:
+    """Widened update_state_values; raises ConflictError on the first ``fail``
+    appends and/or the first ``fail_clear`` clears (clear = values is None)."""
+
+    def __init__(self, *, fail_appends=0, fail_clears=0):
+        self._fail_appends = fail_appends
+        self._fail_clears = fail_clears
+        self._appends = 0
+        self._clears = 0
+        self.calls = []
+
+    async def update_state_values(
+        self, target, thread_id, values, *, as_node=None, metadata=None
+    ):
+        self.calls.append({"values": values, "as_node": as_node, "metadata": metadata})
+        if values is not None:  # append
+            self._appends += 1
+            if self._appends <= self._fail_appends:
+                raise _conflict()
+        else:  # clear
+            self._clears += 1
+            if self._clears <= self._fail_clears:
+                raise _conflict()
+
+
+def _appends(gw):
+    return [c for c in gw.calls if c["values"] is not None]
+
+
+async def _retry_via_gateway(gw, *, max_retries=3):
+    decision = _decide("Hey, want to pick this back up?")
+    return await commit_with_conflict_retry(
+        decision,
+        source_thread_id="src-thread",
+        commit_fn=make_gateway_commit_fn(gw, "target", "src-thread"),
+        read_current_head=_Head("h1"),
+        pre_head="h1",
+        max_retries=max_retries,
+    )
+
+
+async def test_gateway_commit_fn_appends_then_clears():
+    gw = _FakeGateway()
+    commit_fn = make_gateway_commit_fn(gw, "target", "src-thread")
+    d = _decide("Hello there")
+    await commit_fn(d.message, d.metadata, d.as_node)
+    assert len(gw.calls) == 2
+    append, clear = gw.calls
+    assert append["values"] == {"messages": [d.message]}
+    assert append["as_node"] == "model"
+    assert append["metadata"] == d.metadata
+    assert clear["values"] is None
+    assert clear["as_node"] == END
+
+
+async def test_gateway_commit_conflict_on_append_then_succeeds():
+    gw = _FakeGateway(fail_appends=1)
+    outcome = await _retry_via_gateway(gw)
+    assert outcome.status == "committed"
+    assert outcome.attempts == 2
+    assert len(_appends(gw)) == 2  # first conflicted (uncommitted), second landed
+
+
+async def test_gateway_commit_append_conflict_exhausts():
+    gw = _FakeGateway(fail_appends=99)
+    outcome = await _retry_via_gateway(gw, max_retries=2)
+    assert outcome.status == "conflict_exhausted"
+    assert outcome.attempts == 3
+
+
+async def test_gateway_commit_clear_conflict_is_swallowed_no_double_append():
+    # Every clear conflicts, but the append (the actual commit) must land exactly
+    # once — the clear-conflict must NOT trigger a retry that re-appends.
+    gw = _FakeGateway(fail_clears=99)
+    outcome = await _retry_via_gateway(gw)
+    assert outcome.status == "committed"
+    assert outcome.attempts == 1
+    assert len(_appends(gw)) == 1
+
+
+def test_reply_over_the_length_cap_is_skipped_as_too_long():
+    d = _decide("x" * 4001)
+    assert (d.action, d.reason) == ("skip", "too_long")
+    assert d.message is None
+
+
+def test_reply_at_the_length_cap_still_commits():
+    d = _decide("x" * 4000)
+    assert d.action == "would_commit"
+
+
+def test_tool_call_envelope_as_text_is_skipped():
+    d = _decide("<tool_call>execute<arg_key>command</arg_key></tool_call>")
+    assert (d.action, d.reason) == ("skip", "tool_call_text")
+    assert d.message is None
+
+
+def test_committed_push_carries_a_stable_id():
+    d = _decide("Hey there")
+    assert d.message.id == "proactive-pid-123"
+
+
+def test_length_cap_is_configurable():
+    d = decide_commit(
+        "hello world",
+        source_thread_id="s",
+        workspace_dir=None,
+        model=None,
+        pre_head=None,
+        current_head=None,
+        proactive_id="p",
+        max_reply_chars=5,
+    )
+    assert d.reason == "too_long"

--- a/tests/test_proactive_cron.py
+++ b/tests/test_proactive_cron.py
@@ -70,3 +70,29 @@ def test_is_available_gates_on_langgraph_dev(monkeypatch):
     assert cron.is_available() is True
     monkeypatch.setattr(manager, "is_langgraph_dev_running", lambda **_: False)
     assert cron.is_available() is False
+
+
+def test_langgraph_json_registers_proactive_graph():
+    """langgraph.json must map PROACTIVE_GRAPH_ID to the graph module the cron fires."""
+    import json
+    from pathlib import Path
+
+    import EvoScientist
+    from EvoScientist.proactive import cron
+
+    root = Path(EvoScientist.__file__).parent
+    manifest = json.loads(
+        (root / "langgraph_dev" / "langgraph.json").read_text(encoding="utf-8")
+    )
+    assert manifest["graphs"][cron.PROACTIVE_GRAPH_ID] == (
+        "EvoScientist.proactive.graph:proactive_graph"
+    )
+
+
+def test_proactive_graph_imports_and_compiles_without_building_deps():
+    """The registered graph must import + compile cheaply (langgraph-dev does this
+    at startup); heavy deps must stay lazy so a bad-config env can't break startup."""
+    from EvoScientist.proactive import graph
+
+    assert graph.proactive_graph is not None
+    assert graph._DEPS is None  # deps are built on first tick, never at import

--- a/tests/test_proactive_cron.py
+++ b/tests/test_proactive_cron.py
@@ -10,7 +10,12 @@ def _patch_client(monkeypatch):
     from EvoScientist.proactive import cron
 
     fake = MagicMock()
-    fake.crons.create.return_value = {"cron_id": "p-1", "schedule": "*/10 * * * *"}
+    fake.crons.create_for_thread.return_value = {
+        "cron_id": "p-1",
+        "schedule": "*/10 * * * *",
+    }
+    fake.threads.search.return_value = []
+    fake.threads.create.return_value = {"thread_id": "pt-1"}
     fake.crons.search.return_value = [
         {
             "cron_id": "p-1",
@@ -23,22 +28,32 @@ def _patch_client(monkeypatch):
     return cron, fake
 
 
-def test_create_targets_proactive_graph_with_empty_input(monkeypatch):
+def test_create_pins_cron_to_the_tick_thread_and_rejects_overlap(monkeypatch):
     cron, fake = _patch_client(monkeypatch)
     rec = cron.create_proactive_schedule()
     assert rec["cron_id"] == "p-1"
-    kw = fake.crons.create.call_args.kwargs
-    assert kw["assistant_id"] == cron.PROACTIVE_GRAPH_ID
+    args, kw = fake.crons.create_for_thread.call_args
+    assert args == ("pt-1", cron.PROACTIVE_GRAPH_ID)
     assert kw["schedule"] == cron.DEFAULT_PROACTIVE_SCHEDULE
     assert kw["input"] == {}  # non-null (EmptyInputError); graph enumerates itself
     assert kw["metadata"] == {"run_kind": cron.PROACTIVE_RUN_KIND}
+    assert kw["multitask_strategy"] == "reject"  # overlapping ticks are serialized
     assert kw["timezone"] == "Europe/London"
+    fake.threads.create.assert_called_once_with(metadata=cron.PROACTIVE_THREAD_METADATA)
+
+
+def test_create_reuses_an_existing_tick_thread(monkeypatch):
+    cron, fake = _patch_client(monkeypatch)
+    fake.threads.search.return_value = [{"thread_id": "pt-existing"}]
+    cron.create_proactive_schedule()
+    fake.threads.create.assert_not_called()
+    assert fake.crons.create_for_thread.call_args.args[0] == "pt-existing"
 
 
 def test_create_accepts_custom_schedule_and_timezone(monkeypatch):
     cron, fake = _patch_client(monkeypatch)
     cron.create_proactive_schedule(schedule="*/5 * * * *", timezone="UTC")
-    kw = fake.crons.create.call_args.kwargs
+    kw = fake.crons.create_for_thread.call_args.kwargs
     assert kw["schedule"] == "*/5 * * * *"
     assert kw["timezone"] == "UTC"
 

--- a/tests/test_proactive_cron.py
+++ b/tests/test_proactive_cron.py
@@ -1,0 +1,72 @@
+"""Unit tests for the proactive-check cron wrapper (mock langgraph_sdk client).
+
+Mirrors tests/test_cron_schedule.py: pins the cron client-call behaviour.
+"""
+
+from unittest.mock import MagicMock
+
+
+def _patch_client(monkeypatch):
+    from EvoScientist.proactive import cron
+
+    fake = MagicMock()
+    fake.crons.create.return_value = {"cron_id": "p-1", "schedule": "*/10 * * * *"}
+    fake.crons.search.return_value = [
+        {
+            "cron_id": "p-1",
+            "schedule": "*/10 * * * *",
+            "metadata": {"run_kind": "proactive_check"},
+        },
+    ]
+    monkeypatch.setattr(cron, "_client", lambda: fake)
+    monkeypatch.setattr(cron, "_default_timezone", lambda: "Europe/London")
+    return cron, fake
+
+
+def test_create_targets_proactive_graph_with_empty_input(monkeypatch):
+    cron, fake = _patch_client(monkeypatch)
+    rec = cron.create_proactive_schedule()
+    assert rec["cron_id"] == "p-1"
+    kw = fake.crons.create.call_args.kwargs
+    assert kw["assistant_id"] == cron.PROACTIVE_GRAPH_ID
+    assert kw["schedule"] == cron.DEFAULT_PROACTIVE_SCHEDULE
+    assert kw["input"] == {}  # non-null (EmptyInputError); graph enumerates itself
+    assert kw["metadata"] == {"run_kind": cron.PROACTIVE_RUN_KIND}
+    assert kw["timezone"] == "Europe/London"
+
+
+def test_create_accepts_custom_schedule_and_timezone(monkeypatch):
+    cron, fake = _patch_client(monkeypatch)
+    cron.create_proactive_schedule(schedule="*/5 * * * *", timezone="UTC")
+    kw = fake.crons.create.call_args.kwargs
+    assert kw["schedule"] == "*/5 * * * *"
+    assert kw["timezone"] == "UTC"
+
+
+def test_list_uses_server_side_run_kind_filter(monkeypatch):
+    cron, fake = _patch_client(monkeypatch)
+    out = cron.list_proactive_schedules()
+    assert [c["cron_id"] for c in out] == ["p-1"]
+    fake.crons.search.assert_called_once_with(
+        metadata={"run_kind": cron.PROACTIVE_RUN_KIND},
+        limit=1000,
+    )
+
+
+def test_delete_and_set_enabled(monkeypatch):
+    cron, fake = _patch_client(monkeypatch)
+    cron.delete_proactive_schedule("p-1")
+    fake.crons.delete.assert_called_once_with("p-1")
+    cron.set_proactive_enabled("p-1", False)
+    assert fake.crons.update.call_args.kwargs["enabled"] is False
+
+
+def test_is_available_gates_on_langgraph_dev(monkeypatch):
+    from EvoScientist.langgraph_dev import manager
+    from EvoScientist.proactive import cron
+
+    monkeypatch.setattr(cron, "_proactive_url", lambda: "http://localhost:6174")
+    monkeypatch.setattr(manager, "is_langgraph_dev_running", lambda **_: True)
+    assert cron.is_available() is True
+    monkeypatch.setattr(manager, "is_langgraph_dev_running", lambda **_: False)
+    assert cron.is_available() is False

--- a/tests/test_proactive_delivery_watcher.py
+++ b/tests/test_proactive_delivery_watcher.py
@@ -1,0 +1,150 @@
+"""Tests for EvoScientist.proactive.delivery_watcher (serve-side delivery).
+
+Pure/DI'd core — no server or bus. Validates push extraction (dict + BaseMessage),
+idempotency across polls (the ``seen`` set), and retry-on-failure (a failed publish
+stays un-seen).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from EvoScientist.proactive.delivery_watcher import (
+    deliver_pending_pushes,
+    extract_proactive_push,
+)
+
+
+def _push_dict(content, proactive_id):
+    return {
+        "content": content,
+        "additional_kwargs": {
+            "evoscientist": {"is_proactive_push": True, "proactive_id": proactive_id}
+        },
+    }
+
+
+# ---- extract_proactive_push ----
+
+
+def test_extract_from_dict_message():
+    msgs = [{"content": "hi"}, _push_dict("Checking in!", "p1")]
+    assert extract_proactive_push(msgs) == ("p1", "Checking in!")
+
+
+def test_extract_from_basemessage():
+    msgs = [
+        HumanMessage(content="hi"),
+        AIMessage(
+            content="Want to continue?",
+            additional_kwargs={
+                "evoscientist": {"is_proactive_push": True, "proactive_id": "p2"}
+            },
+        ),
+    ]
+    assert extract_proactive_push(msgs) == ("p2", "Want to continue?")
+
+
+def test_extract_returns_none_without_push():
+    assert (
+        extract_proactive_push([{"content": "hi"}, HumanMessage(content="yo")]) is None
+    )
+    assert extract_proactive_push([]) is None
+
+
+def test_extract_returns_most_recent_push():
+    msgs = [_push_dict("old", "p1"), {"content": "reply"}, _push_dict("new", "p2")]
+    assert extract_proactive_push(msgs) == ("p2", "new")
+
+
+def test_extract_skips_push_missing_id_or_content():
+    assert extract_proactive_push([_push_dict("", "p1")]) is None
+    assert (
+        extract_proactive_push(
+            [
+                {
+                    "content": "x",
+                    "additional_kwargs": {"evoscientist": {"is_proactive_push": True}},
+                }
+            ]
+        )
+        is None
+    )
+
+
+# ---- deliver_pending_pushes ----
+
+
+def _reader(mapping):
+    async def _read(thread_id):
+        return mapping.get(thread_id, [])
+
+    return _read
+
+
+class _Publisher:
+    def __init__(self, ok=True):
+        self.ok = ok
+        self.calls = []
+
+    def __call__(self, thread_id, content):
+        self.calls.append((thread_id, content))
+        return self.ok
+
+
+def _deliver(mapping, publisher, seen=None):
+    seen = seen if seen is not None else set()
+    delivered = asyncio.run(
+        deliver_pending_pushes(
+            list(mapping.keys()),
+            read_messages=_reader(mapping),
+            publish=publisher,
+            seen=seen,
+        )
+    )
+    return delivered, seen
+
+
+def test_delivers_unseen_push_and_marks_seen():
+    pub = _Publisher(ok=True)
+    delivered, seen = _deliver({"t1": [_push_dict("hey", "p1")]}, pub)
+    assert delivered == ["p1"]
+    assert seen == {"p1"}
+    assert pub.calls == [("t1", "hey")]
+
+
+def test_already_seen_push_not_redelivered():
+    pub = _Publisher(ok=True)
+    delivered, _ = _deliver({"t1": [_push_dict("hey", "p1")]}, pub, seen={"p1"})
+    assert delivered == []
+    assert pub.calls == []
+
+
+def test_failed_publish_stays_unseen_for_retry():
+    pub = _Publisher(ok=False)  # no origin / bus down
+    delivered, seen = _deliver({"t1": [_push_dict("hey", "p1")]}, pub)
+    assert delivered == []
+    assert seen == set()  # not marked → retried next poll
+    assert pub.calls == [("t1", "hey")]
+
+
+def test_thread_without_push_is_skipped():
+    pub = _Publisher(ok=True)
+    delivered, _ = _deliver({"t1": [{"content": "just chatting"}]}, pub)
+    assert delivered == []
+    assert pub.calls == []
+
+
+def test_multiple_threads_delivered_independently():
+    pub = _Publisher(ok=True)
+    mapping = {
+        "t1": [_push_dict("a", "p1")],
+        "t2": [{"content": "no push"}],
+        "t3": [_push_dict("c", "p3")],
+    }
+    delivered, seen = _deliver(mapping, pub)
+    assert set(delivered) == {"p1", "p3"}
+    assert seen == {"p1", "p3"}
+    assert ("t2", "no push") not in pub.calls

--- a/tests/test_proactive_eligibility.py
+++ b/tests/test_proactive_eligibility.py
@@ -1,0 +1,139 @@
+"""Tests for EvoScientist.proactive.eligibility (server-scoped candidates).
+
+Server-only in production (enumerates the server registry via the SDK), so
+validated with a fake threads client — no running server. The key guarantees:
+candidates come only from server-registry threads carrying the channel-origin
+marker (the "always server-born" invariant), and last-activity is parsed for the
+gate rather than the idle test being re-implemented here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+from EvoScientist.proactive.eligibility import (
+    CHANNEL_ORIGIN_MARKER,
+    list_channel_thread_candidates,
+    stamp_channel_marker,
+)
+
+
+class _FakeThreads:
+    def __init__(self, result, *, is_async=True):
+        self._result = result
+        self._is_async = is_async
+        self.search_kwargs = None
+        self.update_calls = []
+
+    def search(self, **kwargs):
+        self.search_kwargs = kwargs
+        return self._maybe_async(self._result)
+
+    def update(self, thread_id, **kwargs):
+        self.update_calls.append((thread_id, kwargs))
+        return self._maybe_async(None)
+
+    def _maybe_async(self, value):
+        if self._is_async:
+
+            async def _co():
+                return value
+
+            return _co()
+        return value
+
+
+class _FakeClient:
+    def __init__(self, result, *, is_async=True):
+        self.threads = _FakeThreads(result, is_async=is_async)
+
+
+def _run(result, *, is_async=True, **over):
+    client = _FakeClient(result, is_async=is_async)
+    out = asyncio.run(list_channel_thread_candidates(client, **over))
+    return out, client
+
+
+def test_returns_ids_with_parsed_last_activity():
+    threads = [
+        {"thread_id": "t1", "updated_at": "2026-09-04T10:00:00+00:00"},
+        {"thread_id": "t2", "updated_at": "2026-09-04T09:00:00+00:00"},
+    ]
+    out, client = _run(threads)
+    assert out == [
+        ("t1", datetime(2026, 9, 4, 10, 0, tzinfo=UTC)),
+        ("t2", datetime(2026, 9, 4, 9, 0, tzinfo=UTC)),
+    ]
+    # enforces the invariant: the query is scoped by the channel-origin marker
+    assert client.threads.search_kwargs["metadata"] == CHANNEL_ORIGIN_MARKER
+    assert client.threads.search_kwargs["limit"] == 50
+    # in-flight condition enforced server-side: only idle threads are candidates
+    assert client.threads.search_kwargs["status"] == "idle"
+
+
+def test_custom_marker_and_limit_passed_through():
+    out, client = _run([], marker={"run_kind": "channel"}, limit=5)
+    assert out == []
+    assert client.threads.search_kwargs["metadata"] == {"run_kind": "channel"}
+    assert client.threads.search_kwargs["limit"] == 5
+
+
+def test_status_filter_can_be_disabled():
+    _, client = _run([], status=None)
+    assert client.threads.search_kwargs["status"] is None
+
+
+def test_missing_updated_at_yields_none_activity():
+    out, _ = _run([{"thread_id": "t1"}, {"thread_id": "t2", "updated_at": ""}])
+    assert out == [("t1", None), ("t2", None)]
+
+
+def test_threads_without_id_are_skipped():
+    out, _ = _run([{"updated_at": "2026-09-04T10:00:00+00:00"}, {"thread_id": "keep"}])
+    assert out == [("keep", None)]
+
+
+def test_empty_registry_is_empty_list():
+    # Fail-closed: no marker-stamped threads (e.g. serve hasn't stamped yet).
+    out, _ = _run([])
+    assert out == []
+
+
+def test_none_result_is_empty_list():
+    out, _ = _run(None)
+    assert out == []
+
+
+def test_sync_search_result_supported():
+    # A sync client (non-awaitable search) is handled too.
+    threads = [{"thread_id": "t1", "updated_at": "2026-09-04T10:00:00+00:00"}]
+    out, _ = _run(threads, is_async=False)
+    assert out == [("t1", datetime(2026, 9, 4, 10, 0, tzinfo=UTC))]
+
+
+def test_datetime_updated_at_passthrough():
+    dt = datetime(2026, 9, 4, 8, 0, tzinfo=UTC)
+    out, _ = _run([{"thread_id": "t1", "updated_at": dt}])
+    assert out == [("t1", dt)]
+
+
+# ---- stamp_channel_marker (write-side companion) ----
+
+
+def test_stamp_channel_marker_updates_server_metadata():
+    client = _FakeClient([])
+    asyncio.run(stamp_channel_marker(client, "t1"))
+    assert client.threads.update_calls == [("t1", {"metadata": CHANNEL_ORIGIN_MARKER})]
+
+
+def test_stamp_channel_marker_custom_marker():
+    client = _FakeClient([])
+    asyncio.run(stamp_channel_marker(client, "t1", marker={"k": "v"}))
+    assert client.threads.update_calls == [("t1", {"metadata": {"k": "v"}})]
+
+
+def test_stamp_channel_marker_sync_client():
+    client = _FakeClient([], is_async=False)
+    asyncio.run(stamp_channel_marker(client, "t1"))
+    assert client.threads.update_calls == [("t1", {"metadata": CHANNEL_ORIGIN_MARKER})]

--- a/tests/test_proactive_eligibility.py
+++ b/tests/test_proactive_eligibility.py
@@ -15,7 +15,6 @@ from datetime import UTC, datetime
 from EvoScientist.proactive.eligibility import (
     CHANNEL_ORIGIN_MARKER,
     list_channel_thread_candidates,
-    stamp_channel_marker,
 )
 
 
@@ -116,24 +115,3 @@ def test_datetime_updated_at_passthrough():
     dt = datetime(2026, 9, 4, 8, 0, tzinfo=UTC)
     out, _ = _run([{"thread_id": "t1", "updated_at": dt}])
     assert out == [("t1", dt)]
-
-
-# ---- stamp_channel_marker (write-side companion) ----
-
-
-def test_stamp_channel_marker_updates_server_metadata():
-    client = _FakeClient([])
-    asyncio.run(stamp_channel_marker(client, "t1"))
-    assert client.threads.update_calls == [("t1", {"metadata": CHANNEL_ORIGIN_MARKER})]
-
-
-def test_stamp_channel_marker_custom_marker():
-    client = _FakeClient([])
-    asyncio.run(stamp_channel_marker(client, "t1", marker={"k": "v"}))
-    assert client.threads.update_calls == [("t1", {"metadata": {"k": "v"}})]
-
-
-def test_stamp_channel_marker_sync_client():
-    client = _FakeClient([], is_async=False)
-    asyncio.run(stamp_channel_marker(client, "t1"))
-    assert client.threads.update_calls == [("t1", {"metadata": CHANNEL_ORIGIN_MARKER})]

--- a/tests/test_proactive_gate.py
+++ b/tests/test_proactive_gate.py
@@ -1,0 +1,167 @@
+"""Tests for EvoScientist.proactive.gate."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from EvoScientist.proactive.gate import (
+    ProactiveGateSettings,
+    evaluate_gate,
+)
+
+
+def _settings(**over):
+    base = {
+        "enabled": True,
+        "idle_minutes": 120,
+        "quiet_hours": "22:00-08:00",
+        "timezone": "UTC",
+    }
+    base.update(over)
+    return ProactiveGateSettings(**base)
+
+
+# Midday UTC, well outside the 22:00-08:00 quiet window.
+_NOON = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+
+
+def _idle(minutes: int) -> datetime:
+    return _NOON - timedelta(minutes=minutes)
+
+
+def test_gate_passes_when_all_conditions_met():
+    d = evaluate_gate(
+        _settings(),
+        now=_NOON,
+        last_activity=_idle(180),
+        has_origin=True,
+        in_flight=False,
+    )
+    assert d.should_run is True
+    assert d.reason == "ok"
+
+
+def test_gate_disabled():
+    d = evaluate_gate(
+        _settings(enabled=False),
+        now=_NOON,
+        last_activity=_idle(180),
+        has_origin=True,
+        in_flight=False,
+    )
+    assert (d.should_run, d.reason) == (False, "disabled")
+
+
+def test_gate_no_origin():
+    d = evaluate_gate(
+        _settings(),
+        now=_NOON,
+        last_activity=_idle(180),
+        has_origin=False,
+        in_flight=False,
+    )
+    assert (d.should_run, d.reason) == (False, "no_origin")
+
+
+def test_gate_in_flight():
+    d = evaluate_gate(
+        _settings(),
+        now=_NOON,
+        last_activity=_idle(180),
+        has_origin=True,
+        in_flight=True,
+    )
+    assert (d.should_run, d.reason) == (False, "in_flight")
+
+
+def test_gate_no_activity():
+    d = evaluate_gate(
+        _settings(),
+        now=_NOON,
+        last_activity=None,
+        has_origin=True,
+        in_flight=False,
+    )
+    assert (d.should_run, d.reason) == (False, "no_activity")
+
+
+def test_gate_idle_just_under_threshold():
+    d = evaluate_gate(
+        _settings(idle_minutes=120),
+        now=_NOON,
+        last_activity=_idle(119),
+        has_origin=True,
+        in_flight=False,
+    )
+    assert (d.should_run, d.reason) == (False, "idle_below_threshold")
+
+
+def test_gate_idle_exactly_at_threshold_passes():
+    d = evaluate_gate(
+        _settings(idle_minutes=120),
+        now=_NOON,
+        last_activity=_idle(120),
+        has_origin=True,
+        in_flight=False,
+    )
+    assert d.should_run is True
+
+
+def test_gate_quiet_hours_wraparound_night():
+    # 23:00 UTC is inside the 22:00-08:00 window.
+    now = datetime(2026, 8, 20, 23, 0, tzinfo=UTC)
+    d = evaluate_gate(
+        _settings(),
+        now=now,
+        last_activity=now - timedelta(minutes=300),
+        has_origin=True,
+        in_flight=False,
+    )
+    assert (d.should_run, d.reason) == (False, "quiet_hours")
+
+
+def test_gate_quiet_hours_wraparound_early_morning():
+    # 03:00 UTC is inside the 22:00-08:00 window.
+    now = datetime(2026, 8, 20, 3, 0, tzinfo=UTC)
+    d = evaluate_gate(
+        _settings(),
+        now=now,
+        last_activity=now - timedelta(minutes=300),
+        has_origin=True,
+        in_flight=False,
+    )
+    assert (d.should_run, d.reason) == (False, "quiet_hours")
+
+
+def test_gate_quiet_hours_respects_timezone():
+    # 12:00 UTC == 07:00 America/New_York (UTC-5, still inside 22:00-08:00 local).
+    d = evaluate_gate(
+        _settings(timezone="America/New_York"),
+        now=datetime(2026, 1, 20, 12, 0, tzinfo=UTC),
+        last_activity=datetime(2026, 1, 20, 6, 0, tzinfo=UTC),
+        has_origin=True,
+        in_flight=False,
+    )
+    assert (d.should_run, d.reason) == (False, "quiet_hours")
+
+
+def test_gate_no_quiet_hours_configured():
+    d = evaluate_gate(
+        _settings(quiet_hours=None),
+        now=datetime(2026, 8, 20, 23, 0, tzinfo=UTC),
+        last_activity=datetime(2026, 8, 20, 20, 0, tzinfo=UTC),
+        has_origin=True,
+        in_flight=False,
+    )
+    assert d.should_run is True
+
+
+def test_gate_naive_now_treated_as_utc():
+    d = evaluate_gate(
+        _settings(),
+        now=datetime(2026, 8, 20, 12, 0),  # naive
+        last_activity=datetime(2026, 8, 20, 8, 0),  # naive
+        has_origin=True,
+        in_flight=False,
+    )
+    assert d.should_run is True

--- a/tests/test_proactive_gateway_delivery.py
+++ b/tests/test_proactive_gateway_delivery.py
@@ -1,0 +1,109 @@
+"""Tests for EvoScientist.proactive.gateway_delivery (server-path delivery).
+
+Fake gateway (widened update_state_values) — no server. Validates the commit
+shape (append tagged msg as model + clear) and that a ConflictError from the
+append propagates so run_proactive_check's retry loop handles it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+from langgraph.graph import END
+from langgraph_sdk.errors import ConflictError
+
+from EvoScientist.proactive.gateway_delivery import GatewayDeliverer
+
+
+def _conflict():
+    resp = httpx.Response(409, request=httpx.Request("POST", "http://test"))
+    return ConflictError("run in flight", response=resp, body=None)
+
+
+class _FakeGateway:
+    def __init__(self, *, fail_appends=0):
+        self._fail_appends = fail_appends
+        self._appends = 0
+        self.calls = []
+
+    async def update_state_values(
+        self, target, thread_id, values, *, as_node=None, metadata=None
+    ):
+        self.calls.append(
+            {"thread_id": thread_id, "values": values, "as_node": as_node}
+        )
+        if values is not None:  # append
+            self._appends += 1
+            if self._appends <= self._fail_appends:
+                raise _conflict()
+
+
+def test_deliver_appends_tagged_message_then_clears():
+    gw = _FakeGateway()
+    deliverer = GatewayDeliverer(gw, "target")
+    ok = asyncio.run(deliverer.deliver("src", "Checking in!", "pid-1"))
+    assert ok is True
+    assert len(gw.calls) == 2
+    append, clear = gw.calls
+    assert append["thread_id"] == "src"
+    msg = append["values"]["messages"][0]
+    assert msg.content == "Checking in!"
+    assert msg.additional_kwargs == {
+        "evoscientist": {"is_proactive_push": True, "proactive_id": "pid-1"}
+    }
+    assert msg.id == "proactive-pid-1"
+    assert append["as_node"] == "model"
+    assert clear["values"] is None
+    assert clear["as_node"] == END
+
+
+def test_deliver_propagates_append_conflict():
+    # The outer commit_with_conflict_retry (in run_proactive_check) must be the one
+    # that catches this — GatewayDeliverer itself does not swallow append conflicts.
+    gw = _FakeGateway(fail_appends=1)
+    deliverer = GatewayDeliverer(gw, "target")
+    try:
+        asyncio.run(deliverer.deliver("src", "hi", "pid-1"))
+        raise AssertionError("expected ConflictError to propagate")
+    except ConflictError:
+        pass
+
+
+def test_deliver_end_to_end_via_run_proactive_check_retry():
+    # GatewayDeliverer wired into the real check: append conflicts once then lands.
+    from datetime import UTC, datetime, timedelta
+
+    from EvoScientist.proactive.gate import ProactiveGateSettings
+    from EvoScientist.proactive.service import run_proactive_check
+
+    now = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
+    gw = _FakeGateway(fail_appends=1)
+
+    async def _shadow(messages, trigger):
+        return "Want to continue?"
+
+    result = asyncio.run(
+        run_proactive_check(
+            settings=ProactiveGateSettings(
+                enabled=True, idle_minutes=120, quiet_hours=None, timezone="UTC"
+            ),
+            source_thread_id="src",
+            now=now,
+            last_activity=now - timedelta(minutes=180),
+            pre_head="h1",
+            has_origin=True,
+            in_flight=False,
+            source_messages=[{"role": "user", "content": "prior"}],
+            shadow_runner=_shadow,
+            read_current_head=lambda: "h1",
+            deliverer=GatewayDeliverer(gw, "target"),
+            trigger="<proactive_trigger>",
+            workspace_dir="/ws",
+            model="m",
+            proactive_id="pid-1",
+        )
+    )
+    assert result.stage == "delivered"
+    appends = [c for c in gw.calls if c["values"] is not None]
+    assert len(appends) == 2  # first conflicted, retry landed

--- a/tests/test_proactive_graph.py
+++ b/tests/test_proactive_graph.py
@@ -294,3 +294,15 @@ def test_build_deps_memoizes_until_config_changes(monkeypatch):
     )
     assert graph._build_deps().settings.idle_minutes == 5
     assert len(builds) == 3
+
+
+def test_invalid_idle_minutes_fall_back_to_default(caplog):
+    with caplog.at_level("WARNING", logger="EvoScientist.config.settings"):
+        assert _cfg(proactive_idle_minutes=-5).proactive_idle_minutes == 120
+        assert _cfg(proactive_idle_minutes="abc").proactive_idle_minutes == 120
+        assert _cfg(proactive_idle_minutes=True).proactive_idle_minutes == 120
+    assert (
+        len([r for r in caplog.records if "proactive_idle_minutes" in r.message]) == 3
+    )
+    # zero is valid: no idle requirement (the live-test knob)
+    assert _cfg(proactive_idle_minutes=0).proactive_idle_minutes == 0

--- a/tests/test_proactive_graph.py
+++ b/tests/test_proactive_graph.py
@@ -1,0 +1,296 @@
+"""Tests for EvoScientist.proactive.graph (graph node body + config resolution).
+
+Fully DI'd — a fake client (search + get_state, real captured shapes), a fake
+gateway, a fake shadow. No server or model. Proves the whole server-path tick
+composes: enumerate idle marked thread → read state → gate → shadow → commit into
+the source thread via the gateway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from langgraph.graph import END
+
+from EvoScientist.proactive.gate import ProactiveGateSettings
+from EvoScientist.proactive.graph import run_proactive_graph_tick
+
+_NOON = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+
+
+class _FakeThreads:
+    def __init__(self, search_result, state):
+        self._search = search_result
+        self._state = state
+        self.search_kwargs = None
+
+    def search(self, **kwargs):
+        self.search_kwargs = kwargs
+
+        async def _co():
+            return self._search
+
+        return _co()
+
+    def get_state(self, thread_id):
+        return self._state
+
+
+class _FakeClient:
+    def __init__(self, search_result, state):
+        self.threads = _FakeThreads(search_result, state)
+
+
+class _FakeGateway:
+    def __init__(self):
+        self.calls = []
+
+    async def update_state_values(
+        self, target, thread_id, values, *, as_node=None, metadata=None
+    ):
+        self.calls.append(
+            {"thread_id": thread_id, "values": values, "as_node": as_node}
+        )
+
+
+def _settings():
+    return ProactiveGateSettings(
+        enabled=True, idle_minutes=120, quiet_hours=None, timezone="UTC"
+    )
+
+
+def _run(shadow_reply, *, thread_updated="2026-08-20T09:00:00+00:00", head="h1"):
+    thread = {"thread_id": "t1", "updated_at": thread_updated}
+    state = {
+        "checkpoint_id": head,
+        "values": {"messages": [{"content": "prior", "type": "human"}]},
+    }
+    client = _FakeClient([thread], state)
+    gw = _FakeGateway()
+
+    async def _shadow(messages, trigger):
+        return shadow_reply
+
+    results = asyncio.run(
+        run_proactive_graph_tick(
+            client=client,
+            gateway=gw,
+            target="tg",
+            shadow_runner=_shadow,
+            settings=_settings(),
+            trigger="<proactive_trigger>",
+            workspace_dir="/ws",
+            model="m",
+            now=_NOON,
+        )
+    )
+    return results, client, gw
+
+
+def test_graph_tick_delivers_into_source_thread():
+    results, client, gw = _run("Want to continue?")
+    assert [r.stage for r in results] == ["delivered"]
+    # enumeration used the idle-status + marker query
+    assert client.threads.search_kwargs["status"] == "idle"
+    # committed into the SOURCE thread (t1): append tagged msg as model + clear
+    append = [c for c in gw.calls if c["values"] is not None]
+    clear = [c for c in gw.calls if c["values"] is None]
+    assert len(append) == 1
+    assert len(clear) == 1
+    assert append[0]["thread_id"] == "t1"
+    msg = append[0]["values"]["messages"][0]
+    assert msg.additional_kwargs["evoscientist"]["is_proactive_push"] is True
+    assert append[0]["as_node"] == "model"
+    assert clear[0]["as_node"] == END
+
+
+def test_graph_tick_no_push_does_not_commit():
+    results, _, gw = _run("NO_PUSH")
+    assert [r.stage for r in results] == ["no_push"]
+    assert gw.calls == []
+
+
+def test_graph_tick_gate_rejects_recent_thread():
+    # thread active 10 min ago → not idle (idle_minutes=120) → gate_rejected
+    results, _, gw = _run("Hi", thread_updated="2026-08-20T11:50:00+00:00")
+    assert [r.stage for r in results] == ["gate_rejected"]
+    assert gw.calls == []
+
+
+def test_graph_tick_no_candidates_is_empty():
+    client = _FakeClient([], {"checkpoint_id": "h1", "values": {"messages": []}})
+    gw = _FakeGateway()
+
+    async def _shadow(messages, trigger):
+        return "x"
+
+    results = asyncio.run(
+        run_proactive_graph_tick(
+            client=client,
+            gateway=gw,
+            target="tg",
+            shadow_runner=_shadow,
+            settings=_settings(),
+            trigger="<t>",
+            workspace_dir="/ws",
+            model="m",
+            now=_NOON,
+        )
+    )
+    assert results == []
+    assert gw.calls == []
+
+
+# ---- gate settings from config ----
+
+
+def _cfg(**overrides):
+    from EvoScientist.config.settings import EvoScientistConfig
+
+    return EvoScientistConfig(**overrides)
+
+
+def test_gate_settings_defaults_are_off_and_shipped_values(monkeypatch):
+    from EvoScientist.proactive import graph
+
+    monkeypatch.setattr(graph, "_system_timezone", lambda: "Europe/Warsaw")
+    settings = graph.gate_settings_from_config(_cfg())
+    assert settings.enabled is False
+    assert settings.idle_minutes == 120
+    assert settings.quiet_hours == "22:00-08:00"
+    assert settings.timezone == "Europe/Warsaw"  # empty config => host zone
+
+
+def test_gate_settings_blank_quiet_hours_disables_window():
+    from EvoScientist.proactive import graph
+
+    settings = graph.gate_settings_from_config(
+        _cfg(
+            proactive_enabled=True, proactive_quiet_hours="  ", proactive_timezone="UTC"
+        )
+    )
+    assert settings.enabled is True
+    assert settings.quiet_hours is None
+    assert settings.timezone == "UTC"
+
+
+def test_gate_settings_invalid_timezone_falls_back_to_utc(caplog):
+    from EvoScientist.proactive import graph
+
+    with caplog.at_level("WARNING", logger="EvoScientist.proactive.graph"):
+        settings = graph.gate_settings_from_config(
+            _cfg(proactive_timezone="Mars/Olympus")
+        )
+    assert settings.timezone == "UTC"
+    assert any("Mars/Olympus" in r.message for r in caplog.records)
+
+
+def test_proactive_env_mappings_cover_every_field():
+    from EvoScientist.config.settings import _ENV_MAPPINGS
+
+    assert _ENV_MAPPINGS["proactive_enabled"] == "EVOSCIENTIST_PROACTIVE_ENABLED"
+    assert (
+        _ENV_MAPPINGS["proactive_idle_minutes"] == "EVOSCIENTIST_PROACTIVE_IDLE_MINUTES"
+    )
+    assert (
+        _ENV_MAPPINGS["proactive_quiet_hours"] == "EVOSCIENTIST_PROACTIVE_QUIET_HOURS"
+    )
+    assert _ENV_MAPPINGS["proactive_timezone"] == "EVOSCIENTIST_PROACTIVE_TIMEZONE"
+
+
+# ---- tick summary stored on the run ----
+
+
+def test_summarize_results_carries_stage_reason_and_reply_preview():
+    from EvoScientist.proactive.graph import summarize_results
+    from EvoScientist.proactive.service import ProactiveCheckResult
+
+    long_reply = "x" * 900
+    out = summarize_results(
+        [
+            ProactiveCheckResult(
+                "no_push", "no_push", reply="NO_PUSH", source_thread_id="a"
+            ),
+            ProactiveCheckResult(
+                "no_push", "no_reply", reply=None, source_thread_id="b"
+            ),
+            ProactiveCheckResult(
+                "delivered", "ok", reply=long_reply, source_thread_id="c"
+            ),
+        ]
+    )
+    assert out[0] == {
+        "thread_id": "a",
+        "stage": "no_push",
+        "reason": "no_push",
+        "reply": "NO_PUSH",
+    }
+    assert out[1] == {
+        "thread_id": "b",
+        "stage": "no_push",
+        "reason": "no_reply",
+        "reply": None,
+    }
+    assert out[2]["stage"] == "delivered"
+    assert len(out[2]["reply"]) == 600
+
+
+# ---- deps memoization keyed on config ----
+
+
+def _patch_deps_builders(monkeypatch, cfg_holder):
+    """Stub every heavy builder _build_deps touches; count shadow builds."""
+    import EvoScientist.EvoScientist as evo
+    import EvoScientist.gateway as gateway_pkg
+    import EvoScientist.langgraph_dev.sdk as sdk
+    from EvoScientist.config import settings as settings_mod
+    from EvoScientist.proactive import graph, shadow
+
+    builds = []
+    monkeypatch.setattr(settings_mod, "get_effective_config", lambda: cfg_holder["cfg"])
+    monkeypatch.setattr(evo, "_build_chat_model", lambda cfg: object())
+    monkeypatch.setattr(
+        shadow,
+        "build_shadow_graph",
+        lambda cfg, m, ws: builds.append(cfg.model) or object(),
+    )
+    monkeypatch.setattr(
+        gateway_pkg,
+        "create_runtime_gateways",
+        lambda **kw: SimpleNamespace(
+            thread_store=SimpleNamespace(client=object()), graph_gateway=object()
+        ),
+    )
+    monkeypatch.setattr(sdk, "configured_langgraph_dev_url", lambda: "http://x")
+    monkeypatch.setattr(sdk, "langgraph_dev_headers", lambda: {})
+    monkeypatch.setattr(graph, "_DEPS", None)
+    monkeypatch.setattr(graph, "_DEPS_KEY", None)
+    return builds
+
+
+def test_build_deps_memoizes_until_config_changes(monkeypatch):
+    from EvoScientist.proactive import graph
+
+    holder = {"cfg": _cfg(model="model-a", proactive_timezone="UTC")}
+    builds = _patch_deps_builders(monkeypatch, holder)
+
+    first = graph._build_deps()
+    again = graph._build_deps()
+    assert again is first
+    assert builds == ["model-a"]
+    assert first.model == "model-a"
+
+    holder["cfg"] = _cfg(model="model-b", proactive_timezone="UTC")
+    rebuilt = graph._build_deps()
+    assert rebuilt is not first
+    assert rebuilt.model == "model-b"
+    assert builds == ["model-a", "model-b"]
+
+    # gate settings change also rebuilds (idle threshold edited in config.yaml)
+    holder["cfg"] = _cfg(
+        model="model-b", proactive_timezone="UTC", proactive_idle_minutes=5
+    )
+    assert graph._build_deps().settings.idle_minutes == 5
+    assert len(builds) == 3

--- a/tests/test_proactive_mode_middleware.py
+++ b/tests/test_proactive_mode_middleware.py
@@ -1,0 +1,215 @@
+"""Tests for EvoScientist.middleware.proactive_mode."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from EvoScientist.middleware.proactive_mode import (
+    ProactiveModeMiddleware,
+    _read_proactive_mode,
+    create_proactive_mode_middleware,
+)
+
+
+def _request(tools=None):
+    """A minimal ModelRequest stand-in exposing ``tools`` and ``.override``.
+
+    ``override`` mirrors the real immutable contract: it returns a *new*
+    object with the given attributes replaced, leaving the original untouched.
+    """
+    tools = [object(), object()] if tools is None else tools
+    request = SimpleNamespace(tools=tools)
+    request.override = lambda **kwargs: SimpleNamespace(
+        tools=kwargs.get("tools", request.tools)
+    )
+    return request
+
+
+# ---- unit tests: _read_proactive_mode behavior ------------------------------
+
+
+@patch("langgraph.config.get_config")
+def test_read_returns_true_when_flag_set(mock_get_config):
+    mock_get_config.return_value = {"configurable": {"proactive_mode": True}}
+    assert _read_proactive_mode() is True
+
+
+@patch("langgraph.config.get_config")
+def test_read_returns_false_when_configurable_missing(mock_get_config):
+    mock_get_config.return_value = {}
+    assert _read_proactive_mode() is False
+
+
+@patch("langgraph.config.get_config")
+def test_read_returns_false_when_flag_missing(mock_get_config):
+    mock_get_config.return_value = {"configurable": {"other_field": "x"}}
+    assert _read_proactive_mode() is False
+
+
+@patch("langgraph.config.get_config")
+def test_read_returns_false_when_flag_falsey(mock_get_config):
+    mock_get_config.return_value = {"configurable": {"proactive_mode": False}}
+    assert _read_proactive_mode() is False
+
+
+@patch("langgraph.config.get_config")
+def test_read_returns_false_for_non_bool_truthy(mock_get_config):
+    """Only the literal boolean ``True`` enables the strip; a truthy string
+    (e.g. a mis-serialized WebUI value) must not silently arm it."""
+    mock_get_config.return_value = {"configurable": {"proactive_mode": "yes"}}
+    assert _read_proactive_mode() is False
+
+
+@patch("langgraph.config.get_config")
+def test_read_returns_false_when_configurable_not_dict(mock_get_config):
+    mock_get_config.return_value = {"configurable": "not-a-dict"}
+    assert _read_proactive_mode() is False
+
+
+@patch("langgraph.config.get_config", side_effect=RuntimeError("outside context"))
+def test_read_returns_false_outside_runnable_context(mock_get_config):
+    assert _read_proactive_mode() is False
+
+
+# ---- unit tests: middleware behavior ----------------------------------------
+
+
+@patch("langgraph.config.get_config")
+def test_strips_all_tools_when_flag_set(mock_get_config):
+    mock_get_config.return_value = {"configurable": {"proactive_mode": True}}
+    middleware = ProactiveModeMiddleware()
+    modified = middleware._apply(_request())
+    assert modified.tools == []
+
+
+@patch("langgraph.config.get_config")
+def test_passthrough_unchanged_when_flag_absent(mock_get_config):
+    """Flag absent → the exact same request object is returned (byte-identical
+    passthrough), so a normal turn is unaffected by the middleware's presence."""
+    mock_get_config.return_value = {"configurable": {}}
+    middleware = ProactiveModeMiddleware()
+    original = _request()
+    tools_before = original.tools
+    result = middleware._apply(original)
+    assert result is original
+    assert result.tools is tools_before
+
+
+@patch("langgraph.config.get_config")
+def test_wrap_model_call_passes_stripped_request_to_handler(mock_get_config):
+    mock_get_config.return_value = {"configurable": {"proactive_mode": True}}
+    middleware = ProactiveModeMiddleware()
+    seen = {}
+
+    def handler(req):
+        seen["tools"] = req.tools
+        return "response"
+
+    result = middleware.wrap_model_call(_request(), handler)
+    assert result == "response"
+    assert seen["tools"] == []
+
+
+@patch("langgraph.config.get_config")
+def test_awrap_model_call_passes_stripped_request_to_handler(mock_get_config):
+    mock_get_config.return_value = {"configurable": {"proactive_mode": True}}
+    middleware = ProactiveModeMiddleware()
+    seen = {}
+
+    async def handler(req):
+        seen["tools"] = req.tools
+        return "response"
+
+    result = asyncio.run(middleware.awrap_model_call(_request(), handler))
+    assert result == "response"
+    assert seen["tools"] == []
+
+
+# ---- composition tests: _get_default_middleware -----------------------------
+
+
+def _mock_config():
+    cfg = MagicMock()
+    cfg.enable_ask_user = False
+    cfg.auto_mode = False
+    cfg.auto_approve = False
+    cfg.model_fallbacks = None
+    cfg.auxiliary_model = ""
+    cfg.auxiliary_provider = ""
+    cfg.code_interpreter_timeout = 60
+    cfg.code_interpreter_max_result_chars = 6000
+    return cfg
+
+
+@patch("EvoScientist.EvoScientist._ensure_chat_model")
+@patch("EvoScientist.EvoScientist._ensure_config")
+def test_default_middleware_includes_proactive_mode_for_main_agent(
+    mock_config, mock_model
+):
+    mock_config.return_value = _mock_config()
+    mock_model.return_value = MagicMock(profile={"max_input_tokens": 200_000})
+
+    selector = MagicMock(name="tool_selector")
+    with patch(
+        "EvoScientist.middleware.create_tool_selector_middleware",
+        return_value=[selector],
+    ):
+        from EvoScientist.EvoScientist import _get_default_middleware
+
+        middleware = _get_default_middleware()
+
+    assert any(isinstance(m, ProactiveModeMiddleware) for m in middleware)
+
+
+@patch("EvoScientist.EvoScientist._ensure_chat_model")
+@patch("EvoScientist.EvoScientist._ensure_config")
+def test_default_middleware_excludes_proactive_mode_for_async_subagent(
+    mock_config, mock_model
+):
+    mock_config.return_value = _mock_config()
+    mock_model.return_value = MagicMock(profile={"max_input_tokens": 200_000})
+
+    with patch(
+        "EvoScientist.middleware.create_tool_selector_middleware",
+        return_value=[MagicMock()],
+    ):
+        from EvoScientist.EvoScientist import _get_default_middleware
+
+        middleware = _get_default_middleware(for_async_subagent=True)
+
+    assert not any(isinstance(m, ProactiveModeMiddleware) for m in middleware)
+
+
+@patch("EvoScientist.EvoScientist._ensure_chat_model")
+@patch("EvoScientist.EvoScientist._ensure_config")
+def test_proactive_mode_is_outer_of_tool_selector(mock_config, mock_model):
+    """Pins the placement decision: ProactiveMode must sit *before* (outer of)
+    tool_selector so the selector skips its LLM call on an empty tool set.
+    langchain composes the first middleware in the list as the outermost layer,
+    so a lower index == an outer wrap."""
+    mock_config.return_value = _mock_config()
+    mock_model.return_value = MagicMock(profile={"max_input_tokens": 200_000})
+
+    selector = MagicMock(name="tool_selector")
+    with patch(
+        "EvoScientist.middleware.create_tool_selector_middleware",
+        return_value=[selector],
+    ):
+        from EvoScientist.EvoScientist import _get_default_middleware
+
+        middleware = _get_default_middleware()
+
+    proactive_index = next(
+        i for i, m in enumerate(middleware) if isinstance(m, ProactiveModeMiddleware)
+    )
+    selector_index = middleware.index(selector)
+    assert proactive_index < selector_index
+
+
+# ---- factory ----------------------------------------------------------------
+
+
+def test_factory_returns_middleware_instance():
+    assert isinstance(create_proactive_mode_middleware(), ProactiveModeMiddleware)

--- a/tests/test_proactive_serve_delivery.py
+++ b/tests/test_proactive_serve_delivery.py
@@ -258,7 +258,12 @@ def _patch_cron_client(monkeypatch, existing):
 
     fake = MagicMock()
     fake.crons.search.return_value = existing
-    fake.crons.create.return_value = {"cron_id": "p-new", "schedule": "*/10 * * * *"}
+    fake.crons.create_for_thread.return_value = {
+        "cron_id": "p-new",
+        "schedule": "*/10 * * * *",
+    }
+    fake.threads.search.return_value = []
+    fake.threads.create.return_value = {"thread_id": "pt-1"}
     monkeypatch.setattr(cron, "_client", lambda: fake)
     monkeypatch.setattr(cron, "_default_timezone", lambda: "UTC")
     return fake
@@ -269,8 +274,8 @@ def test_ensure_proactive_cron_creates_when_absent(monkeypatch):
 
     fake = _patch_cron_client(monkeypatch, existing=[])
     _serve_ensure_proactive_cron(_proactive_cfg())
-    fake.crons.create.assert_called_once()
-    assert fake.crons.create.call_args.kwargs["assistant_id"] == "proactive"
+    fake.crons.create_for_thread.assert_called_once()
+    assert fake.crons.create_for_thread.call_args.args == ("pt-1", "proactive")
 
 
 def test_ensure_proactive_cron_reuses_existing(monkeypatch):
@@ -278,7 +283,7 @@ def test_ensure_proactive_cron_reuses_existing(monkeypatch):
 
     fake = _patch_cron_client(monkeypatch, existing=[{"cron_id": "p-1"}])
     _serve_ensure_proactive_cron(_proactive_cfg())
-    fake.crons.create.assert_not_called()
+    fake.crons.create_for_thread.assert_not_called()
 
 
 def test_ensure_proactive_cron_noop_when_disabled_or_local(monkeypatch):
@@ -288,7 +293,7 @@ def test_ensure_proactive_cron_noop_when_disabled_or_local(monkeypatch):
     _serve_ensure_proactive_cron(_proactive_cfg(proactive_enabled=False))
     _serve_ensure_proactive_cron(_proactive_cfg(gateway_backend="local"))
     fake.crons.search.assert_not_called()
-    fake.crons.create.assert_not_called()
+    fake.crons.create_for_thread.assert_not_called()
 
 
 def test_ensure_proactive_cron_failure_is_logged_not_raised(monkeypatch, caplog):

--- a/tests/test_proactive_serve_delivery.py
+++ b/tests/test_proactive_serve_delivery.py
@@ -1,0 +1,302 @@
+"""Tests for the serve-side proactive wiring.
+
+Covers the seams added to wire ``proactive.delivery_watcher`` into serve: the
+channel-origins accessor, the server-backend gate, the marker stamp, the
+delivery poll composition, and the cron auto-registration. The watcher's own
+logic is tested in
+test_proactive_delivery_watcher.py; here we test the serve glue with fakes (no
+server, no model, no bus).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from EvoScientist.cli import channel as channel_mod
+from EvoScientist.cli import commands
+
+
+@pytest.fixture(autouse=True)
+def _clear_origins():
+    def _reset():
+        with channel_mod._thread_channel_origins_lock:
+            channel_mod._thread_channel_origins.clear()
+
+    _reset()
+    yield
+    _reset()
+
+
+class _FakeAsyncRuntime:
+    """run_sync that drives the async factory to completion synchronously."""
+
+    def run_sync(self, factory, **_kw):
+        return asyncio.run(factory())
+
+
+class _FakeThreads:
+    def __init__(self, state_by_thread=None):
+        self._state = state_by_thread or {}
+        self.updated: list[tuple[str, dict | None]] = []
+
+    async def get_state(self, thread_id):
+        return self._state.get(thread_id, {"values": {"messages": []}})
+
+    async def update(self, thread_id, metadata=None):
+        self.updated.append((thread_id, metadata))
+
+
+class _FakeClient:
+    def __init__(self, state_by_thread=None):
+        self.threads = _FakeThreads(state_by_thread)
+
+
+def _runtime_state(*, client, thread_id="t1", config=None):
+    thread_store = (
+        SimpleNamespace(client=client) if client is not None else SimpleNamespace()
+    )
+    return SimpleNamespace(
+        config=config if config is not None else _proactive_cfg(),
+        runtime_gateways=SimpleNamespace(thread_store=thread_store),
+        thread_id=thread_id,
+        async_runtime=_FakeAsyncRuntime(),
+    )
+
+
+def _proactive_cfg(**overrides):
+    from EvoScientist.config.settings import EvoScientistConfig
+
+    base = {"gateway_backend": "langgraph_server", "proactive_enabled": True}
+    base.update(overrides)
+    return EvoScientistConfig(**base)
+
+
+def _register(thread_id):
+    msg = SimpleNamespace(
+        channel_type="telegram", chat_id="c1", sender="u1", metadata=None
+    )
+    channel_mod.remember_channel_origin(thread_id, msg)
+
+
+def _tagged_state(proactive_id="pid1", content="ping"):
+    return {
+        "values": {
+            "messages": [
+                {"type": "human", "content": "hi"},
+                {
+                    "type": "ai",
+                    "content": content,
+                    "additional_kwargs": {
+                        "evoscientist": {
+                            "is_proactive_push": True,
+                            "proactive_id": proactive_id,
+                        }
+                    },
+                },
+            ]
+        }
+    }
+
+
+# ---- origins accessor ---------------------------------------------------------
+
+
+def test_list_channel_origin_thread_ids_empty():
+    assert channel_mod.list_channel_origin_thread_ids() == []
+
+
+def test_list_channel_origin_thread_ids_populated():
+    _register("t1")
+    _register("t2")
+    assert set(channel_mod.list_channel_origin_thread_ids()) == {"t1", "t2"}
+
+
+# ---- server-backend gate ------------------------------------------------------
+
+
+def test_server_client_none_on_local_backend():
+    assert commands._serve_server_client(_runtime_state(client=None)) is None
+
+
+def test_server_client_present_on_server_backend():
+    client = _FakeClient()
+    assert commands._serve_server_client(_runtime_state(client=client)) is client
+
+
+# ---- marker stamp -------------------------------------------------------------
+
+
+def test_stamp_marker_noop_on_local():
+    # No client → no crash, no call.
+    commands._serve_stamp_channel_marker(_runtime_state(client=None))
+
+
+def test_stamp_marker_calls_update_on_server():
+    client = _FakeClient()
+    commands._serve_stamp_channel_marker(_runtime_state(client=client, thread_id="t1"))
+    assert client.threads.updated == [("t1", {"has_channel_origin": True})]
+
+
+# ---- delivery poll ------------------------------------------------------------
+
+
+def test_deliver_publishes_then_idempotent(monkeypatch):
+    published: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        commands,
+        "publish_to_channel_origin",
+        lambda tid, content: (published.append((tid, content)), True)[1],
+    )
+    client = _FakeClient({"t1": _tagged_state("pid1", "ping")})
+    _register("t1")
+    seen: set[str] = set()
+    rs = _runtime_state(client=client)
+
+    commands._serve_deliver_proactive_pushes(runtime_state=rs, seen=seen)
+    assert published == [("t1", "ping")]
+    assert "pid1" in seen
+
+    # Second poll: id already seen → no re-publish.
+    commands._serve_deliver_proactive_pushes(runtime_state=rs, seen=seen)
+    assert published == [("t1", "ping")]
+
+
+def test_deliver_noop_on_local(monkeypatch):
+    published: list = []
+    monkeypatch.setattr(
+        commands,
+        "publish_to_channel_origin",
+        lambda tid, content: (published.append((tid, content)), True)[1],
+    )
+    _register("t1")
+    commands._serve_deliver_proactive_pushes(
+        runtime_state=_runtime_state(client=None), seen=set()
+    )
+    assert published == []
+
+
+def test_deliver_noop_on_empty_origins(monkeypatch):
+    published: list = []
+    monkeypatch.setattr(
+        commands,
+        "publish_to_channel_origin",
+        lambda tid, content: (published.append((tid, content)), True)[1],
+    )
+    client = _FakeClient({"t1": _tagged_state()})
+    # No _register → no channel origins → nothing to poll.
+    commands._serve_deliver_proactive_pushes(
+        runtime_state=_runtime_state(client=client), seen=set()
+    )
+    assert published == []
+
+
+def test_deliver_failed_publish_not_seen_then_retries(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def _pub(tid, content):
+        calls.append((tid, content))
+        return len(calls) > 1  # fail first, succeed second
+
+    monkeypatch.setattr(commands, "publish_to_channel_origin", _pub)
+    client = _FakeClient({"t1": _tagged_state("pid1", "ping")})
+    _register("t1")
+    seen: set[str] = set()
+    rs = _runtime_state(client=client)
+
+    commands._serve_deliver_proactive_pushes(runtime_state=rs, seen=seen)
+    assert "pid1" not in seen  # first publish returned False
+
+    commands._serve_deliver_proactive_pushes(runtime_state=rs, seen=seen)
+    assert "pid1" in seen  # retried and succeeded
+    assert len(calls) == 2
+
+
+# ---- config flag --------------------------------------------------------------
+
+
+def test_gateway_backend_default_is_local():
+    from EvoScientist.config.settings import EvoScientistConfig
+
+    assert EvoScientistConfig().gateway_backend == "local"
+
+
+def test_gateway_backend_env_override(monkeypatch):
+    from EvoScientist.config.settings import get_effective_config
+
+    monkeypatch.setenv("EVOSCIENTIST_GATEWAY_BACKEND", "langgraph_server")
+    assert get_effective_config().gateway_backend == "langgraph_server"
+
+
+# ---- proactive gate + cron auto-registration ----------------------------------
+
+
+def test_serve_proactive_enabled_requires_both_flag_and_server_backend():
+    from EvoScientist.cli.commands import _serve_proactive_enabled
+
+    assert _serve_proactive_enabled(_proactive_cfg()) is True
+    assert _serve_proactive_enabled(_proactive_cfg(proactive_enabled=False)) is False
+    assert _serve_proactive_enabled(_proactive_cfg(gateway_backend="local")) is False
+    assert _serve_proactive_enabled(None) is False
+
+
+def test_stamp_marker_skipped_when_proactive_disabled():
+    from EvoScientist.cli.commands import _serve_stamp_channel_marker
+
+    client = _FakeClient()
+    state = _runtime_state(
+        client=client, config=_proactive_cfg(proactive_enabled=False)
+    )
+    _serve_stamp_channel_marker(state)
+    assert client.threads.updated == []
+
+
+def _patch_cron_client(monkeypatch, existing):
+    from EvoScientist.proactive import cron
+
+    fake = MagicMock()
+    fake.crons.search.return_value = existing
+    fake.crons.create.return_value = {"cron_id": "p-new", "schedule": "*/10 * * * *"}
+    monkeypatch.setattr(cron, "_client", lambda: fake)
+    monkeypatch.setattr(cron, "_default_timezone", lambda: "UTC")
+    return fake
+
+
+def test_ensure_proactive_cron_creates_when_absent(monkeypatch):
+    from EvoScientist.cli.commands import _serve_ensure_proactive_cron
+
+    fake = _patch_cron_client(monkeypatch, existing=[])
+    _serve_ensure_proactive_cron(_proactive_cfg())
+    fake.crons.create.assert_called_once()
+    assert fake.crons.create.call_args.kwargs["assistant_id"] == "proactive"
+
+
+def test_ensure_proactive_cron_reuses_existing(monkeypatch):
+    from EvoScientist.cli.commands import _serve_ensure_proactive_cron
+
+    fake = _patch_cron_client(monkeypatch, existing=[{"cron_id": "p-1"}])
+    _serve_ensure_proactive_cron(_proactive_cfg())
+    fake.crons.create.assert_not_called()
+
+
+def test_ensure_proactive_cron_noop_when_disabled_or_local(monkeypatch):
+    from EvoScientist.cli.commands import _serve_ensure_proactive_cron
+
+    fake = _patch_cron_client(monkeypatch, existing=[])
+    _serve_ensure_proactive_cron(_proactive_cfg(proactive_enabled=False))
+    _serve_ensure_proactive_cron(_proactive_cfg(gateway_backend="local"))
+    fake.crons.search.assert_not_called()
+    fake.crons.create.assert_not_called()
+
+
+def test_ensure_proactive_cron_failure_is_logged_not_raised(monkeypatch, caplog):
+    from EvoScientist.cli.commands import _serve_ensure_proactive_cron
+
+    fake = _patch_cron_client(monkeypatch, existing=[])
+    fake.crons.search.side_effect = RuntimeError("server down")
+    with caplog.at_level("WARNING", logger="EvoScientist.cli.commands"):
+        _serve_ensure_proactive_cron(_proactive_cfg())
+    assert any("registration failed" in r.message for r in caplog.records)

--- a/tests/test_proactive_serve_delivery.py
+++ b/tests/test_proactive_serve_delivery.py
@@ -1,8 +1,8 @@
 """Tests for the serve-side proactive wiring.
 
 Covers the seams added to wire ``proactive.delivery_watcher`` into serve: the
-channel-origins accessor, the server-backend gate, the marker stamp, the
-delivery poll composition, and the cron auto-registration. The watcher's own
+channel-origins accessor, the server-backend gate, the turn metadata marker,
+the delivery poll composition, and the cron auto-registration. The watcher's own
 logic is tested in
 test_proactive_delivery_watcher.py; here we test the serve glue with fakes (no
 server, no model, no bus).
@@ -127,18 +127,28 @@ def test_server_client_present_on_server_backend():
     assert commands._serve_server_client(_runtime_state(client=client)) is client
 
 
-# ---- marker stamp -------------------------------------------------------------
+# ---- turn metadata marker -----------------------------------------------------
 
 
-def test_stamp_marker_noop_on_local():
-    # No client → no crash, no call.
-    commands._serve_stamp_channel_marker(_runtime_state(client=None))
+def test_turn_metadata_carries_marker_when_proactive_on_server():
+    meta = commands._serve_turn_metadata(
+        _runtime_state(client=_FakeClient()), "/ws", "m"
+    )
+    assert meta["has_channel_origin"] is True
+    assert meta["workspace_dir"] == "/ws"
+    assert meta["model"] == "m"
 
 
-def test_stamp_marker_calls_update_on_server():
-    client = _FakeClient()
-    commands._serve_stamp_channel_marker(_runtime_state(client=client, thread_id="t1"))
-    assert client.threads.updated == [("t1", {"has_channel_origin": True})]
+def test_turn_metadata_plain_when_proactive_disabled_or_local():
+    for cfg in (
+        _proactive_cfg(proactive_enabled=False),
+        _proactive_cfg(gateway_backend="local"),
+    ):
+        meta = commands._serve_turn_metadata(
+            _runtime_state(client=_FakeClient(), config=cfg), "/ws", "m"
+        )
+        assert "has_channel_origin" not in meta
+        assert meta["workspace_dir"] == "/ws"
 
 
 # ---- delivery poll ------------------------------------------------------------
@@ -241,17 +251,6 @@ def test_serve_proactive_enabled_requires_both_flag_and_server_backend():
     assert _serve_proactive_enabled(_proactive_cfg(proactive_enabled=False)) is False
     assert _serve_proactive_enabled(_proactive_cfg(gateway_backend="local")) is False
     assert _serve_proactive_enabled(None) is False
-
-
-def test_stamp_marker_skipped_when_proactive_disabled():
-    from EvoScientist.cli.commands import _serve_stamp_channel_marker
-
-    client = _FakeClient()
-    state = _runtime_state(
-        client=client, config=_proactive_cfg(proactive_enabled=False)
-    )
-    _serve_stamp_channel_marker(state)
-    assert client.threads.updated == []
 
 
 def _patch_cron_client(monkeypatch, existing):

--- a/tests/test_proactive_serve_delivery.py
+++ b/tests/test_proactive_serve_delivery.py
@@ -304,3 +304,24 @@ def test_ensure_proactive_cron_failure_is_logged_not_raised(monkeypatch, caplog)
     with caplog.at_level("WARNING", logger="EvoScientist.cli.commands"):
         _serve_ensure_proactive_cron(_proactive_cfg())
     assert any("registration failed" in r.message for r in caplog.records)
+
+
+def test_ensure_proactive_cron_reenables_a_disabled_one(monkeypatch):
+    from EvoScientist.cli.commands import _serve_ensure_proactive_cron
+
+    fake = _patch_cron_client(
+        monkeypatch, existing=[{"cron_id": "p-1", "enabled": False}]
+    )
+    _serve_ensure_proactive_cron(_proactive_cfg())
+    fake.crons.update.assert_called_once_with("p-1", enabled=True)
+    fake.crons.create_for_thread.assert_not_called()
+
+
+def test_ensure_proactive_cron_leaves_an_enabled_one_alone(monkeypatch):
+    from EvoScientist.cli.commands import _serve_ensure_proactive_cron
+
+    fake = _patch_cron_client(
+        monkeypatch, existing=[{"cron_id": "p-1", "enabled": True}]
+    )
+    _serve_ensure_proactive_cron(_proactive_cfg())
+    fake.crons.update.assert_not_called()

--- a/tests/test_proactive_service.py
+++ b/tests/test_proactive_service.py
@@ -6,6 +6,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 
 import httpx
+import pytest
 from langgraph_sdk.errors import ConflictError
 
 from EvoScientist.proactive.commit import NO_PUSH_SENTINEL
@@ -173,17 +174,32 @@ class _ConflictDeliverer:
         return True
 
 
-def test_conflict_then_succeeds_delivers():
+@pytest.fixture
+def no_conflict_backoff(monkeypatch):
+    """Keep the conflict tests fast; the real backoff sleeps 1s/2s/4s."""
+    import EvoScientist.proactive.service as service_mod
+
+    async def _instant(attempt):
+        _instant.calls.append(attempt)
+
+    _instant.calls = []
+    monkeypatch.setattr(service_mod, "_conflict_backoff", _instant)
+    return _instant
+
+
+def test_conflict_then_succeeds_delivers(no_conflict_backoff):
     d = _ConflictDeliverer(fail=1)
     result, _, _ = _run(_deliverer=d)
+    assert no_conflict_backoff.calls == [0]  # one deferred retry
     assert result.stage == "delivered"
     assert result.delivered is True
     assert d.calls == 2
 
 
-def test_conflict_exhausted_recorded():
+def test_conflict_exhausted_recorded(no_conflict_backoff):
     d = _ConflictDeliverer(fail=99)
     result, _, _ = _run(_deliverer=d)
+    assert no_conflict_backoff.calls == [0, 1, 2, 3]
     assert result.stage == "conflict_exhausted"
     assert result.reason == "retries_exhausted"
     assert d.calls == 4  # max_retries + 1
@@ -445,3 +461,17 @@ def test_read_source_missing_values_yields_empty_messages():
     src = asyncio.run(make_read_source(_FakeStateClient({"checkpoint_id": "c"}))("t1"))
     assert src.messages == []
     assert src.pre_head == "c"
+
+
+def test_conflict_backoff_grows_and_caps(monkeypatch):
+    import EvoScientist.proactive.service as service_mod
+
+    slept = []
+
+    async def _fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(service_mod.asyncio, "sleep", _fake_sleep)
+    for attempt in range(5):
+        asyncio.run(service_mod._conflict_backoff(attempt))
+    assert slept == [1, 2, 4, 8, 8]

--- a/tests/test_proactive_service.py
+++ b/tests/test_proactive_service.py
@@ -369,18 +369,70 @@ def test_make_read_source_builds_from_get_state():
     assert src.messages == [{"content": "hi", "type": "human"}]
     assert src.has_origin is True
     assert src.in_flight is False
-    assert src.read_current_head() == "ck-1"
+    assert asyncio.run(src.read_current_head()) == "ck-1"
 
 
-def test_read_current_head_returns_captured_head_without_io():
-    # read_current_head is a sync callable on the event loop, so it does NO I/O:
-    # it returns the head captured at read time and never re-fetches.
-    client = _FakeStateClient({"checkpoint_id": "ck-1", "values": {"messages": []}})
+def test_read_current_head_refetches_the_head():
+    """The pre-commit stale check must see a head that moved while the shadow ran
+    (a user turn or a concurrent tick's push), so it re-fetches instead of
+    returning the captured value."""
+    heads = iter(["ck-1", "ck-1", "ck-2"])
+    client = _FakeStateClient(
+        lambda: {"checkpoint_id": next(heads), "values": {"messages": []}}
+    )
     src = asyncio.run(make_read_source(client)("t1"))
-    before = len(client.threads.calls)
-    assert src.read_current_head() == "ck-1"
-    assert src.read_current_head() == "ck-1"
-    assert len(client.threads.calls) == before  # no extra get_state calls
+    assert src.pre_head == "ck-1"
+    assert asyncio.run(src.read_current_head()) == "ck-1"
+    assert asyncio.run(src.read_current_head()) == "ck-2"
+    assert len(client.threads.calls) == 3
+
+
+def test_check_discards_push_when_head_moved_during_shadow():
+    """Server path end-to-end: the head moves between the read and the commit →
+    stale, nothing delivered (covers a user turn or an overlapping tick)."""
+    from EvoScientist.proactive.gate import ProactiveGateSettings
+
+    heads = iter(["ck-1", "ck-2", "ck-2", "ck-2"])
+    client = _FakeStateClient(
+        lambda: {"checkpoint_id": next(heads), "values": {"messages": []}}
+    )
+    src = asyncio.run(make_read_source(client)("t1"))
+
+    class _Deliverer:
+        calls = 0
+
+        async def deliver(self, *a, **k):
+            self.calls += 1
+            return True
+
+    deliverer = _Deliverer()
+
+    async def _shadow(messages, trigger):
+        return "push text"
+
+    result = asyncio.run(
+        run_proactive_check(
+            settings=ProactiveGateSettings(
+                enabled=True, idle_minutes=0, quiet_hours=None, timezone="UTC"
+            ),
+            source_thread_id="t1",
+            now=datetime.now(UTC),
+            last_activity=datetime.now(UTC) - timedelta(hours=1),
+            pre_head=src.pre_head,
+            has_origin=True,
+            in_flight=False,
+            source_messages=src.messages,
+            shadow_runner=_shadow,
+            read_current_head=src.read_current_head,
+            deliverer=deliverer,
+            trigger="t",
+            workspace_dir=None,
+            model=None,
+            proactive_id="p1",
+        )
+    )
+    assert result.stage == "stale"
+    assert deliverer.calls == 0
 
 
 def test_read_source_checkpoint_id_falls_back_to_nested():

--- a/tests/test_proactive_service.py
+++ b/tests/test_proactive_service.py
@@ -1,0 +1,395 @@
+"""Tests for EvoScientist.proactive.service (the check orchestrator)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import httpx
+from langgraph_sdk.errors import ConflictError
+
+from EvoScientist.proactive.commit import NO_PUSH_SENTINEL
+from EvoScientist.proactive.gate import ProactiveGateSettings
+from EvoScientist.proactive.service import (
+    SourceRead,
+    make_read_source,
+    run_proactive_check,
+    run_proactive_scan,
+    run_proactive_tick,
+)
+
+_NOON = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+
+
+def _settings(**over):
+    base = {
+        "enabled": True,
+        "idle_minutes": 120,
+        "quiet_hours": None,
+        "timezone": "UTC",
+    }
+    base.update(over)
+    return ProactiveGateSettings(**base)
+
+
+class _FakeDeliverer:
+    def __init__(self, result=True):
+        self.calls = []
+        self._result = result
+
+    async def deliver(
+        self, source_thread_id, reply, proactive_id, *, source_messages=None
+    ):
+        self.calls.append((source_thread_id, reply, proactive_id))
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+def _run(**over):
+    shadow_calls = []
+    reply = over.pop("_reply", "Hey, want to pick this up?")
+
+    async def _shadow(messages, trigger):
+        shadow_calls.append((messages, trigger))
+        return reply
+
+    deliverer = over.pop("_deliverer", None) or _FakeDeliverer()
+    head_seq = over.pop("_current_head", "h1")
+
+    kwargs = {
+        "settings": over.pop("settings", _settings()),
+        "source_thread_id": "src",
+        "now": _NOON,
+        "last_activity": _NOON - timedelta(minutes=180),
+        "pre_head": "h1",
+        "has_origin": True,
+        "in_flight": False,
+        "source_messages": [{"role": "user", "content": "prior"}],
+        "shadow_runner": _shadow,
+        "read_current_head": lambda: head_seq,
+        "deliverer": deliverer,
+        "trigger": "<proactive_trigger>",
+        "workspace_dir": "/ws",
+        "model": "m",
+        "proactive_id": "pid1",
+    }
+    kwargs.update(over)
+    result = asyncio.run(run_proactive_check(**kwargs))
+    return result, deliverer, shadow_calls
+
+
+def test_gate_rejection_short_circuits_before_shadow():
+    result, deliverer, shadow_calls = _run(settings=_settings(enabled=False))
+    assert result.stage == "gate_rejected"
+    assert result.reason == "disabled"
+    assert shadow_calls == []  # no model call
+    assert deliverer.calls == []
+
+
+def test_full_path_delivers():
+    result, deliverer, shadow_calls = _run()
+    assert result.stage == "delivered"
+    assert result.delivered is True
+    assert result.source_thread_id == "src"
+    assert len(shadow_calls) == 1
+    assert deliverer.calls == [("src", "Hey, want to pick this up?", "pid1")]
+
+
+def test_no_push_reply_does_not_deliver():
+    result, deliverer, _ = _run(_reply=NO_PUSH_SENTINEL)
+    assert result.stage == "no_push"
+    assert result.reason == "no_push"
+    assert deliverer.calls == []
+
+
+def test_empty_reply_does_not_deliver():
+    result, deliverer, _ = _run(_reply="")
+    assert result.stage == "no_push"
+    assert deliverer.calls == []
+
+
+def test_none_reply_does_not_deliver():
+    result, deliverer, _ = _run(_reply=None)
+    assert result.stage == "no_push"
+    assert deliverer.calls == []
+
+
+def test_stale_source_does_not_deliver():
+    # current head differs from pre_head → a user turn landed during the shadow.
+    result, deliverer, _ = _run(_current_head="h2")
+    assert result.stage == "stale"
+    assert deliverer.calls == []
+
+
+def test_delivery_failure_recorded():
+    result, _deliverer, _ = _run(_deliverer=_FakeDeliverer(result=False))
+    assert result.stage == "delivery_failed"
+    assert result.reason == "deliver_returned_false"
+
+
+def test_delivery_exception_recorded():
+    result, _, _ = _run(_deliverer=_FakeDeliverer(result=RuntimeError("boom")))
+    assert result.stage == "delivery_failed"
+    assert result.reason == "exception"
+
+
+def test_ledger_records_results():
+    from EvoScientist.proactive.service import get_ledger
+
+    _run()
+    ledger = get_ledger()
+    assert ledger  # at least our result is present
+    assert ledger[-1].stage == "delivered"
+
+
+# ---- ConflictError defer-and-retry wiring ----
+
+
+def _conflict() -> ConflictError:
+    resp = httpx.Response(409, request=httpx.Request("POST", "http://test"))
+    return ConflictError("run in flight", response=resp, body=None)
+
+
+class _ConflictDeliverer:
+    """Raises ConflictError on the first ``fail`` deliver calls, then returns True.
+
+    Contrived — real deliverers never raise ConflictError (only the gateway commit
+    does) — but it drives the service's conflict wiring: a ConflictError from the
+    commit_fn must reach ``commit_with_conflict_retry``'s retry loop, not the outer
+    delivery_failed handler.
+    """
+
+    def __init__(self, fail: int) -> None:
+        self.fail = fail
+        self.calls = 0
+
+    async def deliver(
+        self, source_thread_id, reply, proactive_id, *, source_messages=None
+    ):
+        self.calls += 1
+        if self.calls <= self.fail:
+            raise _conflict()
+        return True
+
+
+def test_conflict_then_succeeds_delivers():
+    d = _ConflictDeliverer(fail=1)
+    result, _, _ = _run(_deliverer=d)
+    assert result.stage == "delivered"
+    assert result.delivered is True
+    assert d.calls == 2
+
+
+def test_conflict_exhausted_recorded():
+    d = _ConflictDeliverer(fail=99)
+    result, _, _ = _run(_deliverer=d)
+    assert result.stage == "conflict_exhausted"
+    assert result.reason == "retries_exhausted"
+    assert d.calls == 4  # max_retries + 1
+
+
+# ---- run_proactive_scan (one cron tick over candidate threads) ----
+
+
+class _FakeSource:
+    def __init__(
+        self,
+        *,
+        pre_head="h1",
+        has_origin=True,
+        in_flight=False,
+        head="h1",
+        raise_for=(),
+    ):
+        self.pre_head = pre_head
+        self.has_origin = has_origin
+        self.in_flight = in_flight
+        self.head = head
+        self.raise_for = set(raise_for)
+        self.reads = []
+
+    async def __call__(self, thread_id):
+        self.reads.append(thread_id)
+        if thread_id in self.raise_for:
+            raise RuntimeError("boom")
+        return SourceRead(
+            messages=[{"role": "user", "content": f"prior for {thread_id}"}],
+            pre_head=self.pre_head,
+            has_origin=self.has_origin,
+            in_flight=self.in_flight,
+            read_current_head=lambda: self.head,
+        )
+
+
+def _scan(candidates, *, source=None, deliverer=None, settings=None, reply="Hey!"):
+    src = source or _FakeSource()
+    dlv = deliverer or _FakeDeliverer()
+
+    async def _shadow(messages, trigger):
+        return reply
+
+    results = asyncio.run(
+        run_proactive_scan(
+            candidates,
+            now=_NOON,
+            settings=settings or _settings(),
+            read_source=src,
+            shadow_runner=_shadow,
+            deliverer=dlv,
+            trigger="<proactive_trigger>",
+            workspace_dir="/ws",
+            model="m",
+        )
+    )
+    return results, src, dlv
+
+
+_IDLE = _NOON - timedelta(minutes=180)  # older than idle_minutes=120
+
+
+def test_scan_empty_candidates_reads_nothing():
+    results, src, dlv = _scan([])
+    assert results == []
+    assert src.reads == []
+    assert dlv.calls == []
+
+
+def test_scan_delivers_per_candidate_with_unique_ids():
+    results, src, dlv = _scan([("t1", _IDLE), ("t2", _IDLE)])
+    assert [r.stage for r in results] == ["delivered", "delivered"]
+    assert src.reads == ["t1", "t2"]
+    assert [c[0] for c in dlv.calls] == ["t1", "t2"]
+    pids = [c[2] for c in dlv.calls]
+    assert len(set(pids)) == 2  # fresh proactive_id per thread
+
+
+def test_scan_threads_last_activity_into_the_gate():
+    # last_activity = now → not idle (idle_minutes=120) → gate_rejected, no deliver
+    results, _, dlv = _scan([("t1", _NOON)])
+    assert results[0].stage == "gate_rejected"
+    assert dlv.calls == []
+
+
+def test_scan_isolates_a_per_candidate_failure():
+    src = _FakeSource(raise_for=("t1",))
+    results, _, dlv = _scan([("t1", _IDLE), ("t2", _IDLE)], source=src)
+    assert results[0].stage == "scan_error"
+    assert results[1].stage == "delivered"  # t2 still processed after t1 raised
+    assert [c[0] for c in dlv.calls] == ["t2"]
+
+
+# ---- run_proactive_tick (enumerate then check — one tick body) ----
+
+
+class _FakeThreadsAPI:
+    def __init__(self, result):
+        self._result = result
+
+    def search(self, **kwargs):
+        async def _co():
+            return self._result
+
+        return _co()
+
+
+class _FakeTickClient:
+    def __init__(self, threads_result):
+        self.threads = _FakeThreadsAPI(threads_result)
+
+
+def _tick(threads_result, *, source=None, deliverer=None):
+    src = source or _FakeSource()
+    dlv = deliverer or _FakeDeliverer()
+
+    async def _shadow(messages, trigger):
+        return "Hey!"
+
+    results = asyncio.run(
+        run_proactive_tick(
+            _FakeTickClient(threads_result),
+            now=_NOON,
+            settings=_settings(),
+            read_source=src,
+            shadow_runner=_shadow,
+            deliverer=dlv,
+            trigger="<proactive_trigger>",
+            workspace_dir="/ws",
+            model="m",
+        )
+    )
+    return results, src, dlv
+
+
+def test_tick_enumerates_then_checks_each_candidate():
+    threads = [
+        {"thread_id": "t1", "updated_at": "2026-08-20T09:00:00+00:00"},  # idle
+        {"thread_id": "t2", "updated_at": "2026-08-20T09:30:00+00:00"},  # idle
+    ]
+    results, src, dlv = _tick(threads)
+    assert [r.stage for r in results] == ["delivered", "delivered"]
+    assert src.reads == ["t1", "t2"]
+    assert [c[0] for c in dlv.calls] == ["t1", "t2"]
+
+
+def test_tick_no_candidates_does_nothing():
+    results, src, dlv = _tick([])
+    assert results == []
+    assert src.reads == []
+    assert dlv.calls == []
+
+
+# ---- make_read_source (server-backed read, real get_state shape) ----
+
+
+class _FakeStateThreads:
+    def __init__(self, state):
+        self._state = state
+        self.calls = []
+
+    def get_state(self, thread_id):
+        self.calls.append(thread_id)
+        return self._state() if callable(self._state) else self._state
+
+
+class _FakeStateClient:
+    def __init__(self, state):
+        self.threads = _FakeStateThreads(state)
+
+
+def test_make_read_source_builds_from_get_state():
+    # shape captured from a live langgraph-dev probe
+    state = {
+        "checkpoint_id": "ck-1",
+        "values": {"messages": [{"content": "hi", "type": "human"}]},
+    }
+    read_source = make_read_source(_FakeStateClient(state))
+    src = asyncio.run(read_source("t1"))
+    assert src.pre_head == "ck-1"
+    assert src.messages == [{"content": "hi", "type": "human"}]
+    assert src.has_origin is True
+    assert src.in_flight is False
+    assert src.read_current_head() == "ck-1"
+
+
+def test_read_current_head_returns_captured_head_without_io():
+    # read_current_head is a sync callable on the event loop, so it does NO I/O:
+    # it returns the head captured at read time and never re-fetches.
+    client = _FakeStateClient({"checkpoint_id": "ck-1", "values": {"messages": []}})
+    src = asyncio.run(make_read_source(client)("t1"))
+    before = len(client.threads.calls)
+    assert src.read_current_head() == "ck-1"
+    assert src.read_current_head() == "ck-1"
+    assert len(client.threads.calls) == before  # no extra get_state calls
+
+
+def test_read_source_checkpoint_id_falls_back_to_nested():
+    state = {"checkpoint": {"checkpoint_id": "ck-9"}, "values": {"messages": []}}
+    src = asyncio.run(make_read_source(_FakeStateClient(state))("t1"))
+    assert src.pre_head == "ck-9"
+
+
+def test_read_source_missing_values_yields_empty_messages():
+    src = asyncio.run(make_read_source(_FakeStateClient({"checkpoint_id": "c"}))("t1"))
+    assert src.messages == []
+    assert src.pre_head == "c"

--- a/tests/test_proactive_shadow.py
+++ b/tests/test_proactive_shadow.py
@@ -1,0 +1,313 @@
+"""Tests for EvoScientist.proactive.shadow (shadow runner + tool-strip spy)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+
+from EvoScientist.proactive.shadow import (
+    ProactiveToolLeakError,
+    _install_tool_strip_spy,
+    _shadow_cfg,
+    run_shadow_turn,
+)
+
+
+def _minimal_shadow_graph(model):
+    """Build a minimal real graph with the strip middleware + spy installed.
+
+    This is deliberately NOT ``build_shadow_graph`` (which routes through
+    ``create_cli_agent`` and its MCP/network load). It composes ``create_deep_agent``
+    directly with a keyless fake model, the real ``ProactiveModeMiddleware``, and a
+    dummy tool — enough to exercise the safety-critical binding path offline.
+    """
+    from deepagents import create_deep_agent
+    from langchain_core.tools import tool
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from EvoScientist.middleware.proactive_mode import ProactiveModeMiddleware
+
+    @tool
+    def dummy_tool(x: str) -> str:
+        """A dummy tool that must never be bound during a proactive turn."""
+        return x
+
+    return create_deep_agent(
+        model=model,
+        tools=[dummy_tool],
+        middleware=[ProactiveModeMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+
+# ---- _shadow_cfg ------------------------------------------------------------
+
+
+def test_shadow_cfg_flips_side_effect_flags_and_keeps_reasoning():
+    from EvoScientist.config.settings import EvoScientistConfig
+
+    cfg = EvoScientistConfig()
+    cfg.model = "sentinel-model"
+    cfg.provider = "sentinel-provider"
+
+    shadow = _shadow_cfg(cfg)
+
+    # side-effect axis off
+    assert shadow.enable_scheduler is False
+    assert shadow.memory_workers_enabled is False
+    assert shadow.enable_ask_user is False
+    assert shadow.auto_approve is True
+    assert shadow.model_fallbacks == ""
+    # reasoning axis intact
+    assert shadow.model == "sentinel-model"
+    assert shadow.provider == "sentinel-provider"
+    # original untouched (replace returns a copy)
+    assert cfg.enable_scheduler is not False or cfg is not shadow
+    assert cfg is not shadow
+
+
+def test_shadow_cfg_gates_out_the_writer_middleware():
+    """The write-side neutering is a gate, not just a flag: pin that the shadow
+    config feeds the exact predicates `_get_default_middleware` uses to DROP the
+    scheduler and memory-worker middleware. Kept surgical (no graph build) to
+    avoid real MEMORIES_DIR writes from constructing the memory middleware."""
+    from EvoScientist.config.settings import (
+        EvoScientistConfig,
+        MemoryControls,
+        MemoryObservationTarget,
+    )
+
+    shadow = _shadow_cfg(EvoScientistConfig())
+
+    # scheduler-middleware gate (EvoScientist.py:996 `if cfg.enable_scheduler ...`)
+    assert shadow.enable_scheduler is False
+    # memory-worker gate (EvoScientist.py:1001 `if memory_controls.worker_needed(...)`)
+    controls = MemoryControls.from_config(shadow)
+    assert controls.worker_needed(MemoryObservationTarget.TURN_WORKER) is False
+    assert controls.worker_needed(MemoryObservationTarget.SUBAGENT_WORKER) is False
+
+
+# ---- tool-strip spy ---------------------------------------------------------
+
+
+def test_spy_raises_on_non_empty_tool_bind():
+    model = FakeListChatModel(responses=["ok"])
+    spy = _install_tool_strip_spy(model)
+    with pytest.raises(ProactiveToolLeakError, match="record_observation"):
+        spy.bind_tools([{"name": "record_observation"}])
+
+
+def test_spy_preserves_isinstance_and_identity():
+    model = FakeListChatModel(responses=["ok"])
+    spy = _install_tool_strip_spy(model)
+    assert spy is model  # installed in place
+    assert isinstance(spy, FakeListChatModel)  # subclass, original type preserved
+    assert type(spy).__name__.startswith("ToolStripSpy_")
+
+
+# ---- run_shadow_turn --------------------------------------------------------
+
+
+class _FakeGraph:
+    """Graph stand-in exposing the methods run_shadow_turn touches."""
+
+    def __init__(self, last_message=None):
+        self.updates = []
+        self.checkpointer = MagicMock()
+        self.checkpointer.adelete_thread = AsyncMock()
+        self.last_message = last_message
+
+    async def aupdate_state(self, config, values, as_node=None):
+        self.updates.append((config, values))
+
+    async def aget_state(self, config):
+        msgs = [self.last_message] if self.last_message is not None else []
+        return SimpleNamespace(values={"messages": msgs})
+
+
+def _patch_stream(events=None, raise_exc=None):
+    """Patch stream_agent_events with an async generator, capturing its args."""
+    captured = {}
+
+    def _factory(agent, message, thread_id, *, configurable_extra=None, **kw):
+        captured["message"] = message
+        captured["thread_id"] = thread_id
+        captured["configurable_extra"] = configurable_extra
+
+        async def _gen():
+            for ev in events or []:
+                yield ev
+            if raise_exc is not None:
+                raise raise_exc
+
+        return _gen()
+
+    return patch(
+        "EvoScientist.stream.events.stream_agent_events", side_effect=_factory
+    ), captured
+
+
+def test_run_shadow_turn_returns_terminal_done_text():
+    graph = _FakeGraph()
+    msgs = [{"role": "user", "content": "prior message"}]
+    events = [
+        {"type": "text", "content": "hel"},
+        {"type": "text", "content": "lo"},
+        {"type": "done", "content": "hello"},
+    ]
+    patcher, captured = _patch_stream(events=events)
+    with patcher:
+        result = asyncio.run(run_shadow_turn(graph, msgs, "<proactive_trigger>"))
+
+    assert result == "hello"
+    # seeded history under the messages channel
+    assert graph.updates
+    assert graph.updates[0][1] == {"messages": msgs}
+    # proactive_mode carried into the run config
+    assert captured["configurable_extra"] == {"proactive_mode": True}
+    assert captured["message"] == "<proactive_trigger>"
+    # shadow thread cleaned up
+    graph.checkpointer.adelete_thread.assert_awaited_once()
+
+
+def test_run_shadow_turn_falls_back_to_text_when_done_empty():
+    graph = _FakeGraph()
+    events = [
+        {"type": "text", "content": "streamed "},
+        {"type": "text", "content": "answer"},
+        {"type": "done", "content": ""},
+    ]
+    patcher, _ = _patch_stream(events=events)
+    with patcher:
+        result = asyncio.run(run_shadow_turn(graph, [], "t"))
+    assert result == "streamed answer"
+
+
+def test_run_shadow_turn_returns_none_on_tool_leak():
+    graph = _FakeGraph()
+    patcher, _ = _patch_stream(
+        events=[{"type": "text", "content": "partial"}],
+        raise_exc=ProactiveToolLeakError("bound 1 tool(s)"),
+    )
+    with patcher:
+        result = asyncio.run(run_shadow_turn(graph, [], "t"))
+    assert result is None
+    # cleanup still runs on the abort path
+    graph.checkpointer.adelete_thread.assert_awaited_once()
+
+
+def test_run_shadow_turn_returns_none_on_generic_error():
+    graph = _FakeGraph()
+    patcher, _ = _patch_stream(raise_exc=RuntimeError("provider blew up"))
+    with patcher:
+        result = asyncio.run(run_shadow_turn(graph, [], "t"))
+    assert result is None
+    graph.checkpointer.adelete_thread.assert_awaited_once()
+
+
+# ---- spy on the real binding path (no network) ------------------------------
+# These prove the two safety claims the pure-unit tests above cannot: that the
+# spy is actually the object langchain binds against, and that proactive_mode
+# genuinely zeroes tools end-to-end through a composed graph. The full
+# create_cli_agent path (MCP/network) stays deferred; this covers the interlock.
+
+
+def test_proactive_turn_binds_zero_tools_and_spy_stays_silent():
+    """proactive_mode=True → tools stripped → model.bind (not bind_tools) → the
+    turn completes and the spy never fires."""
+    model = _install_tool_strip_spy(FakeListChatModel(responses=["I decide: NO_PUSH"]))
+    graph = _minimal_shadow_graph(model)
+    out = graph.invoke(
+        {"messages": [{"role": "user", "content": "hi"}]},
+        config={"configurable": {"thread_id": "t-proactive", "proactive_mode": True}},
+    )
+    assert out["messages"][-1].content == "I decide: NO_PUSH"
+
+
+def test_spy_fires_when_strip_absent_proving_it_is_on_the_binding_path():
+    """Without proactive_mode the graph binds its tools, so the spy MUST fire —
+    which is the proof that the spy sits on the real model-binding path (a bug
+    that moved it off-path would let this pass silently)."""
+    model = _install_tool_strip_spy(FakeListChatModel(responses=["unused"]))
+    graph = _minimal_shadow_graph(model)
+    with pytest.raises(ProactiveToolLeakError, match="dummy_tool"):
+        graph.invoke(
+            {"messages": [{"role": "user", "content": "hi"}]},
+            config={"configurable": {"thread_id": "t-leak"}},
+        )
+
+
+def test_run_shadow_turn_logs_raw_message_when_reply_is_empty(caplog):
+    """An empty reply is the one outcome the caller cannot explain (NO_PUSH is
+    literal text), so the raw last message is logged before the thread is deleted."""
+    import logging
+
+    from langchain_core.messages import AIMessage
+
+    graph = _FakeGraph(
+        last_message=AIMessage(
+            content="",
+            additional_kwargs={"reasoning_content": "thought about it"},
+            response_metadata={"finish_reason": "stop"},
+        )
+    )
+    patcher, _ = _patch_stream(events=[{"type": "done", "content": ""}])
+    with patcher, caplog.at_level(logging.INFO, logger="EvoScientist.proactive.shadow"):
+        result = asyncio.run(run_shadow_turn(graph, [], "t"))
+
+    assert result == ""
+    hits = [r.message for r in caplog.records if "returned no text" in r.message]
+    assert len(hits) == 1
+    assert "thought about it" in hits[0]
+    assert "finish_reason" in hits[0]
+    graph.checkpointer.adelete_thread.assert_awaited_once()
+
+
+def test_run_shadow_turn_does_not_log_empty_diagnostic_when_text_present(caplog):
+    import logging
+
+    graph = _FakeGraph()
+    patcher, _ = _patch_stream(events=[{"type": "done", "content": "NO_PUSH"}])
+    with patcher, caplog.at_level(logging.INFO, logger="EvoScientist.proactive.shadow"):
+        asyncio.run(run_shadow_turn(graph, [], "t"))
+    assert not [r for r in caplog.records if "returned no text" in r.message]
+
+
+def test_run_shadow_turn_discards_non_clean_finish(caplog):
+    """A truncated or errored generation is never a message to send: the text is
+    dropped (None → fail-closed) even though the stream produced some."""
+    import logging
+
+    from langchain_core.messages import AIMessage
+
+    for reason in ("length", "error", "content_filter"):
+        graph = _FakeGraph(
+            last_message=AIMessage(
+                content="partial", response_metadata={"finish_reason": reason}
+            )
+        )
+        patcher, _ = _patch_stream(events=[{"type": "done", "content": "partial"}])
+        with (
+            patcher,
+            caplog.at_level(logging.WARNING, logger="EvoScientist.proactive.shadow"),
+        ):
+            result = asyncio.run(run_shadow_turn(graph, [], "t"))
+        assert result is None, reason
+        assert any(reason in r.message for r in caplog.records)
+        graph.checkpointer.adelete_thread.assert_awaited_once()
+
+
+def test_run_shadow_turn_keeps_text_on_clean_or_absent_finish():
+    from langchain_core.messages import AIMessage
+
+    for metadata in ({"finish_reason": "stop"}, {}, None):
+        graph = _FakeGraph(
+            last_message=AIMessage(content="msg", response_metadata=metadata or {})
+        )
+        patcher, _ = _patch_stream(events=[{"type": "done", "content": "msg"}])
+        with patcher:
+            assert asyncio.run(run_shadow_turn(graph, [], "t")) == "msg"

--- a/tests/test_proactive_shadow.py
+++ b/tests/test_proactive_shadow.py
@@ -60,6 +60,7 @@ def test_shadow_cfg_flips_side_effect_flags_and_keeps_reasoning():
     assert shadow.enable_scheduler is False
     assert shadow.memory_workers_enabled is False
     assert shadow.enable_ask_user is False
+    assert shadow.auto_mode is True
     assert shadow.auto_approve is True
     assert shadow.model_fallbacks == ""
     # reasoning axis intact
@@ -89,6 +90,10 @@ def test_shadow_cfg_gates_out_the_writer_middleware():
     controls = MemoryControls.from_config(shadow)
     assert controls.worker_needed(MemoryObservationTarget.TURN_WORKER) is False
     assert controls.worker_needed(MemoryObservationTarget.SUBAGENT_WORKER) is False
+    # first-contact profile bootstrap gate (EvoScientist.py
+    # `enable_profile_bootstrap=not for_async_subagent and not bool(cfg.auto_mode)`):
+    # a shadow turn must never ask the consent survey or write intro bookkeeping.
+    assert (not False and not bool(shadow.auto_mode)) is False
 
 
 # ---- tool-strip spy ---------------------------------------------------------

--- a/tests/test_proactive_shadow.py
+++ b/tests/test_proactive_shadow.py
@@ -267,8 +267,11 @@ def test_run_shadow_turn_logs_raw_message_when_reply_is_empty(caplog):
     assert result == ""
     hits = [r.message for r in caplog.records if "returned no text" in r.message]
     assert len(hits) == 1
-    assert "thought about it" in hits[0]
-    assert "finish_reason" in hits[0]
+    # shape only: no raw content or reasoning text reaches the log
+    assert "thought about it" not in hits[0]
+    assert "reasoning_content" in hits[0]  # key name is fine, value is not
+    assert "finish_reason=stop" in hits[0]
+    assert "content_chars=0" in hits[0]
     graph.checkpointer.adelete_thread.assert_awaited_once()
 
 

--- a/tests/test_profile_memory_middleware.py
+++ b/tests/test_profile_memory_middleware.py
@@ -1426,3 +1426,47 @@ def test_sync_subagent_site_does_not_pass_profile_bootstrap(tmp_path, monkeypatc
         m for m in sub["middleware"] if isinstance(m, memory_module.EvoMemoryMiddleware)
     )
     assert instance._enable_profile_bootstrap is False
+
+
+# ---- tool-less requests get no memory tool directives ------------------------
+
+
+def _request_with_tools(tools):
+    request = _request()
+    request.tools = tools
+    return request
+
+
+def test_tool_less_request_gets_no_memory_tool_directives(tmp_path, monkeypatch):
+    """A request with an empty tool list (a proactive shadow turn) must not be
+    told to run the memory preflight or record observations: with no tools the
+    model acts those directives out as text instead of answering."""
+    memories = tmp_path / "memories"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(paths, "WORKSPACE_ROOT", workspace)
+    middleware = memory_module.create_memory_middleware(str(memories))
+
+    with_tools = _system(middleware.modify_request(_request_with_tools([object()])))
+    without = _system(middleware.modify_request(_request_with_tools([])))
+
+    assert "Required memory preflight" in with_tools
+    assert "search_observations" in with_tools
+    assert "Required memory preflight" not in without
+    assert "search_observations" not in without
+    assert "record_observation" not in without
+    assert "No memory tools are available on this turn" in without
+    # the observation memory location + index still reach the tool-less turn
+    assert "/memories/observations/" in without
+
+
+def test_request_without_tools_attribute_keeps_directives(tmp_path, monkeypatch):
+    """Only an explicit empty tool list selects the tool-less variant."""
+    memories = tmp_path / "memories"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(paths, "WORKSPACE_ROOT", workspace)
+    middleware = memory_module.create_memory_middleware(str(memories))
+
+    system = _system(middleware.modify_request(_request()))
+    assert "Required memory preflight" in system

--- a/tests/test_profile_memory_middleware.py
+++ b/tests/test_profile_memory_middleware.py
@@ -371,7 +371,7 @@ def test_construction_defers_observation_index_read_to_first_request(
 
     # Construction must not read the observation store ...
     assert calls == []
-    assert middleware._observation_index_context == ""
+    assert middleware._observation_index_contexts == {}
     # ... but must still create the cross-project search dir it prompts agents
     # to look in.
     assert (memories / "observations" / "global").is_dir()
@@ -1458,6 +1458,39 @@ def test_tool_less_request_gets_no_memory_tool_directives(tmp_path, monkeypatch)
     assert "No memory tools are available on this turn" in without
     # the observation memory location + index still reach the tool-less turn
     assert "/memories/observations/" in without
+    # profile guidance is read-only on a tool-less call (no "edit the file" directives)
+    assert "Read the relevant file before editing it" in with_tools
+    assert "Read the relevant file before editing it" not in without
+    assert "edit the relevant" not in without
+    assert "/memories/profile/USER_PROFILE.md" in without
+
+
+def test_index_fallback_cache_is_per_variant(tmp_path, monkeypatch):
+    """A refresh failure must not hand a tool-less request the cached
+    search-hints footer from an earlier request that had tools."""
+    memories = tmp_path / "memories"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(paths, "WORKSPACE_ROOT", workspace)
+    middleware = memory_module.create_memory_middleware(str(memories))
+
+    with_hints = middleware._refresh_observation_index_context(
+        include_search_hints=True
+    )
+    assert "Search hints:" in with_hints
+
+    def _boom(**_kw):
+        raise OSError("store unreadable")
+
+    monkeypatch.setattr(memory_module, "build_observation_index_context", _boom)
+    fallback_no_hints = middleware._refresh_observation_index_context(
+        include_search_hints=False
+    )
+    fallback_hints = middleware._refresh_observation_index_context(
+        include_search_hints=True
+    )
+    assert "Search hints:" not in fallback_no_hints
+    assert fallback_hints == with_hints
 
 
 def test_request_without_tools_attribute_keeps_directives(tmp_path, monkeypatch):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2268,6 +2268,7 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.IsolatedAsyncioTestCase):
         model: str | None = "test-model",
         agent_name: str | None = "EvoScientist",
         ckpt_prefix: str = "ckpt",
+        has_channel_origin: bool = False,
     ) -> None:
         """Insert minimal checkpoint rows for the given thread_ids into a fresh DB."""
         import json
@@ -2291,6 +2292,8 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.IsolatedAsyncioTestCase):
                 meta_dict["workspace_dir"] = workspace_dir
             if model is not None:
                 meta_dict["model"] = model
+            if has_channel_origin:
+                meta_dict["has_channel_origin"] = True
             meta = json.dumps(meta_dict)
             con.execute(
                 "INSERT INTO checkpoints VALUES (?,?,?,?,?,?,?)",
@@ -2303,6 +2306,47 @@ class TestRestoreWebuiThreadsToGlobalStore(unittest.IsolatedAsyncioTestCase):
         from unittest.mock import patch
 
         return patch("EvoScientist.sessions._api_workspace_dir", return_value=self._WS)
+
+    async def test_restore_carries_channel_origin_marker(self):
+        """A thread whose checkpoint rows carry ``has_channel_origin`` is restored
+        with the marker in its registry metadata (so the proactive cron's
+        ``threads.search(metadata={"has_channel_origin": True})`` finds it after a
+        restart); a thread without it gets no marker."""
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        from EvoScientist.sessions import _restore_webui_threads_to_global_store
+
+        marked = "12345678-1234-1234-1234-123456789abc"
+        plain = "22345678-1234-1234-1234-123456789abc"
+
+        mock_store: dict = {"threads": []}
+        mock_global_store = MagicMock()
+        mock_global_store.get.side_effect = mock_store.get
+        mock_global_store.__getitem__ = lambda self, k: mock_store[k]
+        mock_global_store.__setitem__ = lambda self, k, v: mock_store.__setitem__(k, v)
+        fake_module = MagicMock()
+        fake_module.GLOBAL_STORE = mock_global_store
+
+        with tempfile.TemporaryDirectory() as td:
+            db = os.path.join(td, "sessions.db")
+            self._make_db_with_threads(db, [marked], has_channel_origin=True)
+            self._make_db_with_threads(db, [plain], ckpt_prefix="plain")
+            with (
+                patch(
+                    "EvoScientist.sessions.get_db_path",
+                    return_value=_mock_path(db),
+                ),
+                patch.dict(
+                    sys.modules, {"langgraph_runtime_inmem.database": fake_module}
+                ),
+                self._patch_workspace(),
+            ):
+                await _restore_webui_threads_to_global_store()
+
+        by_id = {str(t["thread_id"]): t for t in mock_store["threads"]}
+        assert by_id[marked]["metadata"]["has_channel_origin"] is True
+        assert "has_channel_origin" not in by_id[plain]["metadata"]
 
     async def test_restores_uuid_threads_into_global_store(self):
         """UUID-format thread IDs from SQLite are injected into GlobalStore."""


### PR DESCRIPTION
feat: proactive research pushes (issue #263 MVP) - draft PoC

## What this is

A working proof of concept of the proactive research MVP from #263, built directly on `main` so it can be tried now, without waiting for the server-gateway migration (#432) to complete. Of that migration only Stages 1-2 are coded (the #434-#444 stack, still in review); Stages 3-6 (dev-server lifecycle, read-path strategy, per-surface cutover, proactive integration) are unwritten and several of their shapes are still under discussion on #432. The goal here is to show how a proactive push looks end to end and to confirm the design choices below, not to merge as-is. Marked draft on purpose.

Mapping to the MVP:

1. Reuse cron, every 10 minutes: `proactive/cron.py` registers a `*/10 * * * *` cron on a dedicated `proactive` graph (`langgraph.json`), auto-registered by `serve` when enabled.
2. Three eligibility checks: `proactive/gate.py` (quiet hours in the configured timezone, idle threshold) plus a server-side `status="idle"` filter in `proactive/eligibility.py`.
3. Shadow turn with the internal instruction, no tools, no questions: messages are read from the source thread and seeded into an in-memory shadow graph; the canonical `<proactive_trigger>` is sent; `ProactiveModeMiddleware` strips every tool and a spy raises if one is ever bound.
4. Temp thread deleted: the in-memory shadow thread is dropped after every turn.
5. Only the resulting `AIMessage` is appended to the original thread, tagged `additional_kwargs.evoscientist.is_proactive_push` with a `proactive_id` and a stable message id.
6. Delivery reuses `publish_to_channel_origin` and the MessageBus: `serve` polls committed pushes every 20 s and publishes them to the thread's channel origin.

## Choices made because the migration is incomplete

Each of these is a deliberate stand-in for a migration stage that has not landed or is still open on #432. They are the things to confirm or overturn.

- Serve-only cutover behind a flag, instead of the full per-surface cutover (Stage 5). `gateway_backend=langgraph_server` routes only `serve` through the dev server, which is enough for the cron to see server-born threads. @din0s agreed on #432 that serve-first is acceptable; the other surfaces stay on the local gateway.
- No full-mode dev server (Stage 2, #438). While the flag is on, interactive serve turns run against the stripped server with no MCP tools. The proactive shadow does not need tools, so the cron is unaffected; interactive turns are the cost until #438 lands. The `gateway_backend` field here has the same name as #438's and is dropped on rebase.
- Server-guarded commit through the gateway (`update_state_values` widened with `as_node` and metadata, two commits cherry-picked from the migration work) rather than the bus-event shape @din0s sketched on #432, where the cron only emits a result and serve applies it to the thread in-process. This PoC keeps the commit in the cron because it is the literal MVP step 5, it was the path already validated live, and the write concurrency was probed (WAL plus busy timeout, no lock errors). The bus-event shape removes the 409 handling and the busy-thread guard and is the main open question; the service layer is written so the deliverer can be swapped without touching gate, shadow, or decision.
- Channel marker persisted through run metadata plus the registry restore, instead of waiting for the read-path work (Stage 4). @din0s pointed out on #432 that `threads.update` metadata does not survive a dev-server restart because the registry is rebuilt from checkpoint metadata. Serve therefore sends the marker as run metadata, the checkpointer persists it, and `sessions.py` restores it into the registry. Enumerating from the server registry also keeps pre-migration and legacy-id threads out of the cron by construction, which is what makes Stage 4 deferrable.
- Delivery via a serve-side poll with an in-memory seen-set, instead of a persisted outbox and origin registry (Stage 6). Delivery runs in the process that already holds the channel origins; restart recovery of routes is MVP out of scope.
- No dev-server watchdog (Stage 3). The cron fires inside langgraph-dev and dies with it; serve already ensures the dev server at startup, and always-on supervision is the OS-service question in #413.
- Concurrency without a lease: ticks are serialized by pinning the cron to one thread with `multitask_strategy="reject"`, and the source head is re-read right before the commit. That covers overlapping ticks and a user turn landing during the shadow without a new table or lock.

## Other design choices to confirm

- Commit into the originating thread (MVP step 5) rather than one thread per proactive round, as raised by @din0s on #432. This PoC does the former so the user's next reply has the push in context; the alternative is simpler to serialize and is worth a decision on #263.
- No thread clone: an in-memory shadow seeded from `get_state` is functionally equivalent and never touches the source thread.
- Memory tool directives (the observation preflight, record instructions, index search hints) are not injected on model calls that carry no tools. This was the root cause of models narrating tool sessions as text in the shadow and applies to any tool-less call.

## Setup

Config fields (also as env vars):

- `proactive_enabled` / `EVOSCIENTIST_PROACTIVE_ENABLED` (default off)
- `proactive_idle_minutes` / `EVOSCIENTIST_PROACTIVE_IDLE_MINUTES` (default 120)
- `proactive_quiet_hours` / `EVOSCIENTIST_PROACTIVE_QUIET_HOURS` (default `22:00-08:00`, empty disables)
- `proactive_timezone` / `EVOSCIENTIST_PROACTIVE_TIMEZONE` (empty = host zone)
- `gateway_backend` / `EVOSCIENTIST_GATEWAY_BACKEND` (`local` default; `langgraph_server` makes serve's threads server-born, required for the cron to see them)

The shadow uses the configured model (`/model <name> --save` or `config.yaml`); config changes are picked up on the next tick, no restart needed. A configured channel is needed for the final delivery hop.

## Usage

Full path (channel + cron + delivery):

```
EVOSCIENTIST_GATEWAY_BACKEND=langgraph_server EVOSCIENTIST_PROACTIVE_ENABLED=1 EvoSci serve
```

Serve registers the cron once, marks every channel thread, and publishes committed pushes back to the channel. Lower `EVOSCIENTIST_PROACTIVE_IDLE_MINUTES` and clear `EVOSCIENTIST_PROACTIVE_QUIET_HOURS` to test without waiting.

Tick-only path (no channel):

```
EVOSCIENTIST_PROACTIVE_ENABLED=1 EVOSCIENTIST_PROACTIVE_IDLE_MINUTES=0 EVOSCIENTIST_PROACTIVE_QUIET_HOURS= EvoSci
```

Then mark an idle server-registered thread with metadata `{"has_channel_origin": true}` over the SDK and run the `proactive` graph once (`runs.wait(None, "proactive", input={})`). The run result lists every checked thread with `stage`, `reason`, and a reply preview; a delivered push is visible in the source thread's state. Note that `EvoSci` reuses an already running langgraph-dev, so kill it first when changing code or env.

## Validated live

- Ticks running inside langgraph-dev: enumerate marked idle threads, gate, tool-stripped shadow (real model call, no tool bound), decision, gateway commit into the source thread, thread back to idle.
- Real pushes delivered with `glm-5.3` on a seeded benchmark thread (a requested comparison table) and on a real ideation thread.
- Serve delivery poll up to the publish attempt against a real committed push, with retry when no bus is present.
- Overlapping tick rejected by the server on the pinned cron thread.

## Caveats

- Push quality is model-dependent. `gemini-3-flash-preview` over OpenRouter returned empty completions, an error finish, and long tool narration in this setup; `glm-5.3` produced real messages once the memory directives were gated.
- The shadow runs the full main-agent system prompt. Guards discard replies that are not a clean finish, exceed 4000 characters, or contain a textual tool-call envelope, so tool-heavy threads may yield `no_push` rather than a message.
- ~~The first-contact profile bootstrap from #450 fires inside shadow turns on a fresh profile; set `intro: skipped` in the profile frontmatter. It still bumps the profile's session counter per shadow turn.~~
-  Shadow turns run with `auto_mode` on, which disables the first-contact profile bootstrap from #450 (it would otherwise ask a consent question and write session bookkeeping into the real profile from every shadow). Shadow turns never write profile or observation files.
- While `gateway_backend=langgraph_server` is on, interactive serve turns run against the stripped dev server (no MCP tools) until #438 lands.

## Known limitations

- The final MessageBus to channel send was not exercised live (no reachable channel in the test environment); everything up to the publish attempt was.
- Marker survival across a langgraph-dev restart is pinned by a unit test on the registry restore, not by a live restart.
- Pending deliveries are tracked in serve's memory; a serve restart before the poll re-reads and re-publishes committed pushes, restart recovery of channel routes is MVP out of scope.
- No cooldown, per-day quota, or preference learning (MVP out of scope). Candidates are capped at 50 per tick.
- Threads adopted with `/resume` from before the server backend are out of scope for the cron.
- QQ and Feishu were not tested; the channel path is the generic one every channel turn uses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional proactive messages for idle conversation channels, with configurable timing, quiet hours, and timezone settings.
  * Proactive checks can decide whether to send a text-only message and deliver approved messages to the original conversation.
  * Added support for routing through a LangGraph server backend.
* **Improvements**
  * Conversation memory now adapts its instructions when no tools are available.
  * Proactive delivery avoids duplicate messages and retries safely after temporary conflicts.
* **Tests**
  * Added comprehensive coverage for proactive checks, scheduling, delivery, gating, and server integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->