### PR TITLE
fix: Ctrl+C mid-tool-run leaves stuck checkpoint; next message replays the entire tool batch

### DIFF
--- a/EvoScientist/stream/events.py
+++ b/EvoScientist/stream/events.py
@@ -87,7 +87,7 @@ async def _recover_interrupted_graph_state(
     agent: Any,
     config: dict[str, Any],
     snapshot: Any | None = None,
-) -> None:
+) -> bool:
     """Close out a run that ended mid-step so the next turn starts fresh.
 
     A cancelled (Ctrl+C / ``/stop``), crashed, or hard-killed run can leave the
@@ -120,8 +120,18 @@ async def _recover_interrupted_graph_state(
     user still needs to answer. ``_snapshot_has_pending_interrupt`` distinguishes the
     two.
 
-    Best-effort: any failure is logged at DEBUG and swallowed so it never shadows
-    the original exception or cancellation that triggered recovery.
+    Returns:
+        ``True`` when the thread is safe to run: it was already clean, it is
+        parked at a genuine human-in-the-loop interrupt (left untouched), or
+        recovery completed and the checkpoint verified clean. ``False`` when
+        the checkpoint may still be stuck — recovery failed or could not be
+        verified. Callers starting a new run must refuse to proceed in that
+        case, or LangGraph could resume the interrupted node and replay its
+        tool side effects.
+
+    Best-effort: any failure is logged and swallowed so it never shadows the
+    original exception or cancellation that triggered recovery — the return
+    value is how callers learn the outcome.
     """
     import logging
 
@@ -131,7 +141,7 @@ async def _recover_interrupted_graph_state(
             snapshot = await agent.aget_state(config)
         # Only act when the graph is genuinely stuck (non-empty next tuple)...
         if not snapshot or not getattr(snapshot, "next", None):
-            return
+            return True
         # ...and not parked at a real human-in-the-loop interrupt.
         if _snapshot_has_pending_interrupt(snapshot):
             _log.debug(
@@ -140,7 +150,7 @@ async def _recover_interrupted_graph_state(
                 config.get("configurable", {}).get("thread_id", "?"),
                 snapshot.next,
             )
-            return
+            return True
 
         stuck_at = snapshot.next
         values = getattr(snapshot, "values", None) or {}
@@ -166,6 +176,18 @@ async def _recover_interrupted_graph_state(
             write_node = "tools" if "tools" in stuck_at else stuck_at[0]
             await agent.aupdate_state(config, {"messages": patch}, as_node=write_node)
         await agent.aupdate_state(config, None, as_node=END)
+        # Verify the checkpoint actually cleared before declaring the thread
+        # safe: a transient checkpoint failure must not let a new run resume
+        # the interrupted node and replay its tool side effects.
+        verify = await agent.aget_state(config)
+        if getattr(verify, "next", None):
+            _log.warning(
+                "Interrupted graph state for thread %s is still stuck at %s "
+                "after recovery",
+                config.get("configurable", {}).get("thread_id", "?"),
+                verify.next,
+            )
+            return False
         _log.debug(
             "Recovered interrupted graph state for thread %s (was stuck at: "
             "%s; closed %d dangling tool call(s))",
@@ -173,12 +195,15 @@ async def _recover_interrupted_graph_state(
             stuck_at,
             len(patch),
         )
-    except Exception as exc:  # pragma: no cover — best-effort recovery
-        _log.debug(
-            "Could not recover interrupted graph state: %s",
+        return True
+    except Exception as exc:
+        _log.warning(
+            "Could not recover interrupted graph state for thread %s: %s",
+            config.get("configurable", {}).get("thread_id", "?"),
             exc,
             exc_info=True,
         )
+        return False
 
 
 @dataclass(frozen=True)
@@ -962,7 +987,18 @@ async def stream_agent_events(
     # interrupted tool batch. A hard process kill runs no cleanup at all, so
     # this start-of-run pass is the only chance to repair those threads.
     if getattr(snapshot, "next", None):
-        await _recover_interrupted_graph_state(agent, config, snapshot=snapshot)
+        if not await _recover_interrupted_graph_state(agent, config, snapshot=snapshot):
+            # The checkpoint may still be stuck (e.g. transient checkpoint
+            # failure). Refuse to start the run: proceeding could make
+            # LangGraph resume the interrupted node and replay its tool side
+            # effects — the exact bug this recovery exists to prevent.
+            error_msg = (
+                "Could not repair the interrupted state of this session "
+                "thread; starting a new run on it risks re-executing its "
+                "previous tool calls. Please retry, or start a new thread."
+            )
+            yield emitter.error(error_msg).data
+            raise RuntimeError(error_msg)
 
     clear_completed_memory_activity_counts()
     astream_input = await build_agent_stream_input(message, media=media)

--- a/EvoScientist/stream/events.py
+++ b/EvoScientist/stream/events.py
@@ -76,39 +76,59 @@ def _snapshot_has_pending_interrupt(snapshot: Any) -> bool:
     return False
 
 
-async def _clear_interrupted_graph_state(
+_INTERRUPTED_TOOL_RESULT = (
+    "Tool execution was interrupted before the run completed. Side effects may "
+    "already have been partially applied; check the current state instead of "
+    "re-running this call unless the user asks."
+)
+
+
+async def _recover_interrupted_graph_state(
     agent: Any,
     config: dict[str, Any],
+    snapshot: Any | None = None,
 ) -> None:
-    """Force the graph back to a clean (non-interrupted) state after an error.
+    """Close out a run that ended mid-step so the next turn starts fresh.
 
-    When an exception occurs mid-run the LangGraph checkpoint can be left with a
-    non-empty ``next`` tuple — the graph is stuck waiting to resume at a specific
-    node. On the next invocation with a fresh user message LangGraph tries to
-    **resume** that interrupted step rather than starting a new turn: it ignores
-    the new human message and replays the broken step, which typically produces
-    no output and leaves the messages channel unchanged. From the user's side the
-    conversation looks like it lost all history because the agent stops responding.
+    A cancelled (Ctrl+C / ``/stop``), crashed, or hard-killed run can leave the
+    LangGraph checkpoint in two kinds of trouble:
 
-    The fix: ``aupdate_state(config, None, as_node=END)`` clears all pending tasks
-    and writes a checkpoint whose ``next`` is the empty tuple, without touching
-    any channel values (message history is preserved).
+    1. Pending tasks: ``next`` stays parked on the interrupted node, so on the
+       next invocation LangGraph tries to **resume** that broken step rather
+       than starting a new turn — it ignores the new human message and replays
+       the interrupted step (older runtimes even re-execute a pending tools
+       node outright).
+    2. Dangling tool calls: the assistant message that dispatched the tools was
+       committed, but its results never were. deepagents'
+       ``PatchToolCallsMiddleware`` then closes each dangling call with "was
+       cancelled - another message came in before it could be completed" and
+       rewrites the whole messages channel — which re-broadcasts every
+       historical tool call to the UI and actively invites the model to
+       re-issue the entire interrupted batch, re-applying real side effects.
+
+    Recovery synthesizes an honest ``ToolMessage`` for every dangling call
+    (telling the model the run was interrupted and side effects may already
+    have partially applied) and then commits the turn as finished via
+    ``aupdate_state(config, None, as_node=END)``, leaving ``next`` empty and a
+    self-consistent history the next turn can build on normally. Channel
+    values (message history) are otherwise preserved.
 
     Critically, this only runs when the stuck state is *not* a legitimate
     human-in-the-loop interrupt. The agent pauses via ``interrupt()`` /
     ``Command(resume=...)`` for ask-user flows, which also leaves ``next``
-    non-empty; clearing those would silently discard a pending question the user
-    still needs to answer. ``_snapshot_has_pending_interrupt`` distinguishes the
+    non-empty; clearing those would silently discard a pending question the
+    user still needs to answer. ``_snapshot_has_pending_interrupt`` distinguishes the
     two.
 
     Best-effort: any failure is logged at DEBUG and swallowed so it never shadows
-    the original exception that triggered recovery.
+    the original exception or cancellation that triggered recovery.
     """
     import logging
 
     _log = logging.getLogger(__name__)
     try:
-        snapshot = await agent.aget_state(config)
+        if snapshot is None:
+            snapshot = await agent.aget_state(config)
         # Only act when the graph is genuinely stuck (non-empty next tuple)...
         if not snapshot or not getattr(snapshot, "next", None):
             return
@@ -123,15 +143,39 @@ async def _clear_interrupted_graph_state(
             return
 
         stuck_at = snapshot.next
+        values = getattr(snapshot, "values", None) or {}
+        messages = values.get("messages") or []
+        answered_ids = {m.tool_call_id for m in messages if m.type == "tool"}
+        patch = [
+            ToolMessage(
+                content=_INTERRUPTED_TOOL_RESULT,
+                tool_call_id=call["id"],
+                name=call.get("name") or "unknown",
+            )
+            for m in messages
+            if isinstance(m, AIMessage)
+            for call in (
+                *m.tool_calls,
+                *(getattr(m, "invalid_tool_calls", None) or ()),
+            )
+            if call.get("id") and call["id"] not in answered_ids
+        ]
+        if patch:
+            # Attribute the synthetic results to the stuck execution node so
+            # they land in history exactly where the real results would have.
+            write_node = "tools" if "tools" in stuck_at else stuck_at[0]
+            await agent.aupdate_state(config, {"messages": patch}, as_node=write_node)
         await agent.aupdate_state(config, None, as_node=END)
         _log.debug(
-            "Cleared interrupted graph state for thread %s (was stuck at: %s)",
+            "Recovered interrupted graph state for thread %s (was stuck at: "
+            "%s; closed %d dangling tool call(s))",
             config.get("configurable", {}).get("thread_id", "?"),
             stuck_at,
+            len(patch),
         )
     except Exception as exc:  # pragma: no cover — best-effort recovery
         _log.debug(
-            "Could not clear interrupted graph state: %s",
+            "Could not recover interrupted graph state: %s",
             exc,
             exc_info=True,
         )
@@ -902,6 +946,7 @@ async def stream_agent_events(
         config["metadata"] = metadata
     emitter = StreamEventEmitter()
     existing_summarization_event: Mapping[str, object] | None = None
+    snapshot: Any = None
     try:
         snapshot = await agent.aget_state(config)
         existing_summarization_event = _find_summarization_event_payload(
@@ -910,12 +955,22 @@ async def stream_agent_events(
     except Exception:
         pass
 
+    # A previous run cancelled (Ctrl+C), crashed, or was hard-killed mid-step
+    # can leave the checkpoint parked with pending tasks and dangling tool
+    # calls. Recover before this run's input is applied, or the interrupted
+    # step interferes with the new turn — worst case replaying the entire
+    # interrupted tool batch. A hard process kill runs no cleanup at all, so
+    # this start-of-run pass is the only chance to repair those threads.
+    if getattr(snapshot, "next", None):
+        await _recover_interrupted_graph_state(agent, config, snapshot=snapshot)
+
     clear_completed_memory_activity_counts()
     astream_input = await build_agent_stream_input(message, media=media)
 
     stream: Any | None = None
     producers: list[asyncio.Task[Any]] = []
     _run_raised: bool = False
+    _run_cancelled: bool = False
     event_sink_token = None
     try:
         from langgraph.stream.transformers import CustomTransformer, UpdatesTransformer
@@ -1041,6 +1096,15 @@ async def stream_agent_events(
         _run_raised = True
         yield emitter.error(str(e)).data
         raise
+    except BaseException:
+        # Cancellation (Ctrl+C / ``/stop``) and GeneratorExit arrive as
+        # BaseException — ``except Exception`` above never sees them, so the
+        # interrupted super-step would otherwise leave the checkpoint stuck
+        # mid-node with dangling tool calls. Flag it so the finally-block
+        # recovery closes the turn out; otherwise the next user message
+        # replays the interrupted tool batch.
+        _run_cancelled = True
+        raise
     finally:
         if stream is not None:
             try:
@@ -1056,11 +1120,20 @@ async def stream_agent_events(
             await asyncio.gather(*producers, return_exceptions=True)
         if event_sink_token is not None:
             reset_run_event_sink(event_sink_token)
-        # When the run ended with an exception the LangGraph checkpoint may be
-        # left interrupted (``next`` non-empty). Clear it — unless it's a real
-        # human-in-the-loop pause — so the next user message starts a fresh turn
-        # instead of replaying the broken step (which would look like lost history).
-        if _run_raised:
-            await _clear_interrupted_graph_state(agent, config)
+        # When the run ended with an exception or was cancelled the LangGraph
+        # checkpoint may be left interrupted (``next`` non-empty, dangling tool
+        # calls). Recover — unless it's a real human-in-the-loop pause — so the
+        # next user message starts a fresh turn instead of replaying the broken
+        # step (which would look like lost history, or worse, re-execute the
+        # interrupted tool batch). Shielded: a second cancel mid-recovery must
+        # not tear the checkpoint writes down half-done.
+        if _run_raised or _run_cancelled:
+            recovery = asyncio.ensure_future(
+                _recover_interrupted_graph_state(agent, config)
+            )
+            try:
+                await asyncio.shield(recovery)
+            except asyncio.CancelledError:
+                pass
 
     yield emitter.done(processor.full_response).data

--- a/tests/test_stream_recovery.py
+++ b/tests/test_stream_recovery.py
@@ -10,11 +10,15 @@ so they actually verify the claims the recovery rests on:
 3. A run cancelled mid-tools leaves dangling tool calls; recovery closes them
    with honest synthetic results so the next turn neither replays the tool
    batch nor floods the UI with historical tool calls.
+4. If recovery itself fails (e.g. a transient checkpoint error), the next run
+   is refused instead of risking a replay of the interrupted tool batch.
 """
 
 import asyncio
 from typing import Any, TypedDict
+from unittest.mock import patch as mock_patch
 
+import pytest
 from deepagents import create_deep_agent
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
@@ -33,12 +37,17 @@ from EvoScientist.stream.events import (
 
 
 class _S(TypedDict):
+    """Minimal state schema for the hand-built test graphs below."""
+
     x: int
 
 
 def _crashing_app():
-    # Node 'b' crashes once, then succeeds — so a post-recovery run can complete
-    # and prove the graph is genuinely unstuck (not replaying the dead step).
+    """Build a graph whose node 'b' crashes once, then succeeds.
+
+    A post-recovery run can therefore complete and prove the graph is
+    genuinely unstuck (not replaying the dead step).
+    """
     crashed = {"v": False}
 
     def a(state):
@@ -60,6 +69,8 @@ def _crashing_app():
 
 
 def _interrupting_app():
+    """Build a graph that parks at a genuine ``interrupt()`` HITL pause."""
+
     def ask(state):
         interrupt({"question": "continue?"})
         return {"x": state["x"] + 1}
@@ -72,6 +83,7 @@ def _interrupting_app():
 
 
 async def test_recovery_clears_stuck_state_after_crash():
+    """Recovery clears a crash-stuck ``next`` and preserves channel values."""
     app = _crashing_app()
     cfg = {"configurable": {"thread_id": "t1"}}
     try:
@@ -81,7 +93,7 @@ async def test_recovery_clears_stuck_state_after_crash():
     # The crash left the graph frozen at node 'b'.
     assert app.get_state(cfg).next == ("b",)
 
-    await _recover_interrupted_graph_state(app, cfg)
+    assert await _recover_interrupted_graph_state(app, cfg) is True
 
     snap = app.get_state(cfg)
     assert snap.next == ()  # stuck state actually cleared
@@ -93,6 +105,7 @@ async def test_recovery_clears_stuck_state_after_crash():
 
 
 async def test_recovery_preserves_pending_hitl_interrupt():
+    """A pending ``interrupt()`` pause is left intact and stays resumable."""
     app = _interrupting_app()
     cfg = {"configurable": {"thread_id": "t1"}}
     app.invoke({"x": 0}, cfg)  # parks at interrupt()
@@ -100,7 +113,7 @@ async def test_recovery_preserves_pending_hitl_interrupt():
     assert before.next == ("ask",)
     assert before.interrupts
 
-    await _recover_interrupted_graph_state(app, cfg)
+    assert await _recover_interrupted_graph_state(app, cfg) is True
 
     after = app.get_state(cfg)
     assert after.next == ("ask",)  # interrupt left intact, still resumable
@@ -125,14 +138,17 @@ class _ScriptedModel(BaseChatModel):
 
     @property
     def _llm_type(self) -> str:
+        """Identifier required by the BaseChatModel interface."""
         return "scripted"
 
     def bind_tools(self, tools, **kwargs: Any) -> "_ScriptedModel":
+        """Accept any tool binding; the scripted responses ignore tools."""
         return self
 
     def _generate(
         self, messages, stop=None, run_manager=None, **kwargs: Any
     ) -> ChatResult:
+        """Return the next scripted message, recording the request history."""
         _MODEL_REQUESTS.append(list(messages))
         msg = _SCRIPT[_script_idx["i"]]
         _script_idx["i"] += 1
@@ -147,6 +163,7 @@ async def _slow_edit(path: str, content: str = "data") -> str:
 
 
 def _tool_call(id_: str, path: str) -> dict[str, Any]:
+    """Build a tool-call entry for ``_slow_edit`` on ``path``."""
     return {
         "id": id_,
         "name": _slow_edit.__name__,
@@ -156,6 +173,7 @@ def _tool_call(id_: str, path: str) -> dict[str, Any]:
 
 
 def _build_agent():
+    """Build a deep agent mirroring the real EvoScientist middleware stack."""
     return create_deep_agent(
         model=_ScriptedModel(),
         tools=[_slow_edit],
@@ -164,7 +182,29 @@ def _build_agent():
     )
 
 
+def _script_tool_batch_then_ack() -> None:
+    """Reset shared script/log state: 3-call tool batch, then an ack."""
+    _TOOL_SIDE_EFFECTS.clear()
+    _MODEL_REQUESTS.clear()
+    _SCRIPT.clear()
+    _script_idx["i"] = 0
+    _SCRIPT.extend(
+        [
+            AIMessage(
+                content="applying the batch of edits",
+                tool_calls=[
+                    _tool_call("call_1", "a.py"),
+                    _tool_call("call_2", "b.py"),
+                    _tool_call("call_3", "c.py"),
+                ],
+            ),
+            AIMessage(content="acknowledged"),
+        ]
+    )
+
+
 async def _run_turn(agent, message: str, thread_id: str) -> list[dict[str, Any]]:
+    """Stream one full turn through the real ``stream_agent_events``."""
     collected = []
     async for ev in stream_agent_events(agent, message, thread_id):
         collected.append(ev)
@@ -185,27 +225,13 @@ async def _cancel_mid_tools(agent, thread_id: str) -> None:
 
 
 def _tool_messages(messages: Any) -> list[ToolMessage]:
+    """Extract the ToolMessages from a message sequence."""
     return [m for m in messages if isinstance(m, ToolMessage)]
 
 
 async def test_cancel_mid_tools_closes_dangling_calls_and_next_turn_is_clean():
-    _TOOL_SIDE_EFFECTS.clear()
-    _MODEL_REQUESTS.clear()
-    _SCRIPT.clear()
-    _script_idx["i"] = 0
-    _SCRIPT.extend(
-        [
-            AIMessage(
-                content="applying the batch of edits",
-                tool_calls=[
-                    _tool_call("call_1", "a.py"),
-                    _tool_call("call_2", "b.py"),
-                    _tool_call("call_3", "c.py"),
-                ],
-            ),
-            AIMessage(content="acknowledged"),
-        ]
-    )
+    """Ctrl+C mid-tools must close the batch honestly; next turn stays clean."""
+    _script_tool_batch_then_ack()
     agent = _build_agent()
     cfg = {"configurable": {"thread_id": "t-cancel"}}
 
@@ -234,33 +260,13 @@ async def test_cancel_mid_tools_closes_dangling_calls_and_next_turn_is_clean():
 
 
 async def test_hard_killed_thread_recovered_at_start_of_next_run():
-    # Simulate a hard process kill: suppress the cancel-path recovery so the
-    # stuck checkpoint survives (nothing runs at kill time), then verify the
-    # start-of-run recovery repairs it when the user sends their next message.
-    _TOOL_SIDE_EFFECTS.clear()
-    _MODEL_REQUESTS.clear()
-    _SCRIPT.clear()
-    _script_idx["i"] = 0
-    _SCRIPT.extend(
-        [
-            AIMessage(
-                content="applying the batch of edits",
-                tool_calls=[
-                    _tool_call("call_1", "a.py"),
-                    _tool_call("call_2", "b.py"),
-                    _tool_call("call_3", "c.py"),
-                ],
-            ),
-            AIMessage(content="acknowledged"),
-        ]
-    )
+    """A hard-killed thread (no cleanup ran) is repaired on the next run."""
+    _script_tool_batch_then_ack()
     agent = _build_agent()
     cfg = {"configurable": {"thread_id": "t-kill"}}
 
     async def _no_recovery(agent, config, snapshot=None):
         return None
-
-    from unittest.mock import patch as mock_patch
 
     with mock_patch.object(
         events_module, "_recover_interrupted_graph_state", _no_recovery
@@ -285,3 +291,50 @@ async def test_hard_killed_thread_recovered_at_start_of_next_run():
 
     snap = await agent.aget_state(cfg)
     assert snap.next == ()
+
+
+async def test_start_of_run_recovery_failure_refuses_the_run(monkeypatch):
+    """If start-of-run recovery fails, the new run is refused, not replayed.
+
+    A transient checkpoint failure (e.g. sqlite error) during recovery must
+    not fall through to ``astream_events`` on a still-stuck thread — LangGraph
+    could resume the interrupted tools node and replay its side effects.
+    """
+    _script_tool_batch_then_ack()
+    agent = _build_agent()
+    cfg = {"configurable": {"thread_id": "t-fail"}}
+
+    async def _no_recovery(agent, config, snapshot=None):
+        return None
+
+    with mock_patch.object(
+        events_module, "_recover_interrupted_graph_state", _no_recovery
+    ):
+        await _cancel_mid_tools(agent, "t-fail")
+    snap = await agent.aget_state(cfg)
+    assert snap.next  # still stuck — recovery has not run yet
+
+    async def _failing_aupdate_state(_config, _values=None, as_node=None):
+        raise RuntimeError("sqlite: disk I/O error")
+
+    monkeypatch.setattr(agent, "aupdate_state", _failing_aupdate_state)
+
+    before = len(_TOOL_SIDE_EFFECTS)
+    events: list[dict[str, Any]] = []
+
+    async def _collect_until_refused() -> None:
+        async for ev in stream_agent_events(agent, "hello", "t-fail"):
+            events.append(ev)
+
+    with pytest.raises(RuntimeError, match="Could not repair the interrupted state"):
+        await _collect_until_refused()
+
+    # The turn was refused before any streaming: an error event for the UI,
+    # no tool side effects, and the stuck checkpoint untouched (still stuck,
+    # so a later retry can attempt recovery again).
+    assert events
+    assert events[0]["type"] == "error"
+    assert "Could not repair the interrupted state" in events[0]["message"]
+    assert len(_TOOL_SIDE_EFFECTS) == before
+    snap = await agent.aget_state(cfg)
+    assert snap.next

--- a/tests/test_stream_recovery.py
+++ b/tests/test_stream_recovery.py
@@ -224,6 +224,35 @@ async def _cancel_mid_tools(agent, thread_id: str) -> None:
         pass
 
 
+async def _hard_kill_mid_tools(agent, thread_id: str) -> None:
+    """Leave a stuck checkpoint behind, as a hard-killed process would.
+
+    Cancels mid-tools with the recovery suppressed: nothing "runs at kill
+    time", so the thread keeps its pending ``next`` and dangling tool calls.
+    """
+
+    async def _no_recovery(agent, config, snapshot=None):
+        return None
+
+    with mock_patch.object(
+        events_module, "_recover_interrupted_graph_state", _no_recovery
+    ):
+        await _cancel_mid_tools(agent, thread_id)
+
+
+async def _collect_refused_turn(agent, thread_id: str) -> list[dict[str, Any]]:
+    """Stream a turn expected to be refused; return events collected so far."""
+    events: list[dict[str, Any]] = []
+
+    async def _collect() -> None:
+        async for ev in stream_agent_events(agent, "hello", thread_id):
+            events.append(ev)
+
+    with pytest.raises(RuntimeError, match="Could not repair the interrupted state"):
+        await _collect()
+    return events
+
+
 def _tool_messages(messages: Any) -> list[ToolMessage]:
     """Extract the ToolMessages from a message sequence."""
     return [m for m in messages if isinstance(m, ToolMessage)]
@@ -265,13 +294,7 @@ async def test_hard_killed_thread_recovered_at_start_of_next_run():
     agent = _build_agent()
     cfg = {"configurable": {"thread_id": "t-kill"}}
 
-    async def _no_recovery(agent, config, snapshot=None):
-        return None
-
-    with mock_patch.object(
-        events_module, "_recover_interrupted_graph_state", _no_recovery
-    ):
-        await _cancel_mid_tools(agent, "t-kill")
+    await _hard_kill_mid_tools(agent, "t-kill")
 
     snap = await agent.aget_state(cfg)
     assert snap.next  # still stuck — the "killed" process never cleaned up
@@ -304,13 +327,7 @@ async def test_start_of_run_recovery_failure_refuses_the_run(monkeypatch):
     agent = _build_agent()
     cfg = {"configurable": {"thread_id": "t-fail"}}
 
-    async def _no_recovery(agent, config, snapshot=None):
-        return None
-
-    with mock_patch.object(
-        events_module, "_recover_interrupted_graph_state", _no_recovery
-    ):
-        await _cancel_mid_tools(agent, "t-fail")
+    await _hard_kill_mid_tools(agent, "t-fail")
     snap = await agent.aget_state(cfg)
     assert snap.next  # still stuck — recovery has not run yet
 
@@ -320,14 +337,7 @@ async def test_start_of_run_recovery_failure_refuses_the_run(monkeypatch):
     monkeypatch.setattr(agent, "aupdate_state", _failing_aupdate_state)
 
     before = len(_TOOL_SIDE_EFFECTS)
-    events: list[dict[str, Any]] = []
-
-    async def _collect_until_refused() -> None:
-        async for ev in stream_agent_events(agent, "hello", "t-fail"):
-            events.append(ev)
-
-    with pytest.raises(RuntimeError, match="Could not repair the interrupted state"):
-        await _collect_until_refused()
+    events = await _collect_refused_turn(agent, "t-fail")
 
     # The turn was refused before any streaming: an error event for the UI,
     # no tool side effects, and the stuck checkpoint untouched (still stuck,
@@ -338,3 +348,34 @@ async def test_start_of_run_recovery_failure_refuses_the_run(monkeypatch):
     assert len(_TOOL_SIDE_EFFECTS) == before
     snap = await agent.aget_state(cfg)
     assert snap.next
+
+
+async def test_unverified_recovery_refuses_the_run(monkeypatch):
+    """Repair writes that leave ``next`` non-empty must refuse the new run.
+
+    Covers the post-write verification branch of recovery: the checkpoint
+    writes "succeed" (no exception) yet the checkpoint still reports a stuck
+    ``next`` — the re-read must catch it and refuse the run.
+    """
+    _script_tool_batch_then_ack()
+    agent = _build_agent()
+    cfg = {"configurable": {"thread_id": "t-verify"}}
+
+    await _hard_kill_mid_tools(agent, "t-verify")
+    snap = await agent.aget_state(cfg)
+    assert snap.next  # stuck thread handed to the next run
+
+    async def _no_op_aupdate_state(_config, _values=None, as_node=None):
+        return None  # accept the write without actually clearing the checkpoint
+
+    monkeypatch.setattr(agent, "aupdate_state", _no_op_aupdate_state)
+
+    before = len(_TOOL_SIDE_EFFECTS)
+    events = await _collect_refused_turn(agent, "t-verify")
+
+    assert events
+    assert events[0]["type"] == "error"
+    assert "Could not repair the interrupted state" in events[0]["message"]
+    assert len(_TOOL_SIDE_EFFECTS) == before  # nothing re-executed
+    snap = await agent.aget_state(cfg)
+    assert snap.next  # still stuck — the writes never really landed

--- a/tests/test_stream_recovery.py
+++ b/tests/test_stream_recovery.py
@@ -1,21 +1,35 @@
 """Targeted tests for interrupted-graph-state recovery.
 
 These run against a real compiled LangGraph graph with a checkpointer,
-so they actually verify the two claims the recovery rests on:
+so they actually verify the claims the recovery rests on:
 
 1. After a mid-run crash, ``aupdate_state(config, None, as_node=END)`` clears the
    stuck ``next`` tuple while preserving channel values.
 2. A legitimate human-in-the-loop ``interrupt()`` (also a non-empty ``next``) is
    left intact, so a pending question is never silently discarded.
+3. A run cancelled mid-tools leaves dangling tool calls; recovery closes them
+   with honest synthetic results so the next turn neither replays the tool
+   batch nor floods the UI with historical tool calls.
 """
 
-from typing import TypedDict
+import asyncio
+from typing import Any, TypedDict
 
+from deepagents import create_deep_agent
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import interrupt
 
-from EvoScientist.stream.events import _clear_interrupted_graph_state
+from EvoScientist.middleware.tool_history_repair import ToolHistoryRepairMiddleware
+from EvoScientist.stream import events as events_module
+from EvoScientist.stream.events import (
+    _INTERRUPTED_TOOL_RESULT,
+    _recover_interrupted_graph_state,
+    stream_agent_events,
+)
 
 
 class _S(TypedDict):
@@ -67,7 +81,7 @@ async def test_recovery_clears_stuck_state_after_crash():
     # The crash left the graph frozen at node 'b'.
     assert app.get_state(cfg).next == ("b",)
 
-    await _clear_interrupted_graph_state(app, cfg)
+    await _recover_interrupted_graph_state(app, cfg)
 
     snap = app.get_state(cfg)
     assert snap.next == ()  # stuck state actually cleared
@@ -86,8 +100,188 @@ async def test_recovery_preserves_pending_hitl_interrupt():
     assert before.next == ("ask",)
     assert before.interrupts
 
-    await _clear_interrupted_graph_state(app, cfg)
+    await _recover_interrupted_graph_state(app, cfg)
 
     after = app.get_state(cfg)
     assert after.next == ("ask",)  # interrupt left intact, still resumable
     assert after.interrupts
+
+
+# --- Full-stack regression: Ctrl+C mid-tools must not replay the batch -------
+#
+# These mirror the real construction path (deepagents create_deep_agent with
+# the project's ToolHistoryRepairMiddleware) so deepagents'
+# PatchToolCallsMiddleware — the layer whose "was cancelled" rewrite causes the
+# replay — is in the stack too.
+
+_TOOL_SIDE_EFFECTS: list[str] = []
+_MODEL_REQUESTS: list[list[BaseMessage]] = []
+_SCRIPT: list[AIMessage] = []
+_script_idx = {"i": 0}
+
+
+class _ScriptedModel(BaseChatModel):
+    """Replays a scripted AI-message sequence; records every request."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted"
+
+    def bind_tools(self, tools, **kwargs: Any) -> "_ScriptedModel":
+        return self
+
+    def _generate(
+        self, messages, stop=None, run_manager=None, **kwargs: Any
+    ) -> ChatResult:
+        _MODEL_REQUESTS.append(list(messages))
+        msg = _SCRIPT[_script_idx["i"]]
+        _script_idx["i"] += 1
+        return ChatResult(generations=[ChatGeneration(message=msg)])
+
+
+async def _slow_edit(path: str, content: str = "data") -> str:
+    """Edit a file; the side effect lands immediately, like edit_file."""
+    _TOOL_SIDE_EFFECTS.append(path)
+    await asyncio.sleep(2.0)
+    return f"edited {path}"
+
+
+def _tool_call(id_: str, path: str) -> dict[str, Any]:
+    return {
+        "id": id_,
+        "name": _slow_edit.__name__,
+        "args": {"path": path},
+        "type": "tool_call",
+    }
+
+
+def _build_agent():
+    return create_deep_agent(
+        model=_ScriptedModel(),
+        tools=[_slow_edit],
+        middleware=[ToolHistoryRepairMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+
+async def _run_turn(agent, message: str, thread_id: str) -> list[dict[str, Any]]:
+    collected = []
+    async for ev in stream_agent_events(agent, message, thread_id):
+        collected.append(ev)
+    return collected
+
+
+async def _cancel_mid_tools(agent, thread_id: str) -> None:
+    """Run a turn whose tool batch is mid-flight, then cancel it (Ctrl+C)."""
+    task = asyncio.create_task(_run_turn(agent, "apply the edits", thread_id))
+    deadline = asyncio.get_running_loop().time() + 10
+    while len(_TOOL_SIDE_EFFECTS) < 3 and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+def _tool_messages(messages: Any) -> list[ToolMessage]:
+    return [m for m in messages if isinstance(m, ToolMessage)]
+
+
+async def test_cancel_mid_tools_closes_dangling_calls_and_next_turn_is_clean():
+    _TOOL_SIDE_EFFECTS.clear()
+    _MODEL_REQUESTS.clear()
+    _SCRIPT.clear()
+    _script_idx["i"] = 0
+    _SCRIPT.extend(
+        [
+            AIMessage(
+                content="applying the batch of edits",
+                tool_calls=[
+                    _tool_call("call_1", "a.py"),
+                    _tool_call("call_2", "b.py"),
+                    _tool_call("call_3", "c.py"),
+                ],
+            ),
+            AIMessage(content="acknowledged"),
+        ]
+    )
+    agent = _build_agent()
+    cfg = {"configurable": {"thread_id": "t-cancel"}}
+
+    await _cancel_mid_tools(agent, "t-cancel")
+
+    # The cancel-path recovery closed the turn out in the generator's finally:
+    # no pending tasks, and every dangling call got an honest synthetic result.
+    snap = await agent.aget_state(cfg)
+    assert snap.next == ()
+    synth = _tool_messages(snap.values["messages"])
+    assert len(synth) == 3
+    assert all(m.content == _INTERRUPTED_TOOL_RESULT for m in synth)
+
+    # The next user message must NOT replay the interrupted tool batch...
+    before = len(_TOOL_SIDE_EFFECTS)
+    events = await _run_turn(agent, "hello, new instruction", "t-cancel")
+    assert len(_TOOL_SIDE_EFFECTS) == before
+    # ...nor re-broadcast historical tool calls to the UI...
+    assert all(ev.get("type") != "tool_call" for ev in events)
+    # ...nor tell the model the calls "were cancelled" (the replay invitation).
+    request = _MODEL_REQUESTS[-1]
+    closed = _tool_messages(request)
+    assert len(closed) == 3
+    assert all(m.content == _INTERRUPTED_TOOL_RESULT for m in closed)
+    assert not any("another message came in" in str(m.content) for m in closed)
+
+
+async def test_hard_killed_thread_recovered_at_start_of_next_run():
+    # Simulate a hard process kill: suppress the cancel-path recovery so the
+    # stuck checkpoint survives (nothing runs at kill time), then verify the
+    # start-of-run recovery repairs it when the user sends their next message.
+    _TOOL_SIDE_EFFECTS.clear()
+    _MODEL_REQUESTS.clear()
+    _SCRIPT.clear()
+    _script_idx["i"] = 0
+    _SCRIPT.extend(
+        [
+            AIMessage(
+                content="applying the batch of edits",
+                tool_calls=[
+                    _tool_call("call_1", "a.py"),
+                    _tool_call("call_2", "b.py"),
+                    _tool_call("call_3", "c.py"),
+                ],
+            ),
+            AIMessage(content="acknowledged"),
+        ]
+    )
+    agent = _build_agent()
+    cfg = {"configurable": {"thread_id": "t-kill"}}
+
+    async def _no_recovery(agent, config, snapshot=None):
+        return None
+
+    from unittest.mock import patch as mock_patch
+
+    with mock_patch.object(
+        events_module, "_recover_interrupted_graph_state", _no_recovery
+    ):
+        await _cancel_mid_tools(agent, "t-kill")
+
+    snap = await agent.aget_state(cfg)
+    assert snap.next  # still stuck — the "killed" process never cleaned up
+    assert not _tool_messages(snap.values["messages"])  # calls left dangling
+
+    before = len(_TOOL_SIDE_EFFECTS)
+    events = await _run_turn(agent, "hello, new instruction", "t-kill")
+
+    # Start-of-run recovery kicked in: no replay, no UI flood, honest results.
+    assert len(_TOOL_SIDE_EFFECTS) == before
+    assert all(ev.get("type") != "tool_call" for ev in events)
+    request = _MODEL_REQUESTS[-1]
+    closed = _tool_messages(request)
+    assert len(closed) == 3
+    assert all(m.content == _INTERRUPTED_TOOL_RESULT for m in closed)
+    assert not any("another message came in" in str(m.content) for m in closed)
+
+    snap = await agent.aget_state(cfg)
+    assert snap.next == ()


### PR DESCRIPTION
## Description

Fixes #463.

When a run is interrupted with **Ctrl+C while tools are executing** — or the process is killed / crashes mid-run — the LangGraph checkpoint is left stuck: pending tasks (`next` parked on the tools node) plus an assistant message whose `tool_calls` never received results. On the next user message, deepagents' `PatchToolCallsMiddleware` closes each dangling call with *"was cancelled - another message came in before it could be completed"* and rewrites the whole messages channel. Two user-visible consequences:

1. the entire history is re-broadcast → the UI floods with every historical `tool_call` event, and
2. the wording tells the model the interrupted work never happened → the model **re-issues the entire interrupted batch**, re-running `edit_file` / `execute` / ... with real side effects (the tools had in fact already executed; only their results were discarded).

The root cause on our side: `stream_agent_events` already had checkpoint recovery (`_clear_interrupted_graph_state`), but it was gated on `except Exception`. `asyncio.CancelledError` / `GeneratorExit` are `BaseException`, so **the Ctrl+C path never ran the recovery**; and hard process kills run no cleanup at all.

This PR repairs the checkpoint at three layers, all inside `EvoScientist/stream/events.py`:

- **Cancel path**: a new `except BaseException` branch flags cancellations so the `finally`-block recovery runs (shielded, so a second Ctrl+C mid-repair cannot tear the checkpoint writes half-done).
- **Start of the next run**: before the new input is applied, a stuck snapshot (non-empty `next`, no pending human-in-the-loop interrupt) is recovered. This is the only chance to repair threads left behind by hard kills, and it also heals threads already stuck in users' existing `sessions.db`.
- **Stronger recovery** (`_clear_interrupted_graph_state` → `_recover_interrupted_graph_state`): besides clearing pending tasks via `aupdate_state(config, None, as_node=END)`, it now synthesizes an honest `ToolMessage` for every dangling call ("interrupted before the run completed; side effects may have partially applied; don't re-run unless asked") attributed to the stuck execution node. With a self-consistent history, deepagents' patch middleware finds nothing to rewrite — no UI re-broadcast, no "was cancelled" invitation to replay. Genuine `interrupt()` pauses are still preserved via the existing `_snapshot_has_pending_interrupt` check.

Verification (repro script in the issue, deterministic, no API key):

| | unpatched `main` | this PR |
|---|---|---|
| checkpoint after Ctrl+C | `next = ('tools', 'tools', 'tools')`, dangling `tool_calls` | `next = ()`, 3 honest synthetic results |
| next-message events | `['text', tool_call ×6, tool_result ×3, ...]` (history re-broadcast + batch replay) | `['text', 'done']` |
| tool side effects re-executed | `['a.py', 'b.py', 'c.py']` | none |

## Type of change

- [x] Bug fix
- [ ] New feature — link issue: #
- [ ] Documentation / examples
- [ ] Test improvement
- [ ] Refactor (no behavior change)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] This targets **core functionality** used by the majority of users (niche features belong in [EvoSkills](https://github.com/EvoScientist/EvoSkills))
- [x] I have added/updated tests where applicable
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes (full suite: 3733 passed, 8 skipped; includes 2 new full-stack regression tests in `tests/test_stream_recovery.py`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after interrupted, cancelled, or forcibly stopped runs.
  * Repairs incomplete tool activity automatically when the next run begins.
  * Prevents unfinished tool calls from replaying or generating duplicate conversation events.
  * Preserves results from tool calls that finished before interruption.
  * Provides clear synthetic completion results for unfinished tool calls so conversations can continue reliably.
  * Verifies that interrupted runs are fully cleared before proceeding when recovery succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->